### PR TITLE
move tantivy-py installation to be separate from wheel

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,7 +30,8 @@ jobs:
         python-version: 3.${{ matrix.python-minor-version }}
     - name: Install lancedb
       run: |
-        pip install -e ".[fts]"
+        pip install -e .
+        pip install tantivy@git+https://github.com/quickwit-oss/tantivy-py#164adc87e1a033117001cf70e38c82a53014d985
         pip install pytest
     - name: Run tests
       run: pytest -x -v --durations=30 tests
@@ -52,7 +53,8 @@ jobs:
         python-version: "3.11"
     - name: Install lancedb
       run: |
-        pip install -e ".[fts]"
+        pip install -e .
+        pip install tantivy@git+https://github.com/quickwit-oss/tantivy-py#164adc87e1a033117001cf70e38c82a53014d985
         pip install pytest
     - name: Run tests
       run: pytest -x -v --durations=30 tests

--- a/docs/src/fts.md
+++ b/docs/src/fts.md
@@ -6,9 +6,10 @@ to make this available for JS as well.
 
 ## Installation
 
-To use full text search, you must install the fts optional dependencies:
+To use full text search, you must install optional dependency tantivy-py:
 
-`pip install lancedb[fts]`
+# tantivy 0.19.2
+pip install tantivy@git+https://github.com/quickwit-oss/tantivy-py#164adc87e1a033117001cf70e38c82a53014d985
 
 
 ## Quickstart

--- a/python/lancedb/fts.py
+++ b/python/lancedb/fts.py
@@ -16,7 +16,13 @@ import os
 from typing import List, Tuple
 
 import pyarrow as pa
-import tantivy
+
+try:
+    import tantivy
+except ImportError:
+    raise ImportError(
+        "Please install tantivy-py `pip install tantivy@git+https://github.com/quickwit-oss/tantivy-py#164adc87e1a033117001cf70e38c82a53014d985` to use the full text search feature."
+    )
 
 from .table import LanceTable
 

--- a/python/lancedb/query.py
+++ b/python/lancedb/query.py
@@ -153,7 +153,7 @@ class LanceFtsQueryBuilder(LanceQueryBuilder):
             import tantivy
         except ImportError:
             raise ImportError(
-                "You need to install the `lancedb[fts]` extra to use this method."
+                "Please install tantivy-py `pip install tantivy@git+https://github.com/quickwit-oss/tantivy-py#164adc87e1a033117001cf70e38c82a53014d985` to use the full text search feature."
             )
 
         from .fts import search_index

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,10 +45,6 @@ dev = [
 docs = [
     "mkdocs", "mkdocs-jupyter", "mkdocs-material", "mkdocstrings[python]"
 ]
-fts = [
-    # tantivy 0.19.2
-    "tantivy@git+https://github.com/quickwit-oss/tantivy-py#164adc87e1a033117001cf70e38c82a53014d985"
-]
 
 [build-system]
 requires = [

--- a/python/tests/test_embeddings.py
+++ b/python/tests/test_embeddings.py
@@ -14,7 +14,6 @@ import sys
 
 import numpy as np
 import pyarrow as pa
-
 from lancedb.embeddings import with_embeddings
 
 

--- a/python/tests/test_fts.py
+++ b/python/tests/test_fts.py
@@ -13,13 +13,13 @@
 import os
 import random
 
+import lancedb.fts
 import numpy as np
 import pandas as pd
 import pytest
 import tantivy
 
 import lancedb as ldb
-import lancedb.fts
 
 
 @pytest.fixture

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -17,7 +17,6 @@ import pandas as pd
 import pandas.testing as tm
 import pyarrow as pa
 import pytest
-
 from lancedb.query import LanceQueryBuilder
 
 

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import pandas as pd
 import pyarrow as pa
 import pytest
-
 from lancedb.table import LanceTable
 
 


### PR DESCRIPTION
pypi does not allow packages to be uploaded that has a direct reference

for now we'll just ask the user to install tantivy separately