### PR TITLE
bump lance to 0.5.2, make object store construction hook public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dad119202267ad3f2a5f5dd4b38a9ce7f66c13c14005c2588f9a18da7f25ab"
+checksum = "c9394675e5f03bedf00952fec1ff4d1525a1a4ceff36ae41018bc354e9ff771a"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -1678,7 +1678,6 @@ dependencies = [
  "roaring",
  "shellexpand",
  "snafu",
- "sqlparser-lance",
  "tokio",
  "url",
  "uuid",
@@ -2910,15 +2909,6 @@ checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
 dependencies = [
  "log",
  "sqlparser_derive",
-]
-
-[[package]]
-name = "sqlparser-lance"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6869d4a81a3594c324d22a21767b8cf91961d30f8f219201f9e10951a16a17"
-dependencies = [
- "log",
 ]
 
 [[package]]

--- a/rust/ffi/node/Cargo.toml
+++ b/rust/ffi/node/Cargo.toml
@@ -15,7 +15,7 @@ arrow-ipc = "40.0"
 arrow-schema = "40.0"
 once_cell = "1"
 futures = "0.3"
-lance = "0.5.1"
+lance = "0.5.2"
 vectordb = { path = "../../vectordb" }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 neon = {version = "0.10.1", default-features = false, features = ["channel-api", "napi-6", "promise-api", "task-api"] }

--- a/rust/vectordb/Cargo.toml
+++ b/rust/vectordb/Cargo.toml
@@ -14,7 +14,7 @@ arrow-data = "40.0"
 arrow-schema = "40.0"
 object_store = "0.6.1"
 snafu = "0.7.4"
-lance = "0.5.1"
+lance = "0.5.2"
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 
 [dev-dependencies]

--- a/rust/vectordb/src/database.rs
+++ b/rust/vectordb/src/database.rs
@@ -20,7 +20,7 @@ use lance::io::object_store::ObjectStore;
 use snafu::prelude::*;
 
 use crate::error::{CreateDirSnafu, Result};
-use crate::table::Table;
+use crate::table::{OpenTableParams, Table};
 
 pub struct Database {
     object_store: ObjectStore,
@@ -107,7 +107,25 @@ impl Database {
     ///
     /// * A [Table] object.
     pub async fn open_table(&self, name: &str) -> Result<Table> {
-        Table::open(&self.uri, name).await
+        self.open_table_with_params(name, OpenTableParams::default())
+            .await
+    }
+
+    /// Open a table in the database.
+    ///
+    /// # Arguments
+    /// * `name` - The name of the table.
+    /// * `params` - The parameters to open the table.
+    ///
+    /// # Returns
+    ///
+    /// * A [Table] object.
+    pub async fn open_table_with_params(
+        &self,
+        name: &str,
+        params: OpenTableParams,
+    ) -> Result<Table> {
+        Table::open_with_params(&self.uri, name, params).await
     }
 
     /// Drop a table in the database.

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -43,7 +43,7 @@ impl std::fmt::Display for Table {
 
 #[derive(Default)]
 pub struct OpenTableParams {
-    pub(crate) dataset_read_params: ReadParams,
+    pub open_table_params: ReadParams,
 }
 
 impl Table {
@@ -85,7 +85,7 @@ impl Table {
             .to_str()
             .context(InvalidTableNameSnafu { name })?;
 
-        let dataset = Dataset::open_with_params(uri, &params.dataset_read_params)
+        let dataset = Dataset::open_with_params(uri, &params.open_table_params)
             .await
             .map_err(|e| match e {
                 lance::Error::DatasetNotFound { .. } => Error::TableNotFound {
@@ -394,7 +394,7 @@ mod tests {
         let wrapper = Arc::new(NoOpCacheWrapper::default());
 
         let param = OpenTableParams {
-            dataset_read_params: ReadParams {
+            open_table_params: ReadParams {
                 store_options: Some(ObjectStoreParams {
                     object_store_wrapper: Some(wrapper.clone()),
                 }),


### PR DESCRIPTION
* bump to 0.5.2 to pick up S3 auth fixes
* make `dataset_read_params` a public attribute
* add `open_table_with_params` on `Database`