### PR TITLE
skipping embeddings rate limit when python version > 3.10

### DIFF
--- a/python/lancedb/embeddings.py
+++ b/python/lancedb/embeddings.py
@@ -12,6 +12,8 @@
 #  limitations under the License.
 
 import math
+import sys
+
 from retry import retry
 from typing import Callable, Union
 
@@ -64,13 +66,17 @@ class EmbeddingFunction:
                 return self.func(c.tolist())
 
         if len(self.rate_limiter_kwargs) > 0:
-            import ratelimiter
+            v = int(sys.version_info.minor)
+            if v >= 11:
+                print("WARNING: rate limit only support up to 3.10, proceeding without rate limiter")
+            else:
+                import ratelimiter
 
-            max_calls = self.rate_limiter_kwargs["max_calls"]
-            limiter = ratelimiter.RateLimiter(
-                max_calls, period=self.rate_limiter_kwargs["period"]
-            )
-            embed_func = limiter(embed_func)
+                max_calls = self.rate_limiter_kwargs["max_calls"]
+                limiter = ratelimiter.RateLimiter(
+                    max_calls, period=self.rate_limiter_kwargs["period"]
+                )
+                embed_func = limiter(embed_func)
         batches = self.to_batches(text)
         embeds = [emb for c in batches for emb in embed_func(c)]
         return embeds
@@ -79,11 +85,6 @@ class EmbeddingFunction:
         return f"EmbeddingFunction(func={self.func})"
 
     def rate_limit(self, max_calls=0.9, period=1.0):
-        import sys
-
-        v = int(sys.version_info.minor)
-        if v >= 11:
-            raise ValueError("rate limit only support up to 3.10")
         self.rate_limiter_kwargs = dict(max_calls=max_calls, period=period)
         return self
 


### PR DESCRIPTION
prints a warning if the python version > 3.10

```
>>> data = with_embeddings(embed_func, df, show_progress=True)
WARNING: rate limit only support up to 3.10, proceeding without rate limiter
```

Tested with Python 3.11.2 (macos) and  Python 3.10.6 (linux)

Long term we should look into another rate limiter library, possibly https://pypi.org/project/throttler/