### PR TITLE
fix(node) Electron crashes when creating external buffer

### DIFF
--- a/node/src/query.ts
+++ b/node/src/query.ts
@@ -112,7 +112,8 @@ export class Query<T = number[]> {
       this._queryVector = this._query as number[]
     }
 
-    const buffer = await tableSearch.call(this._tbl, this)
+    const isElectron = this.isElectron()
+    const buffer = await tableSearch.call(this._tbl, this, isElectron)
     const data = tableFromIPC(buffer)
 
     return data.toArray().map((entry: Record<string, unknown>) => {
@@ -126,5 +127,15 @@ export class Query<T = number[]> {
       })
       return newObject as unknown as T
     })
+  }
+
+  // See https://github.com/electron/electron/issues/2288
+  private isElectron (): boolean {
+    try {
+      // eslint-disable-next-line no-prototype-builtins
+      return (process?.versions?.hasOwnProperty('electron') || navigator?.userAgent?.toLowerCase()?.includes(' electron'))
+    } catch (e) {
+      return false
+    }
   }
 }


### PR DESCRIPTION
Output of `https://github.com/TevinWang/electron-quick-start-typescript/`

```
> electron-quick-start-typescript@1.0.0 start
> npm run build && electron ./dist/main.js


> electron-quick-start-typescript@1.0.0 build
> tsc

[
  '18',      '20', '29',
  '32',      '35', '39',
  '45',      '48', '53',
  '58',      '59', '69',
  '88',      '93', '97',
  'vectors'
]
[
  {
    vector: Float32Array(2) [ 0.10000000149011612, 0.20000000298023224 ],
    id: 1,
    price: 10,
    score: 0.010000001639127731
  },
  {
    vector: Float32Array(2) [ 1.100000023841858, 1.2000000476837158 ],
    id: 2,
    price: 50,
    score: 1.8100000619888306
  }
]
All done!
```

Close #382