### PR TITLE
Handle NaN input data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ node/examples/**/dist
 ## Rust
 target
 
+Cargo.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,13 @@ repos:
     rev: 22.12.0
     hooks:
     -   id: black
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.277
+    hooks:
+    - id: ruff
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    - id: isort
+      name: isort (python)

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -158,6 +158,7 @@ class LanceDBConnection:
         data: DATA = None,
         schema: pa.Schema = None,
         mode: str = "create",
+        strict: bool = False,
     ) -> LanceTable:
         """Create a table in the database.
 
@@ -173,6 +174,10 @@ class LanceDBConnection:
             The mode to use when creating the table. Can be either "create" or "overwrite".
             By default, if the table already exists, an exception is raised.
             If you want to overwrite the table, use mode="overwrite".
+        strict: bool, default False
+            If True then raise ValueError if input data is not all the same
+            length, otherwise rows with vectors less than the max length in
+            the input data will be removed.
 
         Note
         ----
@@ -253,7 +258,8 @@ class LanceDBConnection:
             raise ValueError("mode must be either 'create' or 'overwrite'")
 
         if data is not None:
-            tbl = LanceTable.create(self, name, data, schema, mode=mode)
+            tbl = LanceTable.create(self, name, data, schema, mode=mode,
+                                    strict=strict)
         else:
             tbl = LanceTable.open(self, name)
         return tbl

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -159,7 +159,7 @@ class LanceDBConnection:
         schema: pa.Schema = None,
         mode: str = "create",
         on_bad_vectors: str = "drop",
-        fill_value: float = 0.
+        fill_value: float = 0.0,
     ) -> LanceTable:
         """Create a table in the database.
 
@@ -260,8 +260,15 @@ class LanceDBConnection:
             raise ValueError("mode must be either 'create' or 'overwrite'")
 
         if data is not None:
-            tbl = LanceTable.create(self, name, data, schema, mode=mode,
-                                    on_bad_vectors=on_bad_vectors, fill_value=fill_value)
+            tbl = LanceTable.create(
+                self,
+                name,
+                data,
+                schema,
+                mode=mode,
+                on_bad_vectors=on_bad_vectors,
+                fill_value=fill_value,
+            )
         else:
             tbl = LanceTable.open(self, name)
         return tbl

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -158,7 +158,8 @@ class LanceDBConnection:
         data: DATA = None,
         schema: pa.Schema = None,
         mode: str = "create",
-        strict: bool = False,
+        on_bad_vectors: str = "drop",
+        fill_value: float = 0.
     ) -> LanceTable:
         """Create a table in the database.
 
@@ -174,10 +175,11 @@ class LanceDBConnection:
             The mode to use when creating the table. Can be either "create" or "overwrite".
             By default, if the table already exists, an exception is raised.
             If you want to overwrite the table, use mode="overwrite".
-        strict: bool, default False
-            If True then raise ValueError if input data is not all the same
-            length, otherwise rows with vectors less than the max length in
-            the input data will be removed.
+        on_bad_vectors: str
+            What to do if any of the vectors are not the same size or contains NaNs.
+            One of "raise", "drop", "fill".
+        fill_value: float
+            The value to use when filling vectors. Only used if on_bad_vectors="fill".
 
         Note
         ----
@@ -259,7 +261,7 @@ class LanceDBConnection:
 
         if data is not None:
             tbl = LanceTable.create(self, name, data, schema, mode=mode,
-                                    strict=strict)
+                                    on_bad_vectors=on_bad_vectors, fill_value=fill_value)
         else:
             tbl = LanceTable.open(self, name)
         return tbl

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -15,7 +15,6 @@ import unittest.mock as mock
 
 import lance
 import numpy as np
-import pandas as pd
 import pandas.testing as tm
 import pyarrow as pa
 import pytest

--- a/python/tests/test_remote_client.py
+++ b/python/tests/test_remote_client.py
@@ -30,7 +30,7 @@ class MockLanceDBServer:
         table_name = request.match_info["table_name"]
         assert table_name == "test_table"
 
-        request_json = await request.json()
+        await request.json()
         # TODO: do some matching
 
         vecs = pd.Series([np.random.rand(128) for x in range(10)], name="vector")

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -179,7 +179,8 @@ def test_create_index_method():
             )
 
 
-def test_add_with_nans():
+def test_add_with_nans(db):
+    # LangChain sometimes pass [NaN] if the embedding function fails
     table = LanceTable.create(
         db,
         "test",
@@ -188,4 +189,15 @@ def test_add_with_nans():
             {"vector": [np.nan], "item": "bar", "price": 20.0},
         ],
     )
-    assert table.search([1., 1.]).limit(1).to_arrow()["item"][0] == "foo"
+    assert len(table) == 1
+
+    with pytest.raises(ValueError):
+        LanceTable.create(
+            db,
+            "test",
+            data=[
+                {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
+                {"vector": [np.nan], "item": "bar", "price": 20.0},
+            ],
+            strict=True,
+        )

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -168,7 +168,8 @@ def test_create_index_method():
                 replace=True,
             )
 
-            # Check that the _dataset.create_index method was called with the right parameters
+            # Check that the _dataset.create_index method was called
+            # with the right parameters
             mock_dataset.return_value.create_index.assert_called_once_with(
                 column="vector",
                 index_type="IVF_PQ",

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -183,7 +183,7 @@ def test_add_with_nans(db):
     # By default we drop bad input vectors
     table = LanceTable.create(
         db,
-        "test",
+        "drop_test",
         data=[
             {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
             {"vector": [np.nan], "item": "bar", "price": 20.0},
@@ -196,18 +196,18 @@ def test_add_with_nans(db):
     # We can fill bad input with some value
     table = LanceTable.create(
         db,
-        "test",
+        "fill_test",
         data=[
             {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
             {"vector": [np.nan], "item": "bar", "price": 20.0},
             {"vector": [np.nan, np.nan], "item": "bar", "price": 20.0},
         ],
-        on_invalid_vectors="fill",
+        on_bad_vectors="fill",
         fill_value=0.0,
     )
     assert len(table) == 3
     arrow_tbl = table.to_lance().to_table(filter="item == 'bar'")
-    v = arrow_tbl["item"].to_pylist()[0]
+    v = arrow_tbl["vector"].to_pylist()[0]
     assert np.allclose(v, np.array([0.0, 0.0]))
 
     bad_data = [
@@ -220,10 +220,10 @@ def test_add_with_nans(db):
         with pytest.raises(ValueError):
             LanceTable.create(
                 db,
-                "test",
+                "raise_test",
                 data=[
                     {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
                     row
                 ],
-                on_invalid_vectors="raise",
+                on_bad_vectors="raise",
             )

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -15,6 +15,7 @@ import functools
 from pathlib import Path
 from unittest.mock import PropertyMock, patch
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
@@ -176,3 +177,15 @@ def test_create_index_method():
                 num_sub_vectors=96,
                 replace=True,
             )
+
+
+def test_add_with_nans():
+    table = LanceTable.create(
+        db,
+        "test",
+        data=[
+            {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
+            {"vector": [np.nan], "item": "bar", "price": 20.0},
+        ],
+    )
+    assert table.search([1., 1.]).limit(1).to_arrow()["item"][0] == "foo"

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -214,16 +214,13 @@ def test_add_with_nans(db):
         {"vector": [np.nan], "item": "bar", "price": 20.0},
         {"vector": [5], "item": "bar", "price": 20.0},
         {"vector": [np.nan, np.nan], "item": "bar", "price": 20.0},
-        {"vector": [np.nan, 5.], "item": "bar", "price": 20.0},
+        {"vector": [np.nan, 5.0], "item": "bar", "price": 20.0},
     ]
     for row in bad_data:
         with pytest.raises(ValueError):
             LanceTable.create(
                 db,
                 "raise_test",
-                data=[
-                    {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
-                    row
-                ],
+                data=[{"vector": [3.1, 4.1], "item": "foo", "price": 10.0}, row],
                 on_bad_vectors="raise",
             )


### PR DESCRIPTION
Sometimes LangChain would insert a single `[np.nan]` as a placeholder if the embedding function failed. This causes a problem for Lance format because then the array can't be stored as a FixedSizedListArray.

Instead:
1. By default we remove rows with embedding lengths less than the maximum length in the batch
2. If `strict=True` kwargs is set to True, then a `ValueError` is raised if the embeddings aren't all the same length