### PR TITLE
Revert "Bump version: 0.2.4 → 0.2.5"

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.5
+current_version = 0.2.4
 commit = True
 message = Bump version: {current_version} → {new_version}
 tag = True

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vectordb",
-  "version": "0.2.5",
+  "version": "0.2.4",
   "description": " Serverless, low-latency vector database for AI applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -78,10 +78,10 @@
     }
   },
   "optionalDependencies": {
-    "@lancedb/vectordb-darwin-arm64": "0.2.5",
-    "@lancedb/vectordb-darwin-x64": "0.2.5",
-    "@lancedb/vectordb-linux-arm64-gnu": "0.2.5",
-    "@lancedb/vectordb-linux-x64-gnu": "0.2.5",
-    "@lancedb/vectordb-win32-x64-msvc": "0.2.5"
+    "@lancedb/vectordb-darwin-arm64": "0.2.4",
+    "@lancedb/vectordb-darwin-x64": "0.2.4",
+    "@lancedb/vectordb-linux-arm64-gnu": "0.2.4",
+    "@lancedb/vectordb-linux-x64-gnu": "0.2.4",
+    "@lancedb/vectordb-win32-x64-msvc": "0.2.4"
   }
 }

--- a/rust/ffi/node/Cargo.toml
+++ b/rust/ffi/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectordb-node"
-version = "0.2.5"
+version = "0.2.4"
 description = "Serverless, low-latency vector database for AI applications"
 license = "Apache-2.0"
 edition = "2018"

--- a/rust/vectordb/Cargo.toml
+++ b/rust/vectordb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectordb"
-version = "0.2.5"
+version = "0.2.4"
 edition = "2021"
 description = "Serverless, low-latency vector database for AI applications"
 license = "Apache-2.0"


### PR DESCRIPTION
This reverts commit 87e9a0250f80dc9672d71837bc9c17b228933f16.

I triggered the nodejs release commit GHA by mistake. Reverting it.
The tag will be removed manually.