### PR TITLE
[Rust] Re-export WriteMode from lancedb instead of lance

### DIFF
--- a/rust/ffi/node/src/lib.rs
+++ b/rust/ffi/node/src/lib.rs
@@ -239,7 +239,7 @@ fn table_create(mut cx: FunctionContext) -> JsResult<JsPromise> {
         "overwrite" => WriteMode::Overwrite,
         "append" => WriteMode::Append,
         "create" => WriteMode::Create,
-        _ => return cx.throw_error("Table::create only supports 'overwrite' and 'create' modes")
+        _ => return cx.throw_error("Table::create only supports 'overwrite' and 'create' modes"),
     };
     let mut params = WriteParams::default();
     params.mode = mode;
@@ -255,7 +255,9 @@ fn table_create(mut cx: FunctionContext) -> JsResult<JsPromise> {
             batches.into_iter().map(Ok),
             schema,
         ));
-        let table_rst = database.create_table(&table_name, batch_reader, Some(params)).await;
+        let table_rst = database
+            .create_table(&table_name, batch_reader, Some(params))
+            .await;
 
         deferred.settle_with(&channel, move |mut cx| {
             let table = Arc::new(Mutex::new(

--- a/rust/vectordb/src/lib.rs
+++ b/rust/vectordb/src/lib.rs
@@ -19,3 +19,6 @@ pub mod query;
 pub mod table;
 
 pub use database::Database;
+pub use table::Table;
+
+pub use lance::dataset::WriteMode;


### PR DESCRIPTION
`Table::add(.., mode: WriteMode)`, which is a public API, currently uses the WriteMode exported from `lance`. Re-export it to lancedb so that the pub API looks better.