### PR TITLE
[breaking change] make schema a property

### DIFF
--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -93,9 +93,10 @@ class Table(ABC):
     [Table.create_index][lancedb.table.Table.create_index].
     """
 
+    @property
     @abstractmethod
     def schema(self) -> pa.Schema:
-        """Return the [Arrow Schema](https://arrow.apache.org/docs/python/api/datatypes.html#) of
+        """The [Arrow Schema](https://arrow.apache.org/docs/python/api/datatypes.html#) of
         this [Table](Table)
 
         """


### PR DESCRIPTION
Both existing implementations, `LanceTable` and `RemoteTable`, of the `Table` abstract class implements `schema` as a property. This PR aligns the interface and implementation.