### PR TITLE
wip: search: Make vector optional

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -152,7 +152,7 @@ export interface Table<T = number[]> {
    * Creates a search query to find the nearest neighbors of the given search term
    * @param query The query search term
    */
-  search: (query: T) => Query<T>
+  search: (query?: T) => Query<T>
 
   /**
    * Insert records into this Table.
@@ -338,7 +338,7 @@ export class LocalTable<T = number[]> implements Table<T> {
    * Creates a search query to find the nearest neighbors of the given search term
    * @param query The query search term
    */
-  search (query: T): Query<T> {
+  search (query?: T): Query<T> {
     return new Query(query, this._tbl, this._embeddings)
   }
 

--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -14,7 +14,7 @@
 
 import {
   type EmbeddingFunction, type Table, type VectorIndexParams, type Connection,
-  type ConnectionOptions
+  type ConnectionOptions, type VectorSearch
 } from '../index'
 import { Query } from '../query'
 
@@ -164,6 +164,10 @@ export class RemoteTable<T = number[]> implements Table<T> {
   }
 
   async delete (filter: string): Promise<void> {
+    throw new Error('Not implemented')
+  }
+
+  query (params: VectorSearch<T> | undefined): Query<T> {
     throw new Error('Not implemented')
   }
 }

--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -142,8 +142,9 @@ export class RemoteTable<T = number[]> implements Table<T> {
     return this._name
   }
 
-  search (query: T): Query<T> {
-    return new RemoteQuery(query, this._client, this._name)//, this._embeddings_new)
+  search (query?: T): Query<T> {
+    // FIXME query is optional
+    return new RemoteQuery(query as T, this._client, this._name)//, this._embeddings_new)
   }
 
   async add (data: Array<Record<string, unknown>>): Promise<number> {

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -101,6 +101,25 @@ describe('LanceDB client', function () {
       assertResults(results)
     })
 
+    it('execute a query without passing providing a vector', async function () {
+      const uri = await createTestDB(2, 100)
+      const con = await lancedb.connect(uri)
+      const table = await con.openTable('vectors')
+      const results = await table.search()
+        .select(['id', 'name', 'price', 'is_active'])
+        .filter('id > 2 and id < 10 and is_active = true')
+        .execute()
+
+      const expected = [
+        { id: 3, name: 'name_2', price: 12, is_active: true },
+        { id: 5, name: 'name_4', price: 14, is_active: true },
+        { id: 7, name: 'name_6', price: 16, is_active: true },
+        { id: 9, name: 'name_8', price: 18, is_active: true }
+      ]
+
+      assert.sameDeepMembers(expected, results)
+    })
+
     it('select only a subset of columns', async function () {
       const uri = await createTestDB()
       const con = await lancedb.connect(uri)

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -126,3 +126,45 @@ def test_query_builder_with_different_vector_column():
 
 def cosine_distance(vec1, vec2):
     return 1 - np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2))
+
+def test_vector_search():
+    import lancedb
+    from lancedb.query import VectorSearchBuilder
+
+    db = lancedb.connect('/tmp/lancedb-100')
+    table = db.open_table('vectors')
+
+    results = table.query(VectorSearchBuilder([0.1, 0.2])) \
+        .select(['id', 'name', 'price', 'is_active'])\
+        .where('id > 2 and id < 10 and is_active = true')
+
+    print(results.to_df())
+
+def test_vector_search_with_ann_params():
+    import lancedb
+    from lancedb.query import VectorSearchBuilder
+
+    db = lancedb.connect('/tmp/lancedb-100')
+    table = db.open_table('vectors')
+
+    vector_search = VectorSearchBuilder([0.1, 0.2])\
+        .nprobes(10)\
+        .refine_factor(10)
+
+    results = table.query(vector_search) \
+        .select(['id', 'name', 'price', 'is_active']) \
+        .where('id > 2 and id < 10 and is_active = true')
+
+    print(results.to_df())
+
+def test_table_scan():
+    import lancedb
+
+    db = lancedb.connect('/tmp/lancedb-100')
+    table = db.open_table('vectors')
+
+    results = table.query() \
+        .select(['id', 'name', 'price', 'is_active']) \
+        .where('id > 2 and id < 10 and is_active = true')
+
+    print(results.to_df())

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -239,8 +239,8 @@ impl Table {
     /// # Returns
     ///
     /// * A [Query] object.
-    pub fn search(&self, query_vector: Float32Array) -> Query {
-        Query::new(self.dataset.clone(), query_vector)
+    pub fn search(&self) -> Query {
+        Query::new(self.dataset.clone())
     }
 
     /// Returns the number of rows in this Table
@@ -411,8 +411,8 @@ mod tests {
         let table = Table::open(uri).await.unwrap();
 
         let vector = Float32Array::from_iter_values([0.1, 0.2]);
-        let query = table.search(vector.clone());
-        assert_eq!(vector, query.query_vector);
+        let query = table.search().query_vector(Some(vector.clone()));
+        assert_eq!(Some(vector), query.query_vector);
     }
 
     #[derive(Default, Debug)]


### PR DESCRIPTION
## Current State

Currently we only expose one API to extract data from LanceDB, search by vector:

```typescript
const results = await table.search([0.1, 0.1]).execute()
```

We would like to allow users to search by any attributes / metadata, leveraging the support Lance already implements for that.

## Proposed Solution

Create a new method `Table.query(..)` that servers as a starting point to all search types supported by LanceDB (table scan, vector search, full text search).

### Table Scan - Python

```python
results = table.query() \
  .select(['id', 'name', 'price', 'is_active']) \
  .where('id > 2 and id < 10 and is_active = true')
  .to_df()
```

### Table Scan - Node.js

```javascript
const results = await table.query()
  .select(['id', 'name', 'price', 'is_active'])
  .filter('id > 2 and id < 10 and is_active = true')
  .execute()
```

### Vector Search - Python

2) Create a more detailed API for vector search and  and keep the existing `search` as it is

```python
results = table.query(VectorSearchBuilder([0.1, 0.2])) \
    .select(['id', 'name', 'price', 'is_active'])\
    .where('id > 2 and id < 10 and is_active = true')\
    .to_df()

... or with more ann params...

vector_search = VectorSearchBuilder([0.1, 0.2])\
  .nprobes(10)\
  .refine_factor(10)

results = table.query(vector_search) \
        .select(['id', 'name', 'price', 'is_active']) \
        .where('id > 2 and id < 10 and is_active = true')
```

### Vector Search - Node.js - Option 1

We can follow the Python API here

```typescript
const vectorSearch = new VectorSearch([0.1, 0.2])
  .nprobes(10)
  .refineFactor(45)

const results = await table.query(vectorSearch)
  .select(['id', 'name', 'price', 'is_active'])
  .filter('id > 2 and id < 10 and is_active = true')
  .execute()
```

### Vector Search - Node.js - Option 2

Use Options object instead of a builder

```typescript
const results = await table.query()
  .vectorSearchOption2({ query: [0.1, 0.2] })
  .select(['id', 'name', 'price', 'is_active'])
  .filter('id > 2 and id < 10 and is_active = true')
  .execute()
```

## Other Alternatives

The simplest solution is to make vector optional. For instance this query returns all elements that match the `filter` predicate:

```typescript
const results = await table.search()  
  .select(['id', 'name', 'price', 'is_active'])  
  .filter('id > 2 and id < 10 and is_active = true')  
  .execute()
```

An empty `filter` predicate returns all elements of the Table. We can keep the existing API interface `search(vector)` so that the change is backwards compatible.

Making the search vector optional can make the API confusing because some parameters (`nprobes`,  `refine_factor`, ...)  only make sense when paired with a vector. The list of such parameters will grow as we support more index types.