### PR TITLE
[Python] Do not return Table count for every add operation

### DIFF
--- a/python/lancedb/remote/table.py
+++ b/python/lancedb/remote/table.py
@@ -79,7 +79,6 @@ class RemoteTable(Table):
                 content_type=ARROW_STREAM_CONTENT_TYPE,
             )
         )
-        return len(data)
 
     def search(
         self, query: Union[VEC, str], vector_column: str = VECTOR_COLUMN_NAME

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -151,7 +151,7 @@ class Table(ABC):
         mode: str = "append",
         on_bad_vectors: str = "error",
         fill_value: float = 0.0,
-    ) -> int:
+    ):
         """Add more data to the [Table](Table).
 
         Parameters
@@ -167,10 +167,6 @@ class Table(ABC):
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
 
-        Returns
-        -------
-        int
-            The number of vectors in the table.
         """
         raise NotImplementedError
 
@@ -409,7 +405,7 @@ class LanceTable(Table):
         mode: str = "append",
         on_bad_vectors: str = "error",
         fill_value: float = 0.0,
-    ) -> int:
+    ):
         """Add data to the table.
 
         Parameters
@@ -436,7 +432,6 @@ class LanceTable(Table):
         )
         lance.write_dataset(data, self._dataset_uri, mode=mode)
         self._reset_dataset()
-        return len(self)
 
     def search(
         self, query: Union[VEC, str], vector_column_name=VECTOR_COLUMN_NAME

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -74,7 +74,6 @@ class Table(ABC):
     Can append new data with [Table.add()][lancedb.table.Table.add].
 
     >>> table.add([{"vector": [0.5, 1.3], "b": 4}])
-    2
 
     Can query the table with [Table.search][lancedb.table.Table.search].
 
@@ -303,7 +302,6 @@ class LanceTable(Table):
                vector    type
         0  [1.1, 0.9]  vector
         >>> table.add([{"vector": [0.5, 0.2], "type": "vector"}])
-        2
         >>> table.version
         2
         >>> table.checkout(1)

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -139,8 +139,8 @@ def _add(table, schema):
     # table = LanceTable(db, "test")
     assert len(table) == 2
 
-    count = table.add([{"vector": [6.3, 100.5], "item": "new", "price": 30.0}])
-    assert count == 3
+    table.add([{"vector": [6.3, 100.5], "item": "new", "price": 30.0}])
+    assert len(table) == 3
 
     expected = pa.Table.from_arrays(
         [


### PR DESCRIPTION
`Table::count()` will be linearly slower with more fragments ingested.