### PR TITLE
feat(python): add action to build and publish wheel

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,31 @@
+name: PyPI Publish
+
+on:
+  release:
+    types: [ published ]
+    tags:
+      - 'python-v*' # Push events that matches the python-make-release action
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Build distribution
+        run: |
+          ls -la
+          pip install wheel setuptools --upgrade
+          python setup.py sdist bdist_wheel
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.8.5
+        with:
+          password: ${{ secrets.LANCEDB_PYPI_API_TOKEN }}
+          packages-dir: python/dist


### PR DESCRIPTION
Tested by building and publishing to test.pypi. The version over there doesn't match our own since I had to repeat my tests a couple of times: https://test.pypi.org/project/lancedb/0.1.20/

It can be installed locally by 

```
pip install --index-url https://test.pypi.org/simple/ --no-deps lancedb
```

Since we don't push pylance to the test repo often, you need to install the dependencies manually.