### PR TITLE
Automatically convert pydantic model

### DIFF
--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -96,15 +96,14 @@ In this case, you can create an empty table and specify the schema.
 You may find it easier to use pydantic to specify the model rather than pyarrow.
 
 === "Python"
-       ```python
-        import lancedb
-        from lancedb.pydantic import LanceModel, vector
-        class MyModel(LanceModel):
-             vector: vector(128)
-        db = lancedb.connect("~/.lancedb")
-        tbl = db.create_table("my_table", schema=MyModel)
-        ```
-
+      ```python
+      import lancedb
+      from lancedb.pydantic import LanceModel, vector
+      class MyModel(LanceModel):
+          vector: vector(128)
+      db = lancedb.connect("~/.lancedb")
+      tbl = db.create_table("my_table", schema=MyModel)
+      ```
 
 ## How to open an existing table
 

--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -86,23 +86,9 @@ In this case, you can create an empty table and specify the schema.
 
 === "Python"
       ```python
-      import lancedb
       import pyarrow as pa
-      schema = pa.schema([pa.field("vector", pa.list_(pa.float32(), list_size=128))])
-      db = lancedb.connect("~/.lancedb")
-      tbl = db.create_table("my_table", schema=schema)
-      ```
-
-You may find it easier to use pydantic to specify the model rather than pyarrow.
-
-=== "Python"
-      ```python
-      import lancedb
-      from lancedb.pydantic import LanceModel, vector
-      class MyModel(LanceModel):
-          vector: vector(128)
-      db = lancedb.connect("~/.lancedb")
-      tbl = db.create_table("my_table", schema=MyModel)
+      schema = pa.schema([pa.field("vector", pa.list_(pa.float32(), list_size=2))])
+      tbl = db.create_table("empty_table", schema=schema)
       ```
 
 ## How to open an existing table

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -22,9 +22,9 @@ import pyarrow as pa
 from pyarrow import fs
 
 from .common import DATA, URI
+from .pydantic import LanceModel
 from .table import LanceTable, Table
 from .util import fs_from_uri, get_uri_location, get_uri_scheme
-from .pydantic import LanceModel
 
 
 class DBConnection(ABC):

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -24,6 +24,7 @@ from pyarrow import fs
 from .common import DATA, URI
 from .table import LanceTable, Table
 from .util import fs_from_uri, get_uri_location, get_uri_scheme
+from .pydantic import LanceModel
 
 
 class DBConnection(ABC):
@@ -39,7 +40,7 @@ class DBConnection(ABC):
         self,
         name: str,
         data: Optional[DATA] = None,
-        schema: Optional[pa.Schema] = None,
+        schema: Optional[pa.Schema, LanceModel] = None,
         mode: str = "create",
         on_bad_vectors: str = "error",
         fill_value: float = 0.0,
@@ -52,7 +53,7 @@ class DBConnection(ABC):
             The name of the table.
         data: list, tuple, dict, pd.DataFrame; optional
             The data to initialize the table. User must provide at least one of `data` or `schema`.
-        schema: pyarrow.Schema; optional
+        schema: pyarrow.Schema or LanceModel; optional
             The schema of the table.
         mode: str; default "create"
             The mode to use when creating the table. Can be either "create" or "overwrite".
@@ -277,7 +278,7 @@ class LanceDBConnection(DBConnection):
         self,
         name: str,
         data: Optional[DATA] = None,
-        schema: pa.Schema = None,
+        schema: Optional[pa.Schema, LanceModel] = None,
         mode: str = "create",
         on_bad_vectors: str = "error",
         fill_value: float = 0.0,

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 from abc import ABC, abstractmethod
 from functools import cached_property
@@ -506,7 +507,7 @@ class LanceTable(Table):
         data: list-of-dict, dict, pd.DataFrame, default None
             The data to insert into the table.
             At least one of `data` or `schema` must be provided.
-        schema: dict, optional
+        schema: pa.Schema or LanceModel, optional
             The schema of the table. If not provided, the schema is inferred from the data.
             At least one of `data` or `schema` must be provided.
         mode: str, default "create"
@@ -519,6 +520,8 @@ class LanceTable(Table):
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         """
         tbl = LanceTable(db, name)
+        if inspect.isclass(schema) and issubclass(schema, LanceModel):
+            schema = schema.to_arrow_schema()
         if data is not None:
             data = _sanitize_data(
                 data, schema, on_bad_vectors=on_bad_vectors, fill_value=fill_value

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -17,6 +17,7 @@ import pyarrow as pa
 import pytest
 
 import lancedb
+from lancedb.pydantic import LanceModel
 
 
 def test_basic(tmp_path):
@@ -167,8 +168,14 @@ def test_empty_or_nonexistent_table(tmp_path):
     with pytest.raises(Exception):
         db.open_table("does_not_exist")
 
-    schema = pa.schema([pa.field("a", pa.int32())])
-    db.create_table("test", schema=schema)
+    schema = pa.schema([pa.field("a", pa.int64(), nullable=False)])
+    test = db.create_table("test", schema=schema)
+
+    class TestModel(LanceModel):
+        a: int
+
+    test2 = db.create_table("test2", schema=TestModel)
+    assert test.schema == test2.schema
 
 
 def test_replace_index(tmp_path):


### PR DESCRIPTION
Saves users from having to explicitly call `LanceModel.to_arrow_schema()` when creating an empty table.
See new docs for full details. 