### PR TITLE
[docs] fixed javascript docs for overloaded functions

### DIFF
--- a/docs/src/javascript/README.md
+++ b/docs/src/javascript/README.md
@@ -16,10 +16,8 @@ npm install vectordb
 
 ```javascript
 const lancedb = require('vectordb');
-const db = await lancedb.connect('data/sample-lancedb');
-const table = await db.createTable("my_table", 
-      [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },
-      { id: 2, vector: [3.9, 0.5], item: "bar", price: 20.0 }])
+const db = lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
+const table = await db.openTable('my_table');
 const results = await table.search([0.1, 0.3]).limit(20).execute();
 console.log(results);
 ```

--- a/docs/src/javascript/README.md
+++ b/docs/src/javascript/README.md
@@ -16,8 +16,7 @@ npm install vectordb
 
 ```javascript
 const lancedb = require('vectordb');
-const db = await lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
-const db = lancedb.connect('data/sample-lancedb');
+const db = await lancedb.connect('data/sample-lancedb');
 const table = await db.createTable("my_table",
       [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },
       { id: 2, vector: [3.9, 0.5], item: "bar", price: 20.0 }])

--- a/docs/src/javascript/README.md
+++ b/docs/src/javascript/README.md
@@ -16,7 +16,7 @@ npm install vectordb
 
 ```javascript
 const lancedb = require('vectordb');
-const db = lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
+const db = lancedb.connect('data/sample-lancedb');
 const table = await db.createTable("my_table",
       [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },
       { id: 2, vector: [3.9, 0.5], item: "bar", price: 20.0 }])

--- a/docs/src/javascript/README.md
+++ b/docs/src/javascript/README.md
@@ -17,7 +17,9 @@ npm install vectordb
 ```javascript
 const lancedb = require('vectordb');
 const db = lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
-const table = await db.openTable('my_table');
+const table = await db.createTable("my_table",
+      [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },
+      { id: 2, vector: [3.9, 0.5], item: "bar", price: 20.0 }])
 const results = await table.search([0.1, 0.3]).limit(20).execute();
 console.log(results);
 ```

--- a/docs/src/javascript/README.md
+++ b/docs/src/javascript/README.md
@@ -16,6 +16,7 @@ npm install vectordb
 
 ```javascript
 const lancedb = require('vectordb');
+const db = await lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
 const db = lancedb.connect('data/sample-lancedb');
 const table = await db.createTable("my_table",
       [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },

--- a/docs/src/javascript/classes/LocalConnection.md
+++ b/docs/src/javascript/classes/LocalConnection.md
@@ -46,7 +46,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:157](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L157)
+[index.ts:132](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L132)
 
 ## Properties
 
@@ -56,7 +56,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:155](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L155)
+[index.ts:130](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L130)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[index.ts:154](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L154)
+[index.ts:129](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L129)
 
 ## Accessors
 
@@ -84,13 +84,13 @@ ___
 
 #### Defined in
 
-[index.ts:162](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L162)
+[index.ts:137](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L137)
 
 ## Methods
 
 ### createTable
 
-▸ **createTable**(`name`, `data`): `Promise`<[`Table`](../interfaces/Table.md)<`number`[]\>\>
+▸ **createTable**(`name`, `data`, `mode?`): `Promise`<[`Table`](../interfaces/Table.md)<`number`[]\>\>
 
 Creates a new Table and initialize it with new data.
 
@@ -100,6 +100,7 @@ Creates a new Table and initialize it with new data.
 | :------ | :------ | :------ |
 | `name` | `string` | The name of the table. |
 | `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
+| `mode?` | [`WriteMode`](../enums/WriteMode.md) | The write mode to use when creating the table. |
 
 #### Returns
 
@@ -111,9 +112,31 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:202](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L202)
+[index.ts:177](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L177)
 
-▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
+▸ **createTable**(`name`, `data`, `mode`): `Promise`<[`Table`](../interfaces/Table.md)<`number`[]\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+| `data` | `Record`<`string`, `unknown`\>[] |
+| `mode` | [`WriteMode`](../enums/WriteMode.md) |
+
+#### Returns
+
+`Promise`<[`Table`](../interfaces/Table.md)<`number`[]\>\>
+
+#### Implementation of
+
+Connection.createTable
+
+#### Defined in
+
+[index.ts:178](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L178)
+
+▸ **createTable**<`T`\>(`name`, `data`, `mode`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
 Creates a new Table and initialize it with new data.
 
@@ -129,6 +152,7 @@ Creates a new Table and initialize it with new data.
 | :------ | :------ | :------ |
 | `name` | `string` | The name of the table. |
 | `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
+| `mode` | [`WriteMode`](../enums/WriteMode.md) | The write mode to use when creating the table. |
 | `embeddings` | [`EmbeddingFunction`](../interfaces/EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
 
 #### Returns
@@ -137,11 +161,11 @@ Creates a new Table and initialize it with new data.
 
 #### Implementation of
 
-[Connection](../interfaces/Connection.md).[createTable](../interfaces/Connection.md#createtable)
+Connection.createTable
 
 #### Defined in
 
-[index.ts:210](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L210)
+[index.ts:188](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L188)
 
 ___
 
@@ -166,7 +190,7 @@ ___
 
 #### Defined in
 
-[index.ts:220](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L220)
+[index.ts:201](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L201)
 
 ___
 
@@ -192,7 +216,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:230](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L230)
+[index.ts:211](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L211)
 
 ___
 
@@ -218,7 +242,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:178](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L178)
+[index.ts:153](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L153)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -243,11 +267,11 @@ Open a table in the database.
 
 #### Implementation of
 
-[Connection](../interfaces/Connection.md).[openTable](../interfaces/Connection.md#opentable)
+Connection.openTable
 
 #### Defined in
 
-[index.ts:185](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L185)
+[index.ts:160](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L160)
 
 ___
 
@@ -267,4 +291,4 @@ Get the names of all tables in the database.
 
 #### Defined in
 
-[index.ts:169](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L169)
+[index.ts:144](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L144)

--- a/docs/src/javascript/classes/LocalConnection.md
+++ b/docs/src/javascript/classes/LocalConnection.md
@@ -46,7 +46,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:129](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L129)
+[index.ts:158](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L158)
 
 ## Properties
 
@@ -56,7 +56,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:127](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L127)
+[index.ts:156](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L156)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[index.ts:126](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L126)
+[index.ts:155](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L155)
 
 ## Accessors
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[index.ts:134](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L134)
+[index.ts:163](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L163)
 
 ## Methods
 
@@ -107,11 +107,11 @@ Creates a new Table and initialize it with new data.
 
 #### Implementation of
 
-Connection.createTable
+[Connection](../interfaces/Connection.md).[createTable](../interfaces/Connection.md#createtable)
 
 #### Defined in
 
-[index.ts:174](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L174)
+[index.ts:203](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L203)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -137,11 +137,11 @@ Creates a new Table and initialize it with new data.
 
 #### Implementation of
 
-Connection.createTable
+[Connection](../interfaces/Connection.md).[createTable](../interfaces/Connection.md#createtable)
 
 #### Defined in
 
-[index.ts:182](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L182)
+[index.ts:211](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L211)
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 #### Defined in
 
-[index.ts:192](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L192)
+[index.ts:221](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L221)
 
 ___
 
@@ -192,7 +192,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:202](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L202)
+[index.ts:231](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L231)
 
 ___
 
@@ -214,11 +214,11 @@ Open a table in the database.
 
 #### Implementation of
 
-Connection.openTable
+[Connection](../interfaces/Connection.md).[openTable](../interfaces/Connection.md#opentable)
 
 #### Defined in
 
-[index.ts:150](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L150)
+[index.ts:179](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L179)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -243,11 +243,11 @@ Open a table in the database.
 
 #### Implementation of
 
-Connection.openTable
+[Connection](../interfaces/Connection.md).[openTable](../interfaces/Connection.md#opentable)
 
 #### Defined in
 
-[index.ts:157](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L157)
+[index.ts:186](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L186)
 
 ___
 
@@ -267,4 +267,4 @@ Get the names of all tables in the database.
 
 #### Defined in
 
-[index.ts:141](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L141)
+[index.ts:170](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L170)

--- a/docs/src/javascript/classes/LocalConnection.md
+++ b/docs/src/javascript/classes/LocalConnection.md
@@ -46,7 +46,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:160](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L160)
+[index.ts:157](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L157)
 
 ## Properties
 
@@ -56,7 +56,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:158](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L158)
+[index.ts:155](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L155)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[index.ts:157](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L157)
+[index.ts:154](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L154)
 
 ## Accessors
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[index.ts:165](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L165)
+[index.ts:162](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L162)
 
 ## Methods
 
@@ -111,7 +111,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:205](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L205)
+[index.ts:202](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L202)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -141,7 +141,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:213](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L213)
+[index.ts:210](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L210)
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 #### Defined in
 
-[index.ts:223](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L223)
+[index.ts:220](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L220)
 
 ___
 
@@ -192,7 +192,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:233](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L233)
+[index.ts:230](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L230)
 
 ___
 
@@ -218,7 +218,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:181](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L181)
+[index.ts:178](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L178)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -247,7 +247,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:188](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L188)
+[index.ts:185](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L185)
 
 ___
 
@@ -267,4 +267,4 @@ Get the names of all tables in the database.
 
 #### Defined in
 
-[index.ts:172](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L172)
+[index.ts:169](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L169)

--- a/docs/src/javascript/classes/LocalConnection.md
+++ b/docs/src/javascript/classes/LocalConnection.md
@@ -46,7 +46,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:132](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L132)
+[index.ts:132](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L132)
 
 ## Properties
 
@@ -56,7 +56,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:130](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L130)
+[index.ts:130](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L130)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[index.ts:129](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L129)
+[index.ts:129](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L129)
 
 ## Accessors
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[index.ts:137](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L137)
+[index.ts:137](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L137)
 
 ## Methods
 
@@ -112,7 +112,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:177](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L177)
+[index.ts:177](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L177)
 
 ▸ **createTable**(`name`, `data`, `mode`): `Promise`<[`Table`](../interfaces/Table.md)<`number`[]\>\>
 
@@ -134,7 +134,7 @@ Connection.createTable
 
 #### Defined in
 
-[index.ts:178](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L178)
+[index.ts:178](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L178)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `mode`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -165,7 +165,7 @@ Connection.createTable
 
 #### Defined in
 
-[index.ts:188](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L188)
+[index.ts:188](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L188)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[index.ts:201](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L201)
+[index.ts:201](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L201)
 
 ___
 
@@ -216,7 +216,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:211](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L211)
+[index.ts:211](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L211)
 
 ___
 
@@ -242,7 +242,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:153](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L153)
+[index.ts:153](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L153)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -271,7 +271,7 @@ Connection.openTable
 
 #### Defined in
 
-[index.ts:160](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L160)
+[index.ts:160](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L160)
 
 ___
 
@@ -291,4 +291,4 @@ Get the names of all tables in the database.
 
 #### Defined in
 
-[index.ts:144](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L144)
+[index.ts:144](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L144)

--- a/docs/src/javascript/classes/LocalConnection.md
+++ b/docs/src/javascript/classes/LocalConnection.md
@@ -46,7 +46,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:158](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L158)
+[index.ts:160](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L160)
 
 ## Properties
 
@@ -56,7 +56,7 @@ A connection to a LanceDB database.
 
 #### Defined in
 
-[index.ts:156](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L156)
+[index.ts:158](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L158)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[index.ts:155](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L155)
+[index.ts:157](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L157)
 
 ## Accessors
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[index.ts:163](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L163)
+[index.ts:165](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L165)
 
 ## Methods
 
@@ -111,7 +111,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:203](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L203)
+[index.ts:205](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L205)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -141,7 +141,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:211](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L211)
+[index.ts:213](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L213)
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 #### Defined in
 
-[index.ts:221](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L221)
+[index.ts:223](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L223)
 
 ___
 
@@ -192,7 +192,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:231](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L231)
+[index.ts:233](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L233)
 
 ___
 
@@ -218,7 +218,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:179](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L179)
+[index.ts:181](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L181)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](../interfaces/Table.md)<`T`\>\>
 
@@ -247,7 +247,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:186](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L186)
+[index.ts:188](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L188)
 
 ___
 
@@ -267,4 +267,4 @@ Get the names of all tables in the database.
 
 #### Defined in
 
-[index.ts:170](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L170)
+[index.ts:172](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L172)

--- a/docs/src/javascript/classes/LocalTable.md
+++ b/docs/src/javascript/classes/LocalTable.md
@@ -60,7 +60,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:212](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L212)
+[index.ts:241](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L241)
 
 • **new LocalTable**<`T`\>(`tbl`, `name`, `embeddings`)
 
@@ -80,7 +80,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:218](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L218)
+[index.ts:247](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L247)
 
 ## Properties
 
@@ -90,7 +90,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:210](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L210)
+[index.ts:239](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L239)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[index.ts:209](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L209)
+[index.ts:238](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L238)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[index.ts:208](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L208)
+[index.ts:237](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L237)
 
 ## Accessors
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[index.ts:225](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L225)
+[index.ts:254](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L254)
 
 ## Methods
 
@@ -156,7 +156,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:243](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L243)
+[index.ts:272](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L272)
 
 ___
 
@@ -176,7 +176,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:269](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L269)
+[index.ts:298](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L298)
 
 ___
 
@@ -206,7 +206,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:262](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L262)
+[index.ts:291](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L291)
 
 ___
 
@@ -232,7 +232,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:278](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L278)
+[index.ts:307](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L307)
 
 ___
 
@@ -260,7 +260,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:253](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L253)
+[index.ts:282](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L282)
 
 ___
 
@@ -286,4 +286,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:233](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L233)
+[index.ts:262](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L262)

--- a/docs/src/javascript/classes/LocalTable.md
+++ b/docs/src/javascript/classes/LocalTable.md
@@ -60,7 +60,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:243](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L243)
+[index.ts:240](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L240)
 
 • **new LocalTable**<`T`\>(`tbl`, `name`, `embeddings`)
 
@@ -80,7 +80,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:249](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L249)
+[index.ts:246](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L246)
 
 ## Properties
 
@@ -90,7 +90,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:241](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L241)
+[index.ts:238](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L238)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[index.ts:240](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L240)
+[index.ts:237](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L237)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[index.ts:239](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L239)
+[index.ts:236](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L236)
 
 ## Accessors
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[index.ts:256](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L256)
+[index.ts:253](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L253)
 
 ## Methods
 
@@ -156,7 +156,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:274](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L274)
+[index.ts:271](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L271)
 
 ___
 
@@ -176,7 +176,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:300](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L300)
+[index.ts:297](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L297)
 
 ___
 
@@ -206,7 +206,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:293](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L293)
+[index.ts:290](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L290)
 
 ___
 
@@ -232,7 +232,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:309](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L309)
+[index.ts:306](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L306)
 
 ___
 
@@ -260,7 +260,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:284](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L284)
+[index.ts:281](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L281)
 
 ___
 
@@ -286,4 +286,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:264](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L264)
+[index.ts:261](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L261)

--- a/docs/src/javascript/classes/LocalTable.md
+++ b/docs/src/javascript/classes/LocalTable.md
@@ -60,7 +60,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:241](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L241)
+[index.ts:243](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L243)
 
 • **new LocalTable**<`T`\>(`tbl`, `name`, `embeddings`)
 
@@ -80,7 +80,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:247](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L247)
+[index.ts:249](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L249)
 
 ## Properties
 
@@ -90,7 +90,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:239](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L239)
+[index.ts:241](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L241)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[index.ts:238](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L238)
+[index.ts:240](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L240)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[index.ts:237](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L237)
+[index.ts:239](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L239)
 
 ## Accessors
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[index.ts:254](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L254)
+[index.ts:256](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L256)
 
 ## Methods
 
@@ -156,7 +156,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:272](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L272)
+[index.ts:274](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L274)
 
 ___
 
@@ -176,7 +176,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:298](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L298)
+[index.ts:300](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L300)
 
 ___
 
@@ -206,7 +206,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:291](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L291)
+[index.ts:293](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L293)
 
 ___
 
@@ -232,7 +232,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:307](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L307)
+[index.ts:309](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L309)
 
 ___
 
@@ -260,7 +260,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:282](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L282)
+[index.ts:284](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L284)
 
 ___
 
@@ -286,4 +286,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:262](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L262)
+[index.ts:264](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L264)

--- a/docs/src/javascript/classes/LocalTable.md
+++ b/docs/src/javascript/classes/LocalTable.md
@@ -2,7 +2,7 @@
 
 # Class: LocalTable<T\>
 
-A LanceDB table that allows you to search and update a table.
+A LanceDB Table is the collection of Records. Each Record has one or more vector fields.
 
 ## Type parameters
 
@@ -60,7 +60,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:240](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L240)
+[index.ts:221](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L221)
 
 • **new LocalTable**<`T`\>(`tbl`, `name`, `embeddings`)
 
@@ -80,7 +80,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:246](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L246)
+[index.ts:227](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L227)
 
 ## Properties
 
@@ -90,7 +90,7 @@ A LanceDB table that allows you to search and update a table.
 
 #### Defined in
 
-[index.ts:238](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L238)
+[index.ts:219](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L219)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[index.ts:237](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L237)
+[index.ts:218](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L218)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[index.ts:236](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L236)
+[index.ts:217](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L217)
 
 ## Accessors
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[index.ts:253](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L253)
+[index.ts:234](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L234)
 
 ## Methods
 
@@ -156,7 +156,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:271](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L271)
+[index.ts:252](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L252)
 
 ___
 
@@ -176,7 +176,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:297](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L297)
+[index.ts:278](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L278)
 
 ___
 
@@ -206,7 +206,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:290](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L290)
+[index.ts:271](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L271)
 
 ___
 
@@ -232,7 +232,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:306](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L306)
+[index.ts:287](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L287)
 
 ___
 
@@ -260,7 +260,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:281](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L281)
+[index.ts:262](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L262)
 
 ___
 
@@ -286,4 +286,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:261](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L261)
+[index.ts:242](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L242)

--- a/docs/src/javascript/classes/LocalTable.md
+++ b/docs/src/javascript/classes/LocalTable.md
@@ -60,7 +60,7 @@ A LanceDB Table is the collection of Records. Each Record has one or more vector
 
 #### Defined in
 
-[index.ts:221](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L221)
+[index.ts:221](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L221)
 
 • **new LocalTable**<`T`\>(`tbl`, `name`, `embeddings`)
 
@@ -80,7 +80,7 @@ A LanceDB Table is the collection of Records. Each Record has one or more vector
 
 #### Defined in
 
-[index.ts:227](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L227)
+[index.ts:227](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L227)
 
 ## Properties
 
@@ -90,7 +90,7 @@ A LanceDB Table is the collection of Records. Each Record has one or more vector
 
 #### Defined in
 
-[index.ts:219](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L219)
+[index.ts:219](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L219)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[index.ts:218](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L218)
+[index.ts:218](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L218)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[index.ts:217](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L217)
+[index.ts:217](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L217)
 
 ## Accessors
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[index.ts:234](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L234)
+[index.ts:234](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L234)
 
 ## Methods
 
@@ -156,7 +156,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:252](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L252)
+[index.ts:252](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L252)
 
 ___
 
@@ -176,7 +176,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:278](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L278)
+[index.ts:278](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L278)
 
 ___
 
@@ -206,7 +206,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:271](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L271)
+[index.ts:271](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L271)
 
 ___
 
@@ -232,7 +232,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:287](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L287)
+[index.ts:287](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L287)
 
 ___
 
@@ -260,7 +260,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:262](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L262)
+[index.ts:262](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L262)
 
 ___
 
@@ -286,4 +286,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:242](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L242)
+[index.ts:242](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L242)

--- a/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
+++ b/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
@@ -40,7 +40,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L21)
+[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L21)
 
 ## Properties
 
@@ -50,7 +50,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L19)
+[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L19)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L18)
+[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L18)
 
 ___
 
@@ -76,7 +76,7 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L50)
+[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L50)
 
 ## Methods
 
@@ -102,4 +102,4 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L38)
+[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L38)

--- a/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
+++ b/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
@@ -40,7 +40,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L21)
+[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/7247834/node/src/embedding/openai.ts#L21)
 
 ## Properties
 
@@ -50,7 +50,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L19)
+[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/7247834/node/src/embedding/openai.ts#L19)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L18)
+[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/7247834/node/src/embedding/openai.ts#L18)
 
 ___
 
@@ -76,7 +76,7 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L50)
+[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/7247834/node/src/embedding/openai.ts#L50)
 
 ## Methods
 
@@ -102,4 +102,4 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/openai.ts#L38)
+[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/7247834/node/src/embedding/openai.ts#L38)

--- a/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
+++ b/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
@@ -40,7 +40,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L21)
+[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L21)
 
 ## Properties
 
@@ -50,7 +50,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L19)
+[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L19)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L18)
+[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L18)
 
 ___
 
@@ -76,7 +76,7 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L50)
+[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L50)
 
 ## Methods
 
@@ -102,4 +102,4 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L38)
+[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/openai.ts#L38)

--- a/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
+++ b/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
@@ -40,7 +40,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L21)
+[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L21)
 
 ## Properties
 
@@ -50,7 +50,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L19)
+[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L19)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L18)
+[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L18)
 
 ___
 
@@ -76,7 +76,7 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L50)
+[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L50)
 
 ## Methods
 
@@ -102,4 +102,4 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L38)
+[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/openai.ts#L38)

--- a/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
+++ b/docs/src/javascript/classes/OpenAIEmbeddingFunction.md
@@ -40,7 +40,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/embedding/openai.ts#L21)
+[embedding/openai.ts:21](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L21)
 
 ## Properties
 
@@ -50,7 +50,7 @@ An embedding function that automatically creates vector representation for a giv
 
 #### Defined in
 
-[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/embedding/openai.ts#L19)
+[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L19)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/embedding/openai.ts#L18)
+[embedding/openai.ts:18](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L18)
 
 ___
 
@@ -76,7 +76,7 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/embedding/openai.ts#L50)
+[embedding/openai.ts:50](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L50)
 
 ## Methods
 
@@ -102,4 +102,4 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/embedding/openai.ts#L38)
+[embedding/openai.ts:38](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/openai.ts#L38)

--- a/docs/src/javascript/classes/Query.md
+++ b/docs/src/javascript/classes/Query.md
@@ -62,7 +62,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:353](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L353)
+[index.ts:382](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L382)
 
 ## Properties
 
@@ -72,7 +72,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:351](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L351)
+[index.ts:380](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L380)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[index.ts:349](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L349)
+[index.ts:378](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L378)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[index.ts:345](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L345)
+[index.ts:374](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L374)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[index.ts:350](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L350)
+[index.ts:379](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L379)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[index.ts:347](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L347)
+[index.ts:376](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L376)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[index.ts:343](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L343)
+[index.ts:372](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L372)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[index.ts:344](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L344)
+[index.ts:373](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L373)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[index.ts:346](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L346)
+[index.ts:375](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L375)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[index.ts:348](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L348)
+[index.ts:377](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L377)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[index.ts:342](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L342)
+[index.ts:371](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L371)
 
 ___
 
@@ -188,7 +188,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:401](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L401)
+[index.ts:430](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L430)
 
 ## Methods
 
@@ -210,7 +210,7 @@ Execute the query and return the results as an Array of Objects
 
 #### Defined in
 
-[index.ts:424](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L424)
+[index.ts:453](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L453)
 
 ___
 
@@ -232,7 +232,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:396](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L396)
+[index.ts:425](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L425)
 
 ___
 
@@ -254,7 +254,7 @@ Sets the number of results that will be returned
 
 #### Defined in
 
-[index.ts:369](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L369)
+[index.ts:398](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L398)
 
 ___
 
@@ -280,7 +280,7 @@ MetricType for the different options
 
 #### Defined in
 
-[index.ts:416](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L416)
+[index.ts:445](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L445)
 
 ___
 
@@ -302,7 +302,7 @@ The number of probes used. A higher number makes search more accurate but also s
 
 #### Defined in
 
-[index.ts:387](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L387)
+[index.ts:416](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L416)
 
 ___
 
@@ -324,7 +324,7 @@ Refine the results by reading extra elements and re-ranking them in memory.
 
 #### Defined in
 
-[index.ts:378](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L378)
+[index.ts:407](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L407)
 
 ___
 
@@ -346,4 +346,4 @@ Return only the specified columns.
 
 #### Defined in
 
-[index.ts:407](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L407)
+[index.ts:436](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L436)

--- a/docs/src/javascript/classes/Query.md
+++ b/docs/src/javascript/classes/Query.md
@@ -62,7 +62,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:362](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L362)
+[index.ts:362](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L362)
 
 ## Properties
 
@@ -72,7 +72,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:360](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L360)
+[index.ts:360](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L360)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[index.ts:358](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L358)
+[index.ts:358](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L358)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[index.ts:354](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L354)
+[index.ts:354](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L354)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[index.ts:359](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L359)
+[index.ts:359](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L359)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[index.ts:356](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L356)
+[index.ts:356](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L356)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[index.ts:352](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L352)
+[index.ts:352](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L352)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[index.ts:353](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L353)
+[index.ts:353](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L353)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[index.ts:355](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L355)
+[index.ts:355](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L355)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[index.ts:357](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L357)
+[index.ts:357](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L357)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[index.ts:351](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L351)
+[index.ts:351](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L351)
 
 ___
 
@@ -188,7 +188,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:410](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L410)
+[index.ts:410](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L410)
 
 ## Methods
 
@@ -210,7 +210,7 @@ Execute the query and return the results as an Array of Objects
 
 #### Defined in
 
-[index.ts:433](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L433)
+[index.ts:433](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L433)
 
 ___
 
@@ -232,7 +232,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:405](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L405)
+[index.ts:405](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L405)
 
 ___
 
@@ -254,7 +254,7 @@ Sets the number of results that will be returned
 
 #### Defined in
 
-[index.ts:378](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L378)
+[index.ts:378](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L378)
 
 ___
 
@@ -280,7 +280,7 @@ MetricType for the different options
 
 #### Defined in
 
-[index.ts:425](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L425)
+[index.ts:425](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L425)
 
 ___
 
@@ -302,7 +302,7 @@ The number of probes used. A higher number makes search more accurate but also s
 
 #### Defined in
 
-[index.ts:396](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L396)
+[index.ts:396](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L396)
 
 ___
 
@@ -324,7 +324,7 @@ Refine the results by reading extra elements and re-ranking them in memory.
 
 #### Defined in
 
-[index.ts:387](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L387)
+[index.ts:387](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L387)
 
 ___
 
@@ -346,4 +346,4 @@ Return only the specified columns.
 
 #### Defined in
 
-[index.ts:416](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L416)
+[index.ts:416](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L416)

--- a/docs/src/javascript/classes/Query.md
+++ b/docs/src/javascript/classes/Query.md
@@ -62,7 +62,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:384](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L384)
+[index.ts:381](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L381)
 
 ## Properties
 
@@ -72,7 +72,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:382](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L382)
+[index.ts:379](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L379)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[index.ts:380](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L380)
+[index.ts:377](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L377)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[index.ts:376](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L376)
+[index.ts:373](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L373)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[index.ts:381](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L381)
+[index.ts:378](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L378)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[index.ts:378](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L378)
+[index.ts:375](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L375)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[index.ts:374](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L374)
+[index.ts:371](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L371)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[index.ts:375](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L375)
+[index.ts:372](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L372)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[index.ts:377](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L377)
+[index.ts:374](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L374)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[index.ts:379](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L379)
+[index.ts:376](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L376)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[index.ts:373](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L373)
+[index.ts:370](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L370)
 
 ___
 
@@ -188,7 +188,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:432](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L432)
+[index.ts:429](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L429)
 
 ## Methods
 
@@ -210,7 +210,7 @@ Execute the query and return the results as an Array of Objects
 
 #### Defined in
 
-[index.ts:455](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L455)
+[index.ts:452](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L452)
 
 ___
 
@@ -232,7 +232,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:427](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L427)
+[index.ts:424](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L424)
 
 ___
 
@@ -254,7 +254,7 @@ Sets the number of results that will be returned
 
 #### Defined in
 
-[index.ts:400](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L400)
+[index.ts:397](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L397)
 
 ___
 
@@ -280,7 +280,7 @@ MetricType for the different options
 
 #### Defined in
 
-[index.ts:447](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L447)
+[index.ts:444](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L444)
 
 ___
 
@@ -302,7 +302,7 @@ The number of probes used. A higher number makes search more accurate but also s
 
 #### Defined in
 
-[index.ts:418](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L418)
+[index.ts:415](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L415)
 
 ___
 
@@ -324,7 +324,7 @@ Refine the results by reading extra elements and re-ranking them in memory.
 
 #### Defined in
 
-[index.ts:409](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L409)
+[index.ts:406](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L406)
 
 ___
 
@@ -346,4 +346,4 @@ Return only the specified columns.
 
 #### Defined in
 
-[index.ts:438](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L438)
+[index.ts:435](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L435)

--- a/docs/src/javascript/classes/Query.md
+++ b/docs/src/javascript/classes/Query.md
@@ -62,7 +62,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:381](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L381)
+[index.ts:362](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L362)
 
 ## Properties
 
@@ -72,7 +72,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:379](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L379)
+[index.ts:360](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L360)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[index.ts:377](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L377)
+[index.ts:358](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L358)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[index.ts:373](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L373)
+[index.ts:354](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L354)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[index.ts:378](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L378)
+[index.ts:359](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L359)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[index.ts:375](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L375)
+[index.ts:356](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L356)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[index.ts:371](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L371)
+[index.ts:352](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L352)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[index.ts:372](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L372)
+[index.ts:353](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L353)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[index.ts:374](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L374)
+[index.ts:355](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L355)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[index.ts:376](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L376)
+[index.ts:357](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L357)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[index.ts:370](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L370)
+[index.ts:351](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L351)
 
 ___
 
@@ -188,7 +188,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:429](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L429)
+[index.ts:410](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L410)
 
 ## Methods
 
@@ -210,7 +210,7 @@ Execute the query and return the results as an Array of Objects
 
 #### Defined in
 
-[index.ts:452](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L452)
+[index.ts:433](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L433)
 
 ___
 
@@ -232,7 +232,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:424](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L424)
+[index.ts:405](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L405)
 
 ___
 
@@ -254,7 +254,7 @@ Sets the number of results that will be returned
 
 #### Defined in
 
-[index.ts:397](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L397)
+[index.ts:378](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L378)
 
 ___
 
@@ -280,7 +280,7 @@ MetricType for the different options
 
 #### Defined in
 
-[index.ts:444](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L444)
+[index.ts:425](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L425)
 
 ___
 
@@ -302,7 +302,7 @@ The number of probes used. A higher number makes search more accurate but also s
 
 #### Defined in
 
-[index.ts:415](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L415)
+[index.ts:396](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L396)
 
 ___
 
@@ -324,7 +324,7 @@ Refine the results by reading extra elements and re-ranking them in memory.
 
 #### Defined in
 
-[index.ts:406](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L406)
+[index.ts:387](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L387)
 
 ___
 
@@ -346,4 +346,4 @@ Return only the specified columns.
 
 #### Defined in
 
-[index.ts:435](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L435)
+[index.ts:416](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L416)

--- a/docs/src/javascript/classes/Query.md
+++ b/docs/src/javascript/classes/Query.md
@@ -62,7 +62,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:382](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L382)
+[index.ts:384](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L384)
 
 ## Properties
 
@@ -72,7 +72,7 @@ A builder for nearest neighbor queries for LanceDB.
 
 #### Defined in
 
-[index.ts:380](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L380)
+[index.ts:382](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L382)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[index.ts:378](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L378)
+[index.ts:380](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L380)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[index.ts:374](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L374)
+[index.ts:376](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L376)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[index.ts:379](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L379)
+[index.ts:381](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L381)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[index.ts:376](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L376)
+[index.ts:378](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L378)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[index.ts:372](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L372)
+[index.ts:374](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L374)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[index.ts:373](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L373)
+[index.ts:375](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L375)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[index.ts:375](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L375)
+[index.ts:377](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L377)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[index.ts:377](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L377)
+[index.ts:379](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L379)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[index.ts:371](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L371)
+[index.ts:373](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L373)
 
 ___
 
@@ -188,7 +188,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:430](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L430)
+[index.ts:432](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L432)
 
 ## Methods
 
@@ -210,7 +210,7 @@ Execute the query and return the results as an Array of Objects
 
 #### Defined in
 
-[index.ts:453](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L453)
+[index.ts:455](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L455)
 
 ___
 
@@ -232,7 +232,7 @@ A filter statement to be applied to this query.
 
 #### Defined in
 
-[index.ts:425](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L425)
+[index.ts:427](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L427)
 
 ___
 
@@ -254,7 +254,7 @@ Sets the number of results that will be returned
 
 #### Defined in
 
-[index.ts:398](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L398)
+[index.ts:400](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L400)
 
 ___
 
@@ -280,7 +280,7 @@ MetricType for the different options
 
 #### Defined in
 
-[index.ts:445](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L445)
+[index.ts:447](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L447)
 
 ___
 
@@ -302,7 +302,7 @@ The number of probes used. A higher number makes search more accurate but also s
 
 #### Defined in
 
-[index.ts:416](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L416)
+[index.ts:418](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L418)
 
 ___
 
@@ -324,7 +324,7 @@ Refine the results by reading extra elements and re-ranking them in memory.
 
 #### Defined in
 
-[index.ts:407](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L407)
+[index.ts:409](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L409)
 
 ___
 
@@ -346,4 +346,4 @@ Return only the specified columns.
 
 #### Defined in
 
-[index.ts:436](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L436)
+[index.ts:438](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L438)

--- a/docs/src/javascript/enums/MetricType.md
+++ b/docs/src/javascript/enums/MetricType.md
@@ -9,6 +9,7 @@ Distance metrics type.
 ### Enumeration Members
 
 - [Cosine](MetricType.md#cosine)
+- [Dot](MetricType.md#dot)
 - [L2](MetricType.md#l2)
 
 ## Enumeration Members
@@ -21,7 +22,19 @@ Cosine distance
 
 #### Defined in
 
-[index.ts:465](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L465)
+[index.ts:494](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L494)
+
+___
+
+### Dot
+
+• **Dot** = ``"dot"``
+
+Dot product
+
+#### Defined in
+
+[index.ts:499](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L499)
 
 ___
 
@@ -33,4 +46,4 @@ Euclidean distance
 
 #### Defined in
 
-[index.ts:460](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L460)
+[index.ts:489](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L489)

--- a/docs/src/javascript/enums/MetricType.md
+++ b/docs/src/javascript/enums/MetricType.md
@@ -22,7 +22,7 @@ Cosine distance
 
 #### Defined in
 
-[index.ts:481](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L481)
+[index.ts:481](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L481)
 
 ___
 
@@ -34,7 +34,7 @@ Dot product
 
 #### Defined in
 
-[index.ts:486](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L486)
+[index.ts:486](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L486)
 
 ___
 
@@ -46,4 +46,4 @@ Euclidean distance
 
 #### Defined in
 
-[index.ts:476](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L476)
+[index.ts:476](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L476)

--- a/docs/src/javascript/enums/MetricType.md
+++ b/docs/src/javascript/enums/MetricType.md
@@ -22,7 +22,7 @@ Cosine distance
 
 #### Defined in
 
-[index.ts:493](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L493)
+[index.ts:481](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L481)
 
 ___
 
@@ -34,7 +34,7 @@ Dot product
 
 #### Defined in
 
-[index.ts:498](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L498)
+[index.ts:486](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L486)
 
 ___
 
@@ -46,4 +46,4 @@ Euclidean distance
 
 #### Defined in
 
-[index.ts:488](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L488)
+[index.ts:476](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L476)

--- a/docs/src/javascript/enums/MetricType.md
+++ b/docs/src/javascript/enums/MetricType.md
@@ -22,7 +22,7 @@ Cosine distance
 
 #### Defined in
 
-[index.ts:496](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L496)
+[index.ts:493](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L493)
 
 ___
 
@@ -34,7 +34,7 @@ Dot product
 
 #### Defined in
 
-[index.ts:501](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L501)
+[index.ts:498](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L498)
 
 ___
 
@@ -46,4 +46,4 @@ Euclidean distance
 
 #### Defined in
 
-[index.ts:491](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L491)
+[index.ts:488](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L488)

--- a/docs/src/javascript/enums/MetricType.md
+++ b/docs/src/javascript/enums/MetricType.md
@@ -22,7 +22,7 @@ Cosine distance
 
 #### Defined in
 
-[index.ts:494](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L494)
+[index.ts:496](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L496)
 
 ___
 
@@ -34,7 +34,7 @@ Dot product
 
 #### Defined in
 
-[index.ts:499](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L499)
+[index.ts:501](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L501)
 
 ___
 
@@ -46,4 +46,4 @@ Euclidean distance
 
 #### Defined in
 
-[index.ts:489](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L489)
+[index.ts:491](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L491)

--- a/docs/src/javascript/enums/WriteMode.md
+++ b/docs/src/javascript/enums/WriteMode.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[index.ts:481](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L481)
+[index.ts:478](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L478)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[index.ts:480](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L480)
+[index.ts:477](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L477)

--- a/docs/src/javascript/enums/WriteMode.md
+++ b/docs/src/javascript/enums/WriteMode.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[index.ts:450](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L450)
+[index.ts:479](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L479)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[index.ts:449](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L449)
+[index.ts:478](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L478)

--- a/docs/src/javascript/enums/WriteMode.md
+++ b/docs/src/javascript/enums/WriteMode.md
@@ -2,11 +2,14 @@
 
 # Enumeration: WriteMode
 
+Write mode for writing a table.
+
 ## Table of contents
 
 ### Enumeration Members
 
 - [Append](WriteMode.md#append)
+- [Create](WriteMode.md#create)
 - [Overwrite](WriteMode.md#overwrite)
 
 ## Enumeration Members
@@ -15,9 +18,23 @@
 
 • **Append** = ``"append"``
 
+Append new data to the table.
+
 #### Defined in
 
-[index.ts:478](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L478)
+[index.ts:466](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L466)
+
+___
+
+### Create
+
+• **Create** = ``"create"``
+
+Create a new [Table](../interfaces/Table.md).
+
+#### Defined in
+
+[index.ts:462](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L462)
 
 ___
 
@@ -25,6 +42,8 @@ ___
 
 • **Overwrite** = ``"overwrite"``
 
+Overwrite the existing [Table](../interfaces/Table.md) if presented.
+
 #### Defined in
 
-[index.ts:477](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L477)
+[index.ts:464](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L464)

--- a/docs/src/javascript/enums/WriteMode.md
+++ b/docs/src/javascript/enums/WriteMode.md
@@ -22,7 +22,7 @@ Append new data to the table.
 
 #### Defined in
 
-[index.ts:466](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L466)
+[index.ts:466](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L466)
 
 ___
 
@@ -34,7 +34,7 @@ Create a new [Table](../interfaces/Table.md).
 
 #### Defined in
 
-[index.ts:462](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L462)
+[index.ts:462](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L462)
 
 ___
 
@@ -46,4 +46,4 @@ Overwrite the existing [Table](../interfaces/Table.md) if presented.
 
 #### Defined in
 
-[index.ts:464](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L464)
+[index.ts:464](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L464)

--- a/docs/src/javascript/enums/WriteMode.md
+++ b/docs/src/javascript/enums/WriteMode.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[index.ts:479](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L479)
+[index.ts:481](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L481)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[index.ts:478](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L478)
+[index.ts:480](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L480)

--- a/docs/src/javascript/interfaces/Connection.md
+++ b/docs/src/javascript/interfaces/Connection.md
@@ -32,7 +32,7 @@ Connection could be local against filesystem or remote against a server.
 
 #### Defined in
 
-[index.ts:45](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L45)
+[index.ts:45](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L45)
 
 ## Methods
 
@@ -63,7 +63,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:65](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L65)
+[index.ts:65](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L65)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[index.ts:67](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L67)
+[index.ts:67](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L67)
 
 ___
 
@@ -106,7 +106,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:73](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L73)
+[index.ts:73](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L73)
 
 ___
 
@@ -135,7 +135,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:55](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L55)
+[index.ts:55](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L55)
 
 ___
 
@@ -149,4 +149,4 @@ ___
 
 #### Defined in
 
-[index.ts:47](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L47)
+[index.ts:47](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L47)

--- a/docs/src/javascript/interfaces/Connection.md
+++ b/docs/src/javascript/interfaces/Connection.md
@@ -32,7 +32,7 @@ Connection could be local against filesystem or remote against a server.
 
 #### Defined in
 
-[index.ts:45](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L45)
+[index.ts:45](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L45)
 
 ## Methods
 
@@ -55,7 +55,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:75](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L75)
+[index.ts:75](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L75)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -81,7 +81,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:82](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L82)
+[index.ts:83](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L83)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -107,7 +107,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:89](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L89)
+[index.ts:91](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L91)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[index.ts:94](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L94)
+[index.ts:93](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L93)
 
 ___
 
@@ -150,7 +150,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:100](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L100)
+[index.ts:99](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L99)
 
 ___
 
@@ -172,7 +172,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:56](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L56)
+[index.ts:54](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L54)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -197,7 +197,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:62](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L62)
+[index.ts:61](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L61)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -222,7 +222,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:68](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L68)
+[index.ts:68](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L68)
 
 ___
 
@@ -236,4 +236,4 @@ ___
 
 #### Defined in
 
-[index.ts:50](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L50)
+[index.ts:48](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L48)

--- a/docs/src/javascript/interfaces/Connection.md
+++ b/docs/src/javascript/interfaces/Connection.md
@@ -2,7 +2,7 @@
 
 # Interface: Connection
 
-A LanceDB connection that allows you to open tables and create new ones.
+A LanceDB Connection that allows you to open tables and create new ones.
 
 Connection could be local against filesystem or remote against a server.
 
@@ -32,32 +32,13 @@ Connection could be local against filesystem or remote against a server.
 
 #### Defined in
 
-[index.ts:45](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L45)
+[index.ts:45](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L45)
 
 ## Methods
 
 ### createTable
 
-▸ **createTable**(`name`, `data`): `Promise`<[`Table`](Table.md)<`number`[]\>\>
-
-Creates a new Table and initialize it with new data.
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `name` | `string` | The name of the table. |
-| `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
-
-#### Returns
-
-`Promise`<[`Table`](Table.md)<`number`[]\>\>
-
-#### Defined in
-
-[index.ts:74](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L74)
-
-▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
+▸ **createTable**<`T`\>(`name`, `data`, `mode?`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
 Creates a new Table and initialize it with new data.
 
@@ -72,8 +53,9 @@ Creates a new Table and initialize it with new data.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `name` | `string` | The name of the table. |
-| `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
-| `embeddings` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
+| `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the table |
+| `mode?` | [`WriteMode`](../enums/WriteMode.md) | The write mode to use when creating the table. |
+| `embeddings?` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this table |
 
 #### Returns
 
@@ -81,33 +63,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:82](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L82)
-
-▸ **createTable**<`T`\>(`name`, `data`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
-
-Creates a new Table and initialize it with new data.
-
-#### Type parameters
-
-| Name |
-| :------ |
-| `T` |
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `name` | `string` | The name of the table. |
-| `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
-| `embeddings?` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
-
-#### Returns
-
-`Promise`<[`Table`](Table.md)<`T`\>\>
-
-#### Defined in
-
-[index.ts:90](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L90)
+[index.ts:65](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L65)
 
 ___
 
@@ -128,7 +84,7 @@ ___
 
 #### Defined in
 
-[index.ts:92](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L92)
+[index.ts:67](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L67)
 
 ___
 
@@ -150,54 +106,11 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:98](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L98)
+[index.ts:73](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L73)
 
 ___
 
 ### openTable
-
-▸ **openTable**(`name`): `Promise`<[`Table`](Table.md)<`number`[]\>\>
-
-Open a table in the database.
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `name` | `string` | The name of the table. |
-
-#### Returns
-
-`Promise`<[`Table`](Table.md)<`number`[]\>\>
-
-#### Defined in
-
-[index.ts:53](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L53)
-
-▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
-
-Open a table in the database.
-
-#### Type parameters
-
-| Name |
-| :------ |
-| `T` |
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `name` | `string` | The name of the table. |
-| `embeddings` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
-
-#### Returns
-
-`Promise`<[`Table`](Table.md)<`T`\>\>
-
-#### Defined in
-
-[index.ts:60](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L60)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -214,7 +127,7 @@ Open a table in the database.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `name` | `string` | The name of the table. |
-| `embeddings?` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
+| `embeddings?` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this table |
 
 #### Returns
 
@@ -222,7 +135,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:67](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L67)
+[index.ts:55](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L55)
 
 ___
 
@@ -236,4 +149,4 @@ ___
 
 #### Defined in
 
-[index.ts:47](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L47)
+[index.ts:47](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L47)

--- a/docs/src/javascript/interfaces/Connection.md
+++ b/docs/src/javascript/interfaces/Connection.md
@@ -14,119 +14,17 @@ Connection could be local against filesystem or remote against a server.
 
 ### Properties
 
+- [uri](Connection.md#uri)
+
+### Methods
+
 - [createTable](Connection.md#createtable)
 - [createTableArrow](Connection.md#createtablearrow)
 - [dropTable](Connection.md#droptable)
 - [openTable](Connection.md#opentable)
 - [tableNames](Connection.md#tablenames)
-- [uri](Connection.md#uri)
 
 ## Properties
-
-### createTable
-
-• **createTable**: (`name`: `string`, `data`: `Record`<`string`, `unknown`\>[]) => `Promise`<[`Table`](Table.md)<`number`[]\>\> & <T\>(`name`: `string`, `data`: `Record`<`string`, `unknown`\>[], `embeddings`: [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\>) => `Promise`<[`Table`](Table.md)<`T`\>\> & <T\>(`name`: `string`, `data`: `Record`<`string`, `unknown`\>[], `embeddings?`: [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\>) => `Promise`<[`Table`](Table.md)<`T`\>\>
-
-Creates a new Table and initialize it with new data.
-
-**`Param`**
-
-The name of the table.
-
-**`Param`**
-
-Non-empty Array of Records to be inserted into the Table
-
-#### Defined in
-
-[index.ts:63](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L63)
-
-___
-
-### createTableArrow
-
-• **createTableArrow**: (`name`: `string`, `table`: `Table`<`any`\>) => `Promise`<[`Table`](Table.md)<`number`[]\>\>
-
-#### Type declaration
-
-▸ (`name`, `table`): `Promise`<[`Table`](Table.md)<`number`[]\>\>
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `name` | `string` |
-| `table` | `Table`<`any`\> |
-
-##### Returns
-
-`Promise`<[`Table`](Table.md)<`number`[]\>\>
-
-#### Defined in
-
-[index.ts:65](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L65)
-
-___
-
-### dropTable
-
-• **dropTable**: (`name`: `string`) => `Promise`<`void`\>
-
-#### Type declaration
-
-▸ (`name`): `Promise`<`void`\>
-
-Drop an existing table.
-
-##### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `name` | `string` | The name of the table to drop. |
-
-##### Returns
-
-`Promise`<`void`\>
-
-#### Defined in
-
-[index.ts:71](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L71)
-
-___
-
-### openTable
-
-• **openTable**: (`name`: `string`) => `Promise`<[`Table`](Table.md)<`number`[]\>\> & <T\>(`name`: `string`, `embeddings`: [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\>) => `Promise`<[`Table`](Table.md)<`T`\>\> & <T\>(`name`: `string`, `embeddings?`: [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\>) => `Promise`<[`Table`](Table.md)<`T`\>\>
-
-Open a table in the database.
-
-**`Param`**
-
-The name of the table.
-
-#### Defined in
-
-[index.ts:54](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L54)
-
-___
-
-### tableNames
-
-• **tableNames**: () => `Promise`<`string`[]\>
-
-#### Type declaration
-
-▸ (): `Promise`<`string`[]\>
-
-##### Returns
-
-`Promise`<`string`[]\>
-
-#### Defined in
-
-[index.ts:47](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L47)
-
-___
 
 ### uri
 
@@ -134,4 +32,208 @@ ___
 
 #### Defined in
 
-[index.ts:45](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L45)
+[index.ts:45](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L45)
+
+## Methods
+
+### createTable
+
+▸ **createTable**(`name`, `data`): `Promise`<[`Table`](Table.md)<`number`[]\>\>
+
+Creates a new Table and initialize it with new data.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+| `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
+
+#### Returns
+
+`Promise`<[`Table`](Table.md)<`number`[]\>\>
+
+#### Defined in
+
+[index.ts:75](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L75)
+
+▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
+
+Creates a new Table and initialize it with new data.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+| `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
+| `embeddings` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
+
+#### Returns
+
+`Promise`<[`Table`](Table.md)<`T`\>\>
+
+#### Defined in
+
+[index.ts:82](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L82)
+
+▸ **createTable**<`T`\>(`name`, `data`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
+
+Creates a new Table and initialize it with new data.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+| `data` | `Record`<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the Table |
+| `embeddings?` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
+
+#### Returns
+
+`Promise`<[`Table`](Table.md)<`T`\>\>
+
+#### Defined in
+
+[index.ts:89](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L89)
+
+___
+
+### createTableArrow
+
+▸ **createTableArrow**(`name`, `table`): `Promise`<[`Table`](Table.md)<`number`[]\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+| `table` | `Table`<`any`\> |
+
+#### Returns
+
+`Promise`<[`Table`](Table.md)<`number`[]\>\>
+
+#### Defined in
+
+[index.ts:94](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L94)
+
+___
+
+### dropTable
+
+▸ **dropTable**(`name`): `Promise`<`void`\>
+
+Drop an existing table.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table to drop. |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[index.ts:100](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L100)
+
+___
+
+### openTable
+
+▸ **openTable**(`name`): `Promise`<[`Table`](Table.md)<`number`[]\>\>
+
+Open a table in the database.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+
+#### Returns
+
+`Promise`<[`Table`](Table.md)<`number`[]\>\>
+
+#### Defined in
+
+[index.ts:56](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L56)
+
+▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
+
+Open a table in the database.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+| `embeddings` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
+
+#### Returns
+
+`Promise`<[`Table`](Table.md)<`T`\>\>
+
+#### Defined in
+
+[index.ts:62](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L62)
+
+▸ **openTable**<`T`\>(`name`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
+
+Open a table in the database.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+| `embeddings?` | [`EmbeddingFunction`](EmbeddingFunction.md)<`T`\> | An embedding function to use on this Table |
+
+#### Returns
+
+`Promise`<[`Table`](Table.md)<`T`\>\>
+
+#### Defined in
+
+[index.ts:68](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L68)
+
+___
+
+### tableNames
+
+▸ **tableNames**(): `Promise`<`string`[]\>
+
+#### Returns
+
+`Promise`<`string`[]\>
+
+#### Defined in
+
+[index.ts:50](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L50)

--- a/docs/src/javascript/interfaces/Connection.md
+++ b/docs/src/javascript/interfaces/Connection.md
@@ -32,7 +32,7 @@ Connection could be local against filesystem or remote against a server.
 
 #### Defined in
 
-[index.ts:45](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L45)
+[index.ts:45](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L45)
 
 ## Methods
 
@@ -55,7 +55,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:75](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L75)
+[index.ts:74](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L74)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -81,7 +81,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:83](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L83)
+[index.ts:82](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L82)
 
 ▸ **createTable**<`T`\>(`name`, `data`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -107,7 +107,7 @@ Creates a new Table and initialize it with new data.
 
 #### Defined in
 
-[index.ts:91](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L91)
+[index.ts:90](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L90)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[index.ts:93](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L93)
+[index.ts:92](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L92)
 
 ___
 
@@ -150,7 +150,7 @@ Drop an existing table.
 
 #### Defined in
 
-[index.ts:99](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L99)
+[index.ts:98](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L98)
 
 ___
 
@@ -172,7 +172,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:54](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L54)
+[index.ts:53](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L53)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -197,7 +197,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:61](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L61)
+[index.ts:60](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L60)
 
 ▸ **openTable**<`T`\>(`name`, `embeddings?`): `Promise`<[`Table`](Table.md)<`T`\>\>
 
@@ -222,7 +222,7 @@ Open a table in the database.
 
 #### Defined in
 
-[index.ts:68](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L68)
+[index.ts:67](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L67)
 
 ___
 
@@ -236,4 +236,4 @@ ___
 
 #### Defined in
 
-[index.ts:48](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L48)
+[index.ts:47](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L47)

--- a/docs/src/javascript/interfaces/EmbeddingFunction.md
+++ b/docs/src/javascript/interfaces/EmbeddingFunction.md
@@ -45,7 +45,7 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/embedding/embedding_function.ts#L27)
+[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/embedding_function.ts#L27)
 
 ___
 
@@ -57,4 +57,4 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/embedding/embedding_function.ts#L22)
+[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/embedding_function.ts#L22)

--- a/docs/src/javascript/interfaces/EmbeddingFunction.md
+++ b/docs/src/javascript/interfaces/EmbeddingFunction.md
@@ -45,7 +45,7 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/embedding_function.ts#L27)
+[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/7247834/node/src/embedding/embedding_function.ts#L27)
 
 ___
 
@@ -57,4 +57,4 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/embedding_function.ts#L22)
+[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/7247834/node/src/embedding/embedding_function.ts#L22)

--- a/docs/src/javascript/interfaces/EmbeddingFunction.md
+++ b/docs/src/javascript/interfaces/EmbeddingFunction.md
@@ -45,7 +45,7 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/embedding_function.ts#L27)
+[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/embedding_function.ts#L27)
 
 ___
 
@@ -57,4 +57,4 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/embedding/embedding_function.ts#L22)
+[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/embedding_function.ts#L22)

--- a/docs/src/javascript/interfaces/EmbeddingFunction.md
+++ b/docs/src/javascript/interfaces/EmbeddingFunction.md
@@ -45,7 +45,7 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/embedding_function.ts#L27)
+[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/embedding_function.ts#L27)
 
 ___
 
@@ -57,4 +57,4 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/0162b16/node/src/embedding/embedding_function.ts#L22)
+[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/embedding_function.ts#L22)

--- a/docs/src/javascript/interfaces/EmbeddingFunction.md
+++ b/docs/src/javascript/interfaces/EmbeddingFunction.md
@@ -45,7 +45,7 @@ Creates a vector representation for the given values.
 
 #### Defined in
 
-[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/embedding_function.ts#L27)
+[embedding/embedding_function.ts:27](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/embedding_function.ts#L27)
 
 ___
 
@@ -57,4 +57,4 @@ The name of the column that will be used as input for the Embedding Function.
 
 #### Defined in
 
-[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/20281c7/node/src/embedding/embedding_function.ts#L22)
+[embedding/embedding_function.ts:22](https://github.com/lancedb/lancedb/blob/97101eb/node/src/embedding/embedding_function.ts#L22)

--- a/docs/src/javascript/interfaces/Table.md
+++ b/docs/src/javascript/interfaces/Table.md
@@ -52,7 +52,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:95](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L95)
+[index.ts:95](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L95)
 
 ___
 
@@ -72,7 +72,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:115](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L115)
+[index.ts:115](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L115)
 
 ___
 
@@ -102,7 +102,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:110](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L110)
+[index.ts:110](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L110)
 
 ___
 
@@ -128,7 +128,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:122](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L122)
+[index.ts:122](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L122)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[index.ts:81](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L81)
+[index.ts:81](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L81)
 
 ___
 
@@ -166,7 +166,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:103](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L103)
+[index.ts:103](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L103)
 
 ___
 
@@ -192,4 +192,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:87](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L87)
+[index.ts:87](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L87)

--- a/docs/src/javascript/interfaces/Table.md
+++ b/docs/src/javascript/interfaces/Table.md
@@ -52,7 +52,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:121](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L121)
+[index.ts:123](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L123)
 
 ___
 
@@ -72,7 +72,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:141](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L141)
+[index.ts:143](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L143)
 
 ___
 
@@ -102,7 +102,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:136](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L136)
+[index.ts:138](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L138)
 
 ___
 
@@ -128,7 +128,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:148](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L148)
+[index.ts:150](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L150)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[index.ts:107](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L107)
+[index.ts:109](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L109)
 
 ___
 
@@ -166,7 +166,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:129](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L129)
+[index.ts:131](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L131)
 
 ___
 
@@ -192,4 +192,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:113](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L113)
+[index.ts:115](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L115)

--- a/docs/src/javascript/interfaces/Table.md
+++ b/docs/src/javascript/interfaces/Table.md
@@ -2,7 +2,7 @@
 
 # Interface: Table<T\>
 
-A LanceDB table that allows you to search and update a table.
+A LanceDB Table is the collection of Records. Each Record has one or more vector fields.
 
 ## Type parameters
 
@@ -52,7 +52,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:120](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L120)
+[index.ts:95](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L95)
 
 ___
 
@@ -72,7 +72,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:140](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L140)
+[index.ts:115](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L115)
 
 ___
 
@@ -102,7 +102,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:135](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L135)
+[index.ts:110](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L110)
 
 ___
 
@@ -128,7 +128,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:147](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L147)
+[index.ts:122](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L122)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[index.ts:106](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L106)
+[index.ts:81](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L81)
 
 ___
 
@@ -166,7 +166,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:128](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L128)
+[index.ts:103](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L103)
 
 ___
 
@@ -192,4 +192,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:112](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L112)
+[index.ts:87](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L87)

--- a/docs/src/javascript/interfaces/Table.md
+++ b/docs/src/javascript/interfaces/Table.md
@@ -52,7 +52,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:123](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L123)
+[index.ts:120](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L120)
 
 ___
 
@@ -72,7 +72,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:143](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L143)
+[index.ts:140](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L140)
 
 ___
 
@@ -102,7 +102,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:138](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L138)
+[index.ts:135](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L135)
 
 ___
 
@@ -128,7 +128,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:150](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L150)
+[index.ts:147](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L147)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[index.ts:109](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L109)
+[index.ts:106](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L106)
 
 ___
 
@@ -166,7 +166,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:131](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L131)
+[index.ts:128](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L128)
 
 ___
 
@@ -192,4 +192,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:115](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L115)
+[index.ts:112](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L112)

--- a/docs/src/javascript/interfaces/Table.md
+++ b/docs/src/javascript/interfaces/Table.md
@@ -52,7 +52,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:92](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L92)
+[index.ts:121](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L121)
 
 ___
 
@@ -72,7 +72,7 @@ Returns the number of rows in this table.
 
 #### Defined in
 
-[index.ts:112](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L112)
+[index.ts:141](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L141)
 
 ___
 
@@ -102,7 +102,7 @@ VectorIndexParams.
 
 #### Defined in
 
-[index.ts:107](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L107)
+[index.ts:136](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L136)
 
 ___
 
@@ -128,7 +128,7 @@ Delete rows from this table.
 
 #### Defined in
 
-[index.ts:119](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L119)
+[index.ts:148](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L148)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[index.ts:78](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L78)
+[index.ts:107](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L107)
 
 ___
 
@@ -166,7 +166,7 @@ The number of rows added to the table
 
 #### Defined in
 
-[index.ts:100](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L100)
+[index.ts:129](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L129)
 
 ___
 
@@ -192,4 +192,4 @@ Creates a search query to find the nearest neighbors of the given search term
 
 #### Defined in
 
-[index.ts:84](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L84)
+[index.ts:113](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L113)

--- a/docs/src/javascript/modules.md
+++ b/docs/src/javascript/modules.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[index.ts:336](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L336)
+[index.ts:365](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L365)
 
 ## Functions
 
@@ -60,4 +60,4 @@ Connect to a LanceDB instance at the given URI
 
 #### Defined in
 
-[index.ts:34](https://github.com/lancedb/lancedb/blob/bfb5400/node/src/index.ts#L34)
+[index.ts:34](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L34)

--- a/docs/src/javascript/modules.md
+++ b/docs/src/javascript/modules.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[index.ts:345](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L345)
+[index.ts:345](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L345)
 
 ## Functions
 
@@ -60,4 +60,4 @@ Connect to a LanceDB instance at the given URI
 
 #### Defined in
 
-[index.ts:34](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L34)
+[index.ts:34](https://github.com/lancedb/lancedb/blob/7247834/node/src/index.ts#L34)

--- a/docs/src/javascript/modules.md
+++ b/docs/src/javascript/modules.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[index.ts:367](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L367)
+[index.ts:364](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L364)
 
 ## Functions
 
@@ -60,4 +60,4 @@ Connect to a LanceDB instance at the given URI
 
 #### Defined in
 
-[index.ts:34](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L34)
+[index.ts:34](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L34)

--- a/docs/src/javascript/modules.md
+++ b/docs/src/javascript/modules.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[index.ts:364](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L364)
+[index.ts:345](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L345)
 
 ## Functions
 
@@ -60,4 +60,4 @@ Connect to a LanceDB instance at the given URI
 
 #### Defined in
 
-[index.ts:34](https://github.com/lancedb/lancedb/blob/20281c7/node/src/index.ts#L34)
+[index.ts:34](https://github.com/lancedb/lancedb/blob/97101eb/node/src/index.ts#L34)

--- a/docs/src/javascript/modules.md
+++ b/docs/src/javascript/modules.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[index.ts:365](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L365)
+[index.ts:367](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L367)
 
 ## Functions
 
@@ -60,4 +60,4 @@ Connect to a LanceDB instance at the given URI
 
 #### Defined in
 
-[index.ts:34](https://github.com/lancedb/lancedb/blob/a6bdffd/node/src/index.ts#L34)
+[index.ts:34](https://github.com/lancedb/lancedb/blob/0162b16/node/src/index.ts#L34)

--- a/node/.eslintrc.js
+++ b/node/.eslintrc.js
@@ -12,5 +12,6 @@ module.exports = {
     sourceType: 'module'
   },
   rules: {
+    "@typescript-eslint/method-signature-style": "off",
   }
 }

--- a/node/README.md
+++ b/node/README.md
@@ -15,7 +15,9 @@ npm install vectordb
 ```javascript
 const lancedb = require('vectordb');
 const db = lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
-const table = await db.openTable('my_table');
+const table = await db.createTable("my_table",
+      [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },
+      { id: 2, vector: [3.9, 0.5], item: "bar", price: 20.0 }])
 const results = await table.search([0.1, 0.3]).limit(20).execute();
 console.log(results);
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -14,7 +14,7 @@ npm install vectordb
 
 ```javascript
 const lancedb = require('vectordb');
-const db = await lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
+const db = await lancedb.connect('data/sample-lancedb');
 const table = await db.createTable("my_table",
       [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },
       { id: 2, vector: [3.9, 0.5], item: "bar", price: 20.0 }])

--- a/node/README.md
+++ b/node/README.md
@@ -14,7 +14,7 @@ npm install vectordb
 
 ```javascript
 const lancedb = require('vectordb');
-const db = lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
+const db = await lancedb.connect('<PATH_TO_LANCEDB_DATASET>');
 const table = await db.createTable("my_table",
       [{ id: 1, vector: [0.1, 1.0], item: "foo", price: 10.0 },
       { id: 2, vector: [3.9, 0.5], item: "bar", price: 20.0 }])

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -50,46 +50,27 @@ export interface Connection {
    * Open a table in the database.
    *
    * @param name The name of the table.
+   * @param embeddings An embedding function to use on this table
    */
-  openTable(name: string): Promise<Table>
-
-  /**
-   * Open a table in the database.
-   *
-   * @param name The name of the table.
-   * @param embeddings An embedding function to use on this Table
-   */
-  openTable<T>(name: string, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
   openTable<T>(name: string, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
 
   /**
    * Creates a new Table and initialize it with new data.
    *
    * @param {string} name - The name of the table.
-   * @param data - Non-empty Array of Records to be inserted into the Table
-   * @param {WriteMode} - The write mode to use when creating the table.
+   * @param data - Non-empty Array of Records to be inserted into the table
+   * @param {WriteMode} mode - The write mode to use when creating the table.
+   * @param {EmbeddingFunction} embeddings - An embedding function to use on this table
    */
-  createTable(name: string, data: Array<Record<string, unknown>>, mode?: WriteMode): Promise<Table>
-  createTable(name: string, data: Array<Record<string, unknown>>, mode: WriteMode): Promise<Table>
+  createTable<T>(name: string, data: Array<Record<string, unknown>>, mode?: WriteMode, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
 
-  /**
-   * Creates a new Table and initialize it with new data.
-   *
-   * @param {string} name - The name of the table.
-   * @param data - Non-empty Array of Records to be inserted into the Table
-   * @param {WriteMode} - The write mode to use when creating the table.
-   * @param embeddings - An embedding function to use on this Table
-   */
-  createTable<T>(name: string, data: Array<Record<string, unknown>>, mode: WriteMode, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
-  createTable<T>(name: string, data: Array<Record<string, unknown>>, mode: WriteMode, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
-
-  createTableArrow: (name: string, table: ArrowTable) => Promise<Table>
+  createTableArrow(name: string, table: ArrowTable): Promise<Table>
 
   /**
    * Drop an existing table.
    * @param name The name of the table to drop.
    */
-  dropTable: (name: string) => Promise<void>
+  dropTable(name: string): Promise<void>
 
 }
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -44,31 +44,60 @@ export async function connect (uri: string): Promise<Connection> {
 export interface Connection {
   uri: string
 
-  tableNames: () => Promise<string[]>
+  /**
+   *
+   */
+  tableNames(): Promise<string[]>
 
   /**
    * Open a table in the database.
-   *
    * @param name The name of the table.
    */
-  openTable: ((name: string) => Promise<Table>) & (<T>(name: string, embeddings: EmbeddingFunction<T>) => Promise<Table<T>>) & (<T>(name: string, embeddings?: EmbeddingFunction<T>) => Promise<Table<T>>)
+  openTable(name: string): Promise<Table>
+  /**
+   * Open a table in the database.
+   * @param name The name of the table.
+   * @param embeddings An embedding function to use on this Table
+   */
+  openTable<T>(name: string, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
+  /**
+   * Open a table in the database.
+   * @param name The name of the table.
+   * @param embeddings An embedding function to use on this Table
+   */
+  openTable<T>(name: string, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
 
   /**
    * Creates a new Table and initialize it with new data.
-   *
    * @param name The name of the table.
    * @param data Non-empty Array of Records to be inserted into the Table
    */
+  createTable(name: string, data: Array<Record<string, unknown>>): Promise<Table>
+  /**
+   * Creates a new Table and initialize it with new data.
+   * @param name The name of the table.
+   * @param data Non-empty Array of Records to be inserted into the Table
+   * @param embeddings An embedding function to use on this Table
+  */
+  createTable<T>(name: string, data: Array<Record<string, unknown>>, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
+  /**
+   * Creates a new Table and initialize it with new data.
+   * @param name The name of the table.
+   * @param data Non-empty Array of Records to be inserted into the Table
+   * @param embeddings An embedding function to use on this Table
+  */
+  createTable<T>(name: string, data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
 
-  createTable: ((name: string, data: Array<Record<string, unknown>>) => Promise<Table>) & (<T>(name: string, data: Array<Record<string, unknown>>, embeddings: EmbeddingFunction<T>) => Promise<Table<T>>) & (<T>(name: string, data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>) => Promise<Table<T>>)
-
-  createTableArrow: (name: string, table: ArrowTable) => Promise<Table>
+  /**
+   *
+   */
+  createTableArrow(name: string, table: ArrowTable): Promise<Table>
 
   /**
    * Drop an existing table.
    * @param name The name of the table to drop.
    */
-  dropTable: (name: string) => Promise<void>
+  dropTable(name: string): Promise<void>
 }
 
 /**

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -44,9 +44,7 @@ export async function connect (uri: string): Promise<Connection> {
 export interface Connection {
   uri: string
 
-  /**
-   *
-   */
+  /* eslint-disable @typescript-eslint/method-signature-style */
   tableNames(): Promise<string[]>
 
   /**
@@ -54,12 +52,14 @@ export interface Connection {
    * @param name The name of the table.
    */
   openTable(name: string): Promise<Table>
+
   /**
    * Open a table in the database.
    * @param name The name of the table.
    * @param embeddings An embedding function to use on this Table
    */
   openTable<T>(name: string, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
+
   /**
    * Open a table in the database.
    * @param name The name of the table.
@@ -73,6 +73,7 @@ export interface Connection {
    * @param data Non-empty Array of Records to be inserted into the Table
    */
   createTable(name: string, data: Array<Record<string, unknown>>): Promise<Table>
+
   /**
    * Creates a new Table and initialize it with new data.
    * @param name The name of the table.
@@ -80,6 +81,7 @@ export interface Connection {
    * @param embeddings An embedding function to use on this Table
   */
   createTable<T>(name: string, data: Array<Record<string, unknown>>, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
+
   /**
    * Creates a new Table and initialize it with new data.
    * @param name The name of the table.
@@ -88,9 +90,6 @@ export interface Connection {
   */
   createTable<T>(name: string, data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
 
-  /**
-   *
-   */
   createTableArrow(name: string, table: ArrowTable): Promise<Table>
 
   /**
@@ -98,6 +97,9 @@ export interface Connection {
    * @param name The name of the table to drop.
    */
   dropTable(name: string): Promise<void>
+
+  /* eslint-enable @typescript-eslint/method-signature-style */
+
 }
 
 /**

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -44,7 +44,6 @@ export async function connect (uri: string): Promise<Connection> {
 export interface Connection {
   uri: string
 
-  /* eslint-disable @typescript-eslint/method-signature-style */
   tableNames(): Promise<string[]>
 
   /**
@@ -97,8 +96,6 @@ export interface Connection {
    * @param name The name of the table to drop.
    */
   dropTable(name: string): Promise<void>
-
-  /* eslint-enable @typescript-eslint/method-signature-style */
 
 }
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -48,54 +48,48 @@ export interface Connection {
 
   /**
    * Open a table in the database.
+   *
    * @param name The name of the table.
    */
   openTable(name: string): Promise<Table>
 
   /**
    * Open a table in the database.
+   *
    * @param name The name of the table.
    * @param embeddings An embedding function to use on this Table
    */
   openTable<T>(name: string, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
-
-  /**
-   * Open a table in the database.
-   * @param name The name of the table.
-   * @param embeddings An embedding function to use on this Table
-   */
   openTable<T>(name: string, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
 
   /**
    * Creates a new Table and initialize it with new data.
-   * @param name The name of the table.
-   * @param data Non-empty Array of Records to be inserted into the Table
+   *
+   * @param {string} name - The name of the table.
+   * @param data - Non-empty Array of Records to be inserted into the Table
+   * @param {WriteMode} - The write mode to use when creating the table.
    */
-  createTable(name: string, data: Array<Record<string, unknown>>): Promise<Table>
+  createTable(name: string, data: Array<Record<string, unknown>>, mode?: WriteMode): Promise<Table>
+  createTable(name: string, data: Array<Record<string, unknown>>, mode: WriteMode): Promise<Table>
 
   /**
    * Creates a new Table and initialize it with new data.
-   * @param name The name of the table.
-   * @param data Non-empty Array of Records to be inserted into the Table
-   * @param embeddings An embedding function to use on this Table
-  */
-  createTable<T>(name: string, data: Array<Record<string, unknown>>, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
+   *
+   * @param {string} name - The name of the table.
+   * @param data - Non-empty Array of Records to be inserted into the Table
+   * @param {WriteMode} - The write mode to use when creating the table.
+   * @param embeddings - An embedding function to use on this Table
+   */
+  createTable<T>(name: string, data: Array<Record<string, unknown>>, mode: WriteMode, embeddings: EmbeddingFunction<T>): Promise<Table<T>>
+  createTable<T>(name: string, data: Array<Record<string, unknown>>, mode: WriteMode, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
 
-  /**
-   * Creates a new Table and initialize it with new data.
-   * @param name The name of the table.
-   * @param data Non-empty Array of Records to be inserted into the Table
-   * @param embeddings An embedding function to use on this Table
-  */
-  createTable<T>(name: string, data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>): Promise<Table<T>>
-
-  createTableArrow(name: string, table: ArrowTable): Promise<Table>
+  createTableArrow: (name: string, table: ArrowTable) => Promise<Table>
 
   /**
    * Drop an existing table.
    * @param name The name of the table to drop.
    */
-  dropTable(name: string): Promise<void>
+  dropTable: (name: string) => Promise<void>
 
 }
 


### PR DESCRIPTION
Solves #244 :

![image](https://github.com/lancedb/lancedb/assets/43097991/d1fd9d2a-0d6a-4c16-a0ab-f460cc709349)

Problem was function overloading in the interface caused some weird `typedoc` formatting, so breaking it apart into methods fixed the issue.

Also regenerated and updated javascript docs 