### PR TITLE
version to versioninfo question

### DIFF
--- a/python/lancedb/pydantic.py
+++ b/python/lancedb/pydantic.py
@@ -26,7 +26,7 @@ import pyarrow as pa
 import pydantic
 import semver
 
-PYDANTIC_VERSION = semver.Version.parse(pydantic.__version__)
+PYDANTIC_VERSION = semver.VersionInfo.parse(pydantic.__version__)
 try:
     from pydantic_core import CoreSchema, core_schema
 except ImportError:


### PR DESCRIPTION
is there an older version of lancedb that used a semver version between (>=2.10.2,<3.0.0) ? I am using launchdarkly and they have that constraint on their semver versioning