### PR TITLE
Changhiskhan/nan handling ts

### DIFF
--- a/node/src/arrow.ts
+++ b/node/src/arrow.ts
@@ -15,48 +15,48 @@
 import {
   Field,
   Float32,
-  List, type ListBuilder,
+  List,
+  type ListBuilder,
   makeBuilder,
   RecordBatchFileWriter,
-  Table, Utf8,
+  Table,
+  Utf8,
   type Vector,
   vectorFromArray
 } from 'apache-arrow'
 import { type EmbeddingFunction } from './index'
+import { OnBadVectors, type Result } from './common'
 
-export async function convertToTable<T> (data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>): Promise<Table> {
+export async function convertToTable<T> (
+  data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>,
+  onBadVectors: OnBadVectors = OnBadVectors.DROP,
+  fillValue: number = 0.0): Promise<Table> {
   if (data.length === 0) {
     throw new Error('At least one record needs to be provided')
   }
 
-  const columns = Object.keys(data[0])
-  const records: Record<string, Vector> = {}
+  await embed(data, embeddings)
 
+  // sanitize the data, ensuring the vectors are all the same size and don't contain nulls or undefined
+  const rs = _sanitizeVector(data, 'vector', onBadVectors, fillValue)
+  if (!rs.ok) {
+    throw rs.error
+  } else {
+    data = rs.value
+  }
+
+  const columns = new Set<string>()
+  data.forEach(d => { Object.keys(d).forEach(k => columns.add(k)) })
+  const records: Record<string, Vector> = {}
   for (const columnsKey of columns) {
     if (columnsKey === 'vector') {
       const listBuilder = newVectorListBuilder()
-      const vectorSize = (data[0].vector as any[]).length
       for (const datum of data) {
-        if ((datum[columnsKey] as any[]).length !== vectorSize) {
-          throw new Error(`Invalid vector size, expected ${vectorSize}`)
-        }
-
         listBuilder.append(datum[columnsKey])
       }
       records[columnsKey] = listBuilder.finish().toVector()
     } else {
-      const values = []
-      for (const datum of data) {
-        values.push(datum[columnsKey])
-      }
-
-      if (columnsKey === embeddings?.sourceColumn) {
-        const vectors = await embeddings.embed(values as T[])
-        const listBuilder = newVectorListBuilder()
-        vectors.map(v => listBuilder.append(v))
-        records.vector = listBuilder.finish().toVector()
-      }
-
+      const values = data.map(d => d[columnsKey])
       if (typeof values[0] === 'string') {
         // `vectorFromArray` converts strings into dictionary vectors, forcing it back to a string column
         records[columnsKey] = vectorFromArray(values, new Utf8())
@@ -69,6 +69,67 @@ export async function convertToTable<T> (data: Array<Record<string, unknown>>, e
   return new Table(records)
 }
 
+async function embed<T> (data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>): Promise<void> {
+  // create embeddings if needed
+  if (embeddings !== undefined) {
+    const values: T[] = data.map(d => d[embeddings.sourceColumn] as T)
+    const vectors = await embeddings.embed(values)
+    if (vectors.length !== data.length) {
+      throw new Error('Embedding function returned wrong number of vectors')
+    }
+    data.forEach((d, i) => {
+      d.vector = vectors[i]
+    })
+  }
+}
+
+function _sanitizeVector<T extends number> (
+  data: Array<Record<string, unknown>>,
+  vectorColumnName: string,
+  onBadVectors: OnBadVectors,
+  fillValue?: T): Result<Array<Record<string, unknown>>, Error> {
+  const lengths = data.map(d => (d[vectorColumnName] as number[]).length)
+  const maxNdims = lengths.reduce((a, b) => Math.max(a, b))
+
+  if (onBadVectors === OnBadVectors.ERROR) {
+    for (const rec of data) {
+      const vec = rec[vectorColumnName] as any[]
+      if (vec.length !== maxNdims) {
+        return { ok: false, error: new Error(`Invalid vector size, expected ${maxNdims}`) }
+      }
+      if (vec.findIndex(v => v === null || v === undefined) >= 0) {
+        return { ok: false, error: new Error('Vector contains null') }
+      }
+    }
+    return { ok: true, value: data }
+  } else if (onBadVectors === OnBadVectors.DROP) {
+    return { ok: true, value: data.filter(d => isVectorValid(d[vectorColumnName] as any[], maxNdims)) }
+  } else if (onBadVectors === OnBadVectors.FILL) {
+    if (fillValue === undefined) {
+      throw new TypeError('If onBadVectors is FILL, fillValue must be provided')
+    }
+    return { ok: true, value: data.map(d => fillVector(d, vectorColumnName, maxNdims, fillValue)) }
+  } else {
+    throw new Error('Invalid value for onBadVector')
+  }
+}
+
+function isVectorValid (vec: any[], maxNdims: number): boolean {
+  return vec.length === maxNdims && vec.findIndex(v => v === null || v === undefined) < 0
+}
+
+// Fill vectors that have nulls or
+function fillVector (rec: Record<string, unknown>, vectorColumnName: string,
+  maxNdims: number, fillValue: number): Record<string, unknown> {
+  let vec = rec[vectorColumnName] as any[]
+  vec = vec.map(v => (v === null || v === undefined) ? fillValue : v)
+  if (vec.length < maxNdims) {
+    vec = vec.concat(Array(maxNdims - vec.length).fill(fillValue))
+  }
+  rec[vectorColumnName] = vec
+  return rec
+}
+
 // Creates a new Arrow ListBuilder that stores a Vector column
 function newVectorListBuilder (): ListBuilder<Float32, any> {
   const children = new Field<Float32>('item', new Float32())
@@ -78,8 +139,11 @@ function newVectorListBuilder (): ListBuilder<Float32, any> {
   })
 }
 
-export async function fromRecordsToBuffer<T> (data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>): Promise<Buffer> {
-  const table = await convertToTable(data, embeddings)
+export async function fromRecordsToBuffer<T> (
+  data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>,
+  onBadVectors: OnBadVectors = OnBadVectors.DROP,
+  fillValue: number = 0.0): Promise<Buffer> {
+  const table = await convertToTable(data, embeddings, onBadVectors, fillValue)
   const writer = RecordBatchFileWriter.writeAll(table)
   return Buffer.from(await writer.toUint8Array())
 }

--- a/node/src/arrow.ts
+++ b/node/src/arrow.ts
@@ -29,7 +29,7 @@ import { OnBadVectors, type Result } from './common'
 
 export async function convertToTable<T> (
   data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>,
-  onBadVectors: OnBadVectors = OnBadVectors.DROP,
+  onBadVectors: OnBadVectors = OnBadVectors.ERROR,
   fillValue: number = 0.0): Promise<Table> {
   if (data.length === 0) {
     throw new Error('At least one record needs to be provided')
@@ -141,7 +141,7 @@ function newVectorListBuilder (): ListBuilder<Float32, any> {
 
 export async function fromRecordsToBuffer<T> (
   data: Array<Record<string, unknown>>, embeddings?: EmbeddingFunction<T>,
-  onBadVectors: OnBadVectors = OnBadVectors.DROP,
+  onBadVectors: OnBadVectors = OnBadVectors.ERROR,
   fillValue: number = 0.0): Promise<Buffer> {
   const table = await convertToTable(data, embeddings, onBadVectors, fillValue)
   const writer = RecordBatchFileWriter.writeAll(table)

--- a/node/src/common.ts
+++ b/node/src/common.ts
@@ -1,0 +1,10 @@
+
+export enum OnBadVectors {
+  DROP = 1,
+  ERROR = 2,
+  FILL = 3,
+}
+
+export type Result<T, E = Error> =
+  | { ok: true, value: T }
+  | { ok: false, error: E }

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -254,7 +254,7 @@ export class LocalTable<T = number[]> implements Table<T> {
    * @return The number of rows added to the table
    */
   async add (data: Array<Record<string, unknown>>,
-    onBadVectors: OnBadVectors = OnBadVectors.DROP,
+    onBadVectors: OnBadVectors = OnBadVectors.ERROR,
     fillValue: number = 0.0): Promise<number> {
     const tblData = await fromRecordsToBuffer(data, this._embeddings, onBadVectors, fillValue)
     return tableAdd.call(this._tbl, tblData, WriteMode.Append.toString())
@@ -269,7 +269,7 @@ export class LocalTable<T = number[]> implements Table<T> {
    * @return The number of rows added to the table
    */
   async overwrite (data: Array<Record<string, unknown>>,
-    onBadVectors: OnBadVectors = OnBadVectors.DROP,
+    onBadVectors: OnBadVectors = OnBadVectors.ERROR,
     fillValue: number = 0.0): Promise<number> {
     const tblData = await fromRecordsToBuffer(data, this._embeddings, onBadVectors, fillValue)
     return tableAdd.call(this._tbl, tblData, WriteMode.Overwrite.toString())

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -20,7 +20,7 @@ import {
 } from 'apache-arrow'
 import { fromRecordsToBuffer } from './arrow'
 import type { EmbeddingFunction } from './embedding/embedding_function'
-import {OnBadVectors} from "./common";
+import { OnBadVectors } from './common'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { databaseNew, databaseTableNames, databaseOpenTable, databaseDropTable, tableCreate, tableSearch, tableAdd, tableCreateVectorIndex, tableCountRows, tableDelete } = require('../native.js')


### PR DESCRIPTION
I haven't changed the interface so currently it defaults to dropping rows that don't have the right number of dimensions or with NaNs.

i think this at least will prevent the langchain integration from failing when openai errors out.

- [ ] needs additional unit tests
- [ ] i don't know what's the right way to expose these options without declaring a bazillion new interface variants tho