### PR TITLE
[Rust] Checkout a version of dataset.

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectordb",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vectordb",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "cpu": [
         "x64",
         "arm64"
@@ -50,11 +50,11 @@
         "typescript": "*"
       },
       "optionalDependencies": {
-        "vectordb-darwin-arm64": "0.1.13",
-        "vectordb-darwin-x64": "0.1.13",
-        "vectordb-linux-arm64-gnu": "0.1.13",
-        "vectordb-linux-x64-gnu": "0.1.13",
-        "vectordb-win32-x64-msvc": "0.1.13"
+        "vectordb-darwin-arm64": "0.1.14",
+        "vectordb-darwin-x64": "0.1.14",
+        "vectordb-linux-arm64-gnu": "0.1.14",
+        "vectordb-linux-x64-gnu": "0.1.14",
+        "vectordb-win32-x64-msvc": "0.1.14"
       }
     },
     "node_modules/@apache-arrow/ts": {
@@ -4289,9 +4289,9 @@
       "dev": true
     },
     "node_modules/vectordb-darwin-arm64": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.1.13.tgz",
-      "integrity": "sha512-9lLuX5P8m75EfP85pfC4LxO9J7Tzu4LngX55BVAdFe6qPRHu+iHmLw0QYYSVDqNm3GtDr2qFJlL2ILlsApyYyg==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.1.14.tgz",
+      "integrity": "sha512-5doSFMUR4scxseo73thCxScmO3Wpb+cqPsIa7+2uneTEtBSViMbkw/1mGTC+rV4NTCnxhoiqHk9pJzZVeDMkPg==",
       "cpu": [
         "arm64"
       ],
@@ -4301,9 +4301,9 @@
       ]
     },
     "node_modules/vectordb-darwin-x64": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/vectordb-darwin-x64/-/vectordb-darwin-x64-0.1.13.tgz",
-      "integrity": "sha512-5mkhBJlcfAqcty7Ww2csgYogq+b0NhtllAbag9IIznvqfcrvITU0H0vm5LGWbRuE/BUUxC25MJhm93YWBzqEVA==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/vectordb-darwin-x64/-/vectordb-darwin-x64-0.1.14.tgz",
+      "integrity": "sha512-x+qVaKNhAG65HdENL6GRJjxl1hZ7erRm3a2rhplyYoQyzuRPPBILeWzxkE01G1fb0+47dehe7Q4f/8BDaghcCQ==",
       "cpu": [
         "x64"
       ],
@@ -4313,9 +4313,9 @@
       ]
     },
     "node_modules/vectordb-linux-x64-gnu": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.1.13.tgz",
-      "integrity": "sha512-fU+sIHUkXyMdrWjggT93p0blKD+pbgr+x01tn9d2/pbA1ePo2AwuE86rYPA+BjyCUE1QifPgKadzGVVpqWYmnQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.1.14.tgz",
+      "integrity": "sha512-hvA2YYwTZK92k6nPH99Jn5N0CwagDOdnwMmjtCpzFOEYK7dY/2kcTOoQNlBwwNP9MYvgN6jdFD/Cwkih1X/qjA==",
       "cpu": [
         "x64"
       ],
@@ -7620,21 +7620,21 @@
       "dev": true
     },
     "vectordb-darwin-arm64": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.1.13.tgz",
-      "integrity": "sha512-9lLuX5P8m75EfP85pfC4LxO9J7Tzu4LngX55BVAdFe6qPRHu+iHmLw0QYYSVDqNm3GtDr2qFJlL2ILlsApyYyg==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.1.14.tgz",
+      "integrity": "sha512-5doSFMUR4scxseo73thCxScmO3Wpb+cqPsIa7+2uneTEtBSViMbkw/1mGTC+rV4NTCnxhoiqHk9pJzZVeDMkPg==",
       "optional": true
     },
     "vectordb-darwin-x64": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/vectordb-darwin-x64/-/vectordb-darwin-x64-0.1.13.tgz",
-      "integrity": "sha512-5mkhBJlcfAqcty7Ww2csgYogq+b0NhtllAbag9IIznvqfcrvITU0H0vm5LGWbRuE/BUUxC25MJhm93YWBzqEVA==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/vectordb-darwin-x64/-/vectordb-darwin-x64-0.1.14.tgz",
+      "integrity": "sha512-x+qVaKNhAG65HdENL6GRJjxl1hZ7erRm3a2rhplyYoQyzuRPPBILeWzxkE01G1fb0+47dehe7Q4f/8BDaghcCQ==",
       "optional": true
     },
     "vectordb-linux-x64-gnu": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.1.13.tgz",
-      "integrity": "sha512-fU+sIHUkXyMdrWjggT93p0blKD+pbgr+x01tn9d2/pbA1ePo2AwuE86rYPA+BjyCUE1QifPgKadzGVVpqWYmnQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.1.14.tgz",
+      "integrity": "sha512-hvA2YYwTZK92k6nPH99Jn5N0CwagDOdnwMmjtCpzFOEYK7dY/2kcTOoQNlBwwNP9MYvgN6jdFD/Cwkih1X/qjA==",
       "optional": true
     },
     "vscode-oniguruma": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lancedb"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = ["pylance~=0.5.8", "ratelimiter", "retry", "tqdm", "aiohttp", "pydantic>=2", "attr"]
 description = "lancedb"
 authors = [

--- a/rust/vectordb/src/index/vector.rs
+++ b/rust/vectordb/src/index/vector.rs
@@ -24,6 +24,7 @@ pub trait VectorIndexBuilder {
     fn get_replace(&self) -> bool;
 }
 
+#[derive(Default)]
 pub struct IvfPQIndexBuilder {
     column: Option<String>,
     index_name: Option<String>,

--- a/rust/vectordb/src/index/vector.rs
+++ b/rust/vectordb/src/index/vector.rs
@@ -24,7 +24,6 @@ pub trait VectorIndexBuilder {
     fn get_replace(&self) -> bool;
 }
 
-
 pub struct IvfPQIndexBuilder {
     column: Option<String>,
     index_name: Option<String>,

--- a/rust/vectordb/src/index/vector.rs
+++ b/rust/vectordb/src/index/vector.rs
@@ -24,7 +24,7 @@ pub trait VectorIndexBuilder {
     fn get_replace(&self) -> bool;
 }
 
-#[derive(Default)]
+
 pub struct IvfPQIndexBuilder {
     column: Option<String>,
     index_name: Option<String>,
@@ -36,6 +36,12 @@ pub struct IvfPQIndexBuilder {
 
 impl IvfPQIndexBuilder {
     pub fn new() -> IvfPQIndexBuilder {
+        Default::default()
+    }
+}
+
+impl Default for IvfPQIndexBuilder {
+    fn default() -> Self {
         IvfPQIndexBuilder {
             column: None,
             index_name: None,

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -12,22 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
 use std::sync::Arc;
 
 use arrow_array::{Float32Array, RecordBatchReader};
 use arrow_schema::SchemaRef;
-use lance::dataset::{Dataset, ReadParams, WriteParams};
+use lance::dataset::{Dataset, WriteParams};
 use lance::index::IndexType;
-use snafu::prelude::*;
 
-use crate::error::{Error, InvalidTableNameSnafu, Result};
+use crate::error::{Error, Result};
 use crate::index::vector::VectorIndexBuilder;
 use crate::query::Query;
 use crate::WriteMode;
 
+pub use lance::dataset::ReadParams;
+
 pub const VECTOR_COLUMN_NAME: &str = "vector";
-pub const LANCE_FILE_EXTENSION: &str = "lance";
 
 /// A table in a LanceDB database.
 #[derive(Debug, Clone)]
@@ -43,24 +42,19 @@ impl std::fmt::Display for Table {
     }
 }
 
-#[derive(Default)]
-pub struct OpenTableParams {
-    pub open_table_params: ReadParams,
-}
-
 impl Table {
     /// Opens an existing Table
     ///
     /// # Arguments
     ///
-    /// * `base_path` - The base path where the table is located
-    /// * `name` The Table name
+    /// * `uri` - The uri to a [Table]
+    /// * `name` - The table name
     ///
     /// # Returns
     ///
     /// * A [Table] object.
-    pub async fn open(base_uri: &str, name: &str) -> Result<Self> {
-        Self::open_with_params(base_uri, name, OpenTableParams::default()).await
+    pub async fn open(uri: &str, name: &str) -> Result<Self> {
+        Self::open_with_params(uri, name, &ReadParams::default()).await
     }
 
     /// Opens an existing Table
@@ -69,25 +63,42 @@ impl Table {
     ///
     /// * `base_path` - The base path where the table is located
     /// * `name` The Table name
-    /// * `params` The [OpenTableParams] to use when opening the table
+    /// * `params` The [ReadParams] to use when opening the table
     ///
     /// # Returns
     ///
     /// * A [Table] object.
-    pub async fn open_with_params(
-        base_uri: &str,
+    pub async fn open_with_params(uri: &str, name: &str, params: &ReadParams) -> Result<Self> {
+        let dataset = Dataset::open_with_params(uri, params)
+            .await
+            .map_err(|e| match e {
+                lance::Error::DatasetNotFound { .. } => Error::TableNotFound {
+                    name: name.to_string(),
+                },
+                e => Error::Lance {
+                    message: e.to_string(),
+                },
+            })?;
+        Ok(Table {
+            name: name.to_string(),
+            uri: uri.to_string(),
+            dataset: Arc::new(dataset),
+        })
+    }
+
+    /// Checkout a specific version of this [`Table`]
+    ///
+    pub async fn checkout(uri: &str, name: &str, version: u64) -> Result<Self> {
+        Self::checkout_with_params(uri, name, version, &ReadParams::default()).await
+    }
+
+    pub async fn checkout_with_params(
+        uri: &str,
         name: &str,
-        params: OpenTableParams,
+        version: u64,
+        params: &ReadParams,
     ) -> Result<Self> {
-        let path = Path::new(base_uri);
-
-        let table_uri = path.join(format!("{}.{}", name, LANCE_FILE_EXTENSION));
-        let uri = table_uri
-            .as_path()
-            .to_str()
-            .context(InvalidTableNameSnafu { name })?;
-
-        let dataset = Dataset::open_with_params(uri, &params.open_table_params)
+        let dataset = Dataset::checkout_with_params(uri, version, params)
             .await
             .map_err(|e| match e {
                 lance::Error::DatasetNotFound { .. } => Error::TableNotFound {
@@ -108,27 +119,21 @@ impl Table {
     ///
     /// # Arguments
     ///
-    /// * `base_path` - The base path where the table is located
+    /// * `uri` - The URI to the table.
     /// * `name` The Table name
-    /// * `batches` RecordBatch to be saved in the database
+    /// * `batches` RecordBatch to be saved in the database.
+    /// * `params` - Write parameters.
     ///
     /// # Returns
     ///
     /// * A [Table] object.
     pub async fn create(
-        base_uri: &str,
+        uri: &str,
         name: &str,
         batches: impl RecordBatchReader + Send + 'static,
         params: Option<WriteParams>,
     ) -> Result<Self> {
-        let base_path = Path::new(base_uri);
-        let table_uri = base_path.join(format!("{}.{}", name, LANCE_FILE_EXTENSION));
-        let uri = table_uri
-            .as_path()
-            .to_str()
-            .context(InvalidTableNameSnafu { name })?
-            .to_string();
-        let dataset = Dataset::write(batches, &uri, params)
+        let dataset = Dataset::write(batches, uri, params)
             .await
             .map_err(|e| match e {
                 lance::Error::DatasetAlreadyExists { .. } => Error::TableAlreadyExists {
@@ -140,7 +145,7 @@ impl Table {
             })?;
         Ok(Table {
             name: name.to_string(),
-            uri,
+            uri: uri.to_string(),
             dataset: Arc::new(dataset),
         })
     }
@@ -264,14 +269,15 @@ mod tests {
     async fn test_open() {
         let tmp_dir = tempdir().unwrap();
         let dataset_path = tmp_dir.path().join("test.lance");
-        let uri = tmp_dir.path().to_str().unwrap();
 
         let batches = make_test_batches();
         Dataset::write(batches, dataset_path.to_str().unwrap(), None)
             .await
             .unwrap();
 
-        let table = Table::open(uri, "test").await.unwrap();
+        let table = Table::open(dataset_path.to_str().unwrap(), "test")
+            .await
+            .unwrap();
 
         assert_eq!(table.name, "test")
     }
@@ -371,7 +377,7 @@ mod tests {
     async fn test_search() {
         let tmp_dir = tempdir().unwrap();
         let dataset_path = tmp_dir.path().join("test.lance");
-        let uri = tmp_dir.path().to_str().unwrap();
+        let uri = dataset_path.to_str().unwrap();
 
         let batches = make_test_batches();
         Dataset::write(batches, dataset_path.to_str().unwrap(), None)
@@ -410,7 +416,7 @@ mod tests {
     async fn test_open_table_options() {
         let tmp_dir = tempdir().unwrap();
         let dataset_path = tmp_dir.path().join("test.lance");
-        let uri = tmp_dir.path().to_str().unwrap();
+        let uri = dataset_path.to_str().unwrap();
 
         let batches = make_test_batches();
         Dataset::write(batches, dataset_path.to_str().unwrap(), None)
@@ -421,15 +427,12 @@ mod tests {
 
         let mut object_store_params = ObjectStoreParams::default();
         object_store_params.object_store_wrapper = Some(wrapper.clone());
-        let param = OpenTableParams {
-            open_table_params: ReadParams {
-                store_options: Some(object_store_params),
-                ..ReadParams::default()
-            },
+        let param = ReadParams {
+            store_options: Some(object_store_params),
+            ..Default::default()
         };
-
         assert!(!wrapper.called());
-        let _ = Table::open_with_params(uri, "test", param).await.unwrap();
+        let _ = Table::open_with_params(uri, "test", &param).await.unwrap();
         assert!(wrapper.called());
     }
 


### PR DESCRIPTION
* `Table::open()` from absolute path, and gives the responsibility of organizing metadata out of Table object
* Fix Clippy warnings
* Add `Table::checkout(version)` API 