### PR TITLE
Add favicon in docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,12 +6,12 @@ docs_dir: src
 theme:
   name: "material"
   logo: assets/logo.png
+  favicon: assets/logo.png
   features:
     - content.code.copy
     - content.tabs.link
   icon:
     repo: fontawesome/brands/github
-  favicon: assets/logo.png
 
 plugins:
 - search

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ theme:
     - content.tabs.link
   icon:
     repo: fontawesome/brands/github
+  favicon: assets/logo.png
 
 plugins:
 - search


### PR DESCRIPTION
Currently, the default mkdocs material favicon is used for docs in prod. I'm not sure if we have some other asset intended for this use, but meanwhile reusing the logo as a favicon would be better than nothing.
<img width="119" alt="Screenshot 2023-06-20 at 1 01 54 AM" src="https://github.com/lancedb/lancedb/assets/15766192/ece504a4-374f-4e5d-b819-9153693069a8">
<img width="112" alt="Screenshot 2023-06-20 at 1 02 08 AM" src="https://github.com/lancedb/lancedb/assets/15766192/35f1bdbf-6754-4753-b79a-51663d841c92">
