### PR TITLE
Fixed documentation link for the Youtube Transcripts Jupyter Notebook

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,7 +38,7 @@ result = table.search([100, 100]).limit(2).to_df()
 ## Complete Demos
 
 We will be adding completed demo apps built using LanceDB.
-- [YouTube Transcript Search](../notebooks/youtube_transcript_search.ipynb)
+- [YouTube Transcript Search](../../notebooks/youtube_transcript_search.ipynb)
 
 
 ## Documentation Quick Links


### PR DESCRIPTION
Changed the link to the Youtube Transcripts jupyter notebook path on the documentation.

Previously it went inside docs/notebooks (which does not exist). I've modified it to go inside the notebooks folder instead.