### PR TITLE
Make creating (and adding to) tables via Iterators more flexible & intuitive

### DIFF
--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -66,9 +66,11 @@ def _sanitize_data(data, schema, on_bad_vectors, fill_value):
 def _to_record_batch_generator(data: Iterable, schema, on_bad_vectors, fill_value):
     for batch in data:
         if not isinstance(batch, pa.RecordBatch):
-            batch = _sanitize_data(
+            table = _sanitize_data(
                 batch, schema, on_bad_vectors, fill_value
-            ).to_batches()[0]
+            )
+            for batch in table.to_batches():
+                yield batch
         yield batch
 
 

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -66,9 +66,7 @@ def _sanitize_data(data, schema, on_bad_vectors, fill_value):
 def _to_record_batch_generator(data: Iterable, schema, on_bad_vectors, fill_value):
     for batch in data:
         if not isinstance(batch, pa.RecordBatch):
-            table = _sanitize_data(
-                batch, schema, on_bad_vectors, fill_value
-            )
+            table = _sanitize_data(batch, schema, on_bad_vectors, fill_value)
             for batch in table.to_batches():
                 yield batch
         yield batch

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -62,11 +62,15 @@ def _sanitize_data(data, schema, on_bad_vectors, fill_value):
         raise TypeError(f"Unsupported data type: {type(data)}")
     return data
 
+
 def _to_record_batch_generator(data: Iterable, schema, on_bad_vectors, fill_value):
     for batch in data:
         if not isinstance(batch, pa.RecordBatch):
-            batch = _sanitize_data(batch, schema, on_bad_vectors, fill_value).to_batches()[0]
+            batch = _sanitize_data(
+                batch, schema, on_bad_vectors, fill_value
+            ).to_batches()[0]
         yield batch
+
 
 class Table(ABC):
     """

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -56,10 +56,17 @@ def _sanitize_data(data, schema, on_bad_vectors, fill_value):
         metadata = {k: v for k, v in metadata.items() if k != b"pandas"}
         schema = data.schema.with_metadata(metadata)
         data = pa.Table.from_arrays(data.columns, schema=schema)
+    if isinstance(data, Iterable):
+        data = _to_record_batch_generator(data, schema, on_bad_vectors, fill_value)
     if not isinstance(data, (pa.Table, Iterable)):
         raise TypeError(f"Unsupported data type: {type(data)}")
     return data
 
+def _to_record_batch_generator(data: Iterable, schema, on_bad_vectors, fill_value):
+    for batch in data:
+        if not isinstance(batch, pa.RecordBatch):
+            batch = _sanitize_data(batch, schema, on_bad_vectors, fill_value).to_batches()[0]
+        yield batch
 
 class Table(ABC):
     """

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -116,6 +116,16 @@ def test_ingest_iterator(tmp_path):
                     ],
                     ["vector", "item", "price"],
                 ),
+                # pa Table
+                pa.Table.from_arrays(
+                    [
+                        pa.array([[3.1, 4.1], [5.9, 26.5]],
+                                pa.list_(pa.float32(), 2)),
+                        pa.array(["foo", "bar"]),
+                        pa.array([10.0, 20.0]),
+                    ],
+                    ["vector", "item", "price"],
+                ),
                 # pydantic list
                 [
                     PydanticSchema(vector=[3.1, 4.1], item="foo", price=10.0),

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -119,8 +119,7 @@ def test_ingest_iterator(tmp_path):
                 # pa Table
                 pa.Table.from_arrays(
                     [
-                        pa.array([[3.1, 4.1], [5.9, 26.5]],
-                                pa.list_(pa.float32(), 2)),
+                        pa.array([[3.1, 4.1], [5.9, 26.5]], pa.list_(pa.float32(), 2)),
                         pa.array(["foo", "bar"]),
                         pa.array([10.0, 20.0]),
                     ],

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -82,46 +82,46 @@ def test_ingest_iterator(tmp_path):
         vector: vector(2)
         item: str
         price: float
-    
-    arrow_schema = pa.schema([
-        pa.field("vector", pa.list_(pa.float32(), 2)),
-        pa.field("item", pa.utf8()),
-        pa.field("price", pa.float32()),
-    ])
+
+    arrow_schema = pa.schema(
+        [
+            pa.field("vector", pa.list_(pa.float32(), 2)),
+            pa.field("item", pa.utf8()),
+            pa.field("price", pa.float32()),
+        ]
+    )
 
     def make_batches():
         for _ in range(5):
-            yield from [ 
-            # pandas
-            pd.DataFrame({
-                "vector": [[3.1, 4.1], [1, 1]],
-                "item": ["foo", "bar"],
-                "price": [10.0, 20.0],
-            }),
-            
-            # pylist
-            [
-                {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
-                {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
-            ],
-
-            # recordbatch
-            pa.RecordBatch.from_arrays(
+            yield from [
+                # pandas
+                pd.DataFrame(
+                    {
+                        "vector": [[3.1, 4.1], [1, 1]],
+                        "item": ["foo", "bar"],
+                        "price": [10.0, 20.0],
+                    }
+                ),
+                # pylist
                 [
-                    pa.array([[3.1, 4.1], [5.9, 26.5]], pa.list_(pa.float32(), 2)),
-                    pa.array(["foo", "bar"]),
-                    pa.array([10.0, 20.0]),
-                ], 
-                ["vector", "item", "price"],
-            ),
-
-            # pydantic list
-            [
-                PydanticSchema(vector=[3.1, 4.1], item="foo", price=10.0),
-                PydanticSchema(vector=[5.9, 26.5], item="bar", price=20.0),
-            ]
-
-            # TODO: test pydict separately. it is unique column number and names contraint
+                    {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
+                    {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
+                ],
+                # recordbatch
+                pa.RecordBatch.from_arrays(
+                    [
+                        pa.array([[3.1, 4.1], [5.9, 26.5]], pa.list_(pa.float32(), 2)),
+                        pa.array(["foo", "bar"]),
+                        pa.array([10.0, 20.0]),
+                    ],
+                    ["vector", "item", "price"],
+                ),
+                # pydantic list
+                [
+                    PydanticSchema(vector=[3.1, 4.1], item="foo", price=10.0),
+                    PydanticSchema(vector=[5.9, 26.5], item="bar", price=20.0),
+                ]
+                # TODO: test pydict separately. it is unique column number and names contraint
             ]
 
     def run_tests(schema):
@@ -137,7 +137,7 @@ def test_ingest_iterator(tmp_path):
         assert len(tbl) == tbl_len * 2
         assert len(tbl.list_versions()) == 2
         db.drop_database()
-        
+
     run_tests(arrow_schema)
     run_tests(PydanticSchema)
 


### PR DESCRIPTION
It improves the UX as iterators can be of any type supported by the table (plus recordbatch) & there is no separate requirement. 
Also expands the test cases for pydantic & arrow schema.
If this is looks good I'll update the docs.

Example usage:
```
class Content(LanceModel):
    vector: vector(2)
    item: str
    price: float

def make_batches():
    for _ in range(5):
        yield from [ 
        # pandas
        pd.DataFrame({
            "vector": [[3.1, 4.1], [1, 1]],
            "item": ["foo", "bar"],
            "price": [10.0, 20.0],
        }),
        
        # pylist
        [
            {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
            {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
        ],

        # recordbatch
        pa.RecordBatch.from_arrays(
            [
                pa.array([[3.1, 4.1], [5.9, 26.5]], pa.list_(pa.float32(), 2)),
                pa.array(["foo", "bar"]),
                pa.array([10.0, 20.0]),
            ], 
            ["vector", "item", "price"],
        ),

        # pydantic list
        [
            Content(vector=[3.1, 4.1], item="foo", price=10.0),
            Content(vector=[5.9, 26.5], item="bar", price=20.0),
        ]]

db = lancedb.connect("db")
tbl = db.create_table("tabley", make_batches(), schema=Content, mode="overwrite")

tbl.add(make_batches())
```
Same should with arrow schema.
