### PR TITLE
Allow copying table 

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,12 +6,12 @@ docs_dir: src
 theme:
   name: "material"
   logo: assets/logo.png
+  favicon: assets/logo.png
   features:
     - content.code.copy
     - content.tabs.link
   icon:
     repo: fontawesome/brands/github
-  favicon: assets/logo.png
 
 plugins:
 - search

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,7 +6,6 @@ docs_dir: src
 theme:
   name: "material"
   logo: assets/logo.png
-  favicon: assets/logo.png
   features:
     - content.code.copy
     - content.tabs.link

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ theme:
     - content.tabs.link
   icon:
     repo: fontawesome/brands/github
+  favicon: assets/logo.png
 
 plugins:
 - search

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -256,7 +256,9 @@ class LanceDBConnection:
             tbl = LanceTable(self, name)
         return tbl
 
-    def copy_table(self, source: Union[str, Path, LanceTable], name: str = None) -> LanceTable:
+    def copy_table(
+        self, source: Union[str, Path, LanceTable], name: str = None
+    ) -> LanceTable:
         """Copy a table in the database.
 
         Parameters
@@ -287,13 +289,14 @@ class LanceDBConnection:
         dest_uri = os.path.join(self.uri, dest_table_name + ".lance")
         source_uri = str(source_uri)
         if source_uri == dest_uri:
-            raise ValueError("Cannot copy table to itself. Provide a different name if you intend to copy the table in the same databse.")
+            raise ValueError(
+                "Cannot copy table to itself. Provide a different name if you intend to copy the table in the same databse."
+            )
         elif dest_table_name in self.table_names():
             raise ValueError("Table already exists in database.")
 
         pa.fs.copy_files(source_uri, dest_uri)
         return LanceTable(self, dest_table_name)
-
 
     def open_table(self, name: str) -> LanceTable:
         """Open a table in the database.

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -261,7 +261,7 @@ class LanceDBConnection:
 
         Parameters
         ----------
-        source: str or LanceTable
+        source: str, Path, LanceTable
             The name of the table or a LanceTable object.
         name: str; optional
             The name of the new table. If not provided, the name of the source table is used.

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -288,6 +288,8 @@ class LanceDBConnection:
         source_uri = str(source_uri)
         if source_uri == dest_uri:
             raise ValueError("Cannot copy table to itself. Provide a different name if you intend to copy the table in the same databse.")
+        elif dest_table_name in self.table_names():
+            raise ValueError("Table already exists in database.")
 
         pa.fs.copy_files(source_uri, dest_uri)
         return LanceTable(self, dest_table_name)

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -121,27 +121,32 @@ def test_delete_table(tmp_path):
     db.create_table("test", data=data)
     assert db.table_names() == ["test"]
 
+
 def test_copying(tmp_path_factory):
     db = lancedb.connect(tmp_path_factory.mktemp("source"))
     db_dest = lancedb.connect(tmp_path_factory.mktemp("db_dest"))
-    data=[
-            {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
-            {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
-        ]
-    
+    data = [
+        {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
+        {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
+    ]
+
     source_table = db.create_table("source_table", data=data)
 
-    dest_table = db_dest.copy_table(source_table) # Copy from LanceTable Object
+    dest_table = db_dest.copy_table(source_table)  # Copy from LanceTable Object
     assert "source_table" in db_dest.table_names()
     assert dest_table._conn == db_dest
     assert dest_table.name == source_table.name
 
-    dest_table = db_dest.copy_table(source_table._dataset_uri, "dest_table") # Copy from Lancetable URI
+    dest_table = db_dest.copy_table(
+        source_table._dataset_uri, "dest_table"
+    )  # Copy from Lancetable URI
     assert "dest_table" in db_dest.table_names()
     assert dest_table._conn == db_dest
     assert dest_table.name == "dest_table"
 
-    db_dest.copy_table(dest_table, "table_copy2") # Copy from same LanceTable Object with new name
+    db_dest.copy_table(
+        dest_table, "table_copy2"
+    )  # Copy from same LanceTable Object with new name
 
-    with pytest.raises(ValueError): # Copy from same LanceTable Object with same name
+    with pytest.raises(ValueError):  # Copy from same LanceTable Object with same name
         db_dest.copy_table(dest_table)

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -122,26 +122,26 @@ def test_delete_table(tmp_path):
     assert db.table_names() == ["test"]
 
 def test_copying(tmp_path_factory):
-    db = lancedb.connect(tmp_path_factory.mktemp("db"))
-    db_cp = lancedb.connect(tmp_path_factory.mktemp("db_copy"))
+    db = lancedb.connect(tmp_path_factory.mktemp("source"))
+    db_dest = lancedb.connect(tmp_path_factory.mktemp("db_dest"))
     data=[
             {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
             {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
         ]
     
-    table = db.create_table("source_table", data=data)
+    source_table = db.create_table("source_table", data=data)
 
-    cp_table1 = db_cp.copy_table(table) # Copy from LanceTable Object
-    assert "source_table" in db_cp.table_names()
-    assert cp_table1._conn == db_cp
-    assert cp_table1.name == table.name
+    dest_table = db_dest.copy_table(source_table) # Copy from LanceTable Object
+    assert "source_table" in db_dest.table_names()
+    assert dest_table._conn == db_dest
+    assert dest_table.name == source_table.name
 
-    cp_table2 = db_cp.copy_table(table._dataset_uri, "table_copy") # Copy from Lancetable URI
-    assert "table_copy" in db_cp.table_names()
-    assert cp_table2._conn == db_cp
-    assert cp_table2.name == "table_copy"
+    dest_table = db_dest.copy_table(source_table._dataset_uri, "dest_table") # Copy from Lancetable URI
+    assert "dest_table" in db_dest.table_names()
+    assert dest_table._conn == db_dest
+    assert dest_table.name == "dest_table"
 
-    db_cp.copy_table(cp_table1, "table_copy2") # Copy from LanceTable Object with new name
-    
-    with pytest.raises(ValueError): # Copy table to itself with same name
-        db_cp.copy_table(cp_table1)
+    db_dest.copy_table(dest_table, "table_copy2") # Copy from same LanceTable Object with new name
+
+    with pytest.raises(ValueError): # Copy from same LanceTable Object with same name
+        db_dest.copy_table(dest_table)

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -129,14 +129,19 @@ def test_copying(tmp_path_factory):
             {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
         ]
     
-    table = db.create_table("test", data=data)
+    table = db.create_table("source_table", data=data)
 
     cp_table1 = db_cp.copy_table(table) # Copy from LanceTable Object
-    assert "table_copy" in db_cp.table_names()
+    assert "source_table" in db_cp.table_names()
     assert cp_table1._conn == db_cp
     assert cp_table1.name == table.name
 
-    cp_table2 = db_cp.copy_table(table._conn.uri + "/test.lance", "table_copy") # Copy from Lancetable URI
-    assert "table_copy2" in db_cp.table_names()
+    cp_table2 = db_cp.copy_table(table._dataset_uri, "table_copy") # Copy from Lancetable URI
+    assert "table_copy" in db_cp.table_names()
     assert cp_table2._conn == db_cp
     assert cp_table2.name == "table_copy"
+
+    db_cp.copy_table(cp_table1, "table_copy2") # Copy from LanceTable Object with new name
+    
+    with pytest.raises(ValueError): # Copy table to itself with same name
+        db_cp.copy_table(cp_table1)

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -120,3 +120,23 @@ def test_delete_table(tmp_path):
 
     db.create_table("test", data=data)
     assert db.table_names() == ["test"]
+
+def test_copying(tmp_path_factory):
+    db = lancedb.connect(tmp_path_factory.mktemp("db"))
+    db_cp = lancedb.connect(tmp_path_factory.mktemp("db_copy"))
+    data=[
+            {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
+            {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
+        ]
+    
+    table = db.create_table("test", data=data)
+
+    cp_table1 = db_cp.copy_table(table) # Copy from LanceTable Object
+    assert "table_copy" in db_cp.table_names()
+    assert cp_table1._conn == db_cp
+    assert cp_table1.name == table.name
+
+    cp_table2 = db_cp.copy_table(table._conn.uri + "/test.lance", "table_copy") # Copy from Lancetable URI
+    assert "table_copy2" in db_cp.table_names()
+    assert cp_table2._conn == db_cp
+    assert cp_table2.name == "table_copy"


### PR DESCRIPTION
**Story - https://github.com/lancedb/lancedb/issues/130**

**Motivation - Allow simple workflow to copy/import tables**
Usage 1 - Using lanceDB tables as assets, like model weights, to be loaded and shared via path
```
lancedb_art = "path/to/my_table.lance" # lanceDB artifact
db = lancedb.connect(".db/")
db.copy_table(lancedb_art)  
```
Usage 2 - Creating table from a table
```
table_dest = db_dest.copy_table(table_source)
```

Can be used to implement `LanceTable.copy(name)`
A bit conficted about calling this `import_table()` tbh. `copy_table()` makes it explicit that the table won't be altered.

TODO:
- [x] check tests
- [ ] Implement `table.copy()`