### PR TITLE
Check if table exists before opening a table

### DIFF
--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -27,6 +27,7 @@ pub const VECTOR_COLUMN_NAME: &str = "vector";
 pub const LANCE_FILE_EXTENSION: &str = "lance";
 
 /// A table in a LanceDB database.
+#[derive(Debug)]
 pub struct Table {
     name: String,
     uri: String,


### PR DESCRIPTION
The `open` api will open an existing table
```rust
impl Table {
    /// Opens an existing Table
    ///
    /// # Arguments
    ///
    /// * `base_path` - The base path where the table is located
    /// * `name` The Table name
    ///
    /// # Returns
    ///
    /// * A [Table] object.
    pub async fn open(base_uri: &str, name: &str) -> Result<Self> {
```

So it's better to check if a table exists before opening it.

Btw, the example in https://lancedb.com/ will be better to create table before opening table
<img width="665" alt="image" src="https://github.com/lancedb/lancedb/assets/41979257/4119a739-7e87-468f-81cf-e812bfe2843b">


