### PR TITLE
[python] Fix a few minor bugs

### DIFF
--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -356,18 +356,15 @@ class LanceDBConnection(DBConnection):
         if mode.lower() not in ["create", "overwrite"]:
             raise ValueError("mode must be either 'create' or 'overwrite'")
 
-        if data is not None:
-            tbl = LanceTable.create(
-                self,
-                name,
-                data,
-                schema,
-                mode=mode,
-                on_bad_vectors=on_bad_vectors,
-                fill_value=fill_value,
-            )
-        else:
-            tbl = LanceTable.open(self, name)
+        tbl = LanceTable.create(
+            self,
+            name,
+            data,
+            schema,
+            mode=mode,
+            on_bad_vectors=on_bad_vectors,
+            fill_value=fill_value,
+        )
         return tbl
 
     def open_table(self, name: str) -> LanceTable:

--- a/python/lancedb/pydantic.py
+++ b/python/lancedb/pydantic.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import inspect
 import sys
 import types
-from abc import ABC, abstractstaticmethod
+from abc import ABC, abstractmethod
 from typing import Any, List, Type, Union, _GenericAlias
 
 import pyarrow as pa
@@ -27,11 +27,13 @@ from pydantic_core import CoreSchema, core_schema
 
 
 class FixedSizeListMixin(ABC):
-    @abstractstaticmethod
+    @staticmethod
+    @abstractmethod
     def dim() -> int:
         raise NotImplementedError
 
-    @abstractstaticmethod
+    @staticmethod
+    @abstractmethod
     def value_arrow_type() -> pa.DataType:
         raise NotImplementedError
 

--- a/python/lancedb/query.py
+++ b/python/lancedb/query.py
@@ -226,6 +226,7 @@ class LanceQueryBuilder:
             columns=self._columns,
             nprobes=self._nprobes,
             refine_factor=self._refine_factor,
+            vector_column=self._vector_column,
         )
         return self._table._execute_query(query)
 

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -13,6 +13,7 @@
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 import lancedb
@@ -130,6 +131,9 @@ def test_empty_or_nonexistent_table(tmp_path):
 
     with pytest.raises(Exception):
         db.open_table("does_not_exist")
+
+    schema = pa.schema([pa.field("a", pa.int32())])
+    db.create_table("test", schema=schema)
 
 
 def test_replace_index(tmp_path):

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -119,6 +119,7 @@ def test_query_builder_with_different_vector_column():
             columns=["b"],
             nprobes=20,
             refine_factor=None,
+            vector_column="foo_vector",
         )
     )
 


### PR DESCRIPTION
1. Create empty table was failing because top level API wasn't exposed correctly.
2. Passing in different vector column was failing because QueryBuilder.to_arrow didn't pass the vector_column argument
3. Remove deprecated abstractstaticmethod usage in pydantic