### PR TITLE
ci: fix docs build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -66,3 +66,36 @@ jobs:
       run: black --check --diff --no-color --quiet .
     - name: Run tests
       run: pytest -m "not slow" -x -v --durations=30 tests
+  pydantic1x:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-minor-version: [ "8" ]
+    runs-on: "ubuntu-22.04"
+    defaults:
+      run:
+        shell: bash
+        working-directory: python
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Install lancedb
+      run: |
+        pip install "pydantic<2"
+        pip install -e .[tests]
+        pip install tantivy@git+https://github.com/quickwit-oss/tantivy-py#164adc87e1a033117001cf70e38c82a53014d985
+        pip install pytest pytest-mock black isort
+    - name: Black
+      run: black --check --diff --no-color --quiet .
+    - name: isort
+      run: isort --check --diff --quiet .
+    - name: Run tests
+      run: pytest -m "not slow" -x -v --durations=30 tests
+    - name: doctest
+      run: pytest --doctest-modules lancedb

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,9 +68,6 @@ jobs:
       run: pytest -m "not slow" -x -v --durations=30 tests
   pydantic1x:
     timeout-minutes: 30
-    strategy:
-      matrix:
-        python-minor-version: [ "8" ]
     runs-on: "ubuntu-22.04"
     defaults:
       run:
@@ -84,7 +81,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install lancedb
       run: |
         pip install "pydantic<2"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -94,5 +94,5 @@ jobs:
       run: isort --check --diff --quiet .
     - name: Run tests
       run: pytest -m "not slow" -x -v --durations=30 tests
-    - name: doctest
-      run: pytest --doctest-modules lancedb
+    # - name: doctest
+    #  run: pytest --doctest-modules lancedb

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -84,17 +84,8 @@ A Table is a collection of Records in a LanceDB Database. You can follow along o
     ```
 
     ### From Pydantic Models
-    When you create an empty table without data, you must specify the table schema.
     LanceDB supports creating tables by specifying a pyarrow schema or a specialized
     pydantic model called LanceModel.
-
-    For example, the following Content model specifies a table with 5 columns: 
-    movie_id, vector, genres, title, and imdb_id. When you create a table, you can
-    pass the class as the value of the `schema` parameter to `create_table`. 
-    The `vector` column is a `Vector` type, which is a specialized pydantic type that
-    can be configured with the vector dimensions. It is also important to note that
-    LanceDB only understands subclasses of `lancedb.pydantic.LanceModel` 
-    (which itself derives from `pydantic.BaseModel`).
 
     ```python
     from lancedb.pydantic import Vector, LanceModel

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -84,7 +84,17 @@ A Table is a collection of Records in a LanceDB Database. You can follow along o
     ```
 
     ### From Pydantic Models
-    LanceDB supports to create Apache Arrow Schema from a Pydantic BaseModel via pydantic_to_schema() method.
+    When you create an empty table without data, you must specify the table schema.
+    LanceDB supports creating tables by specifying a pyarrow schema or a specialized
+    pydantic model called LanceModel.
+
+    For example, the following Content model specifies a table with 5 columns: 
+    movie_id, vector, genres, title, and imdb_id. When you create a table, you can
+    pass the class as the value of the `schema` parameter to `create_table`. 
+    The `vector` column is a `Vector` type, which is a specialized pydantic type that
+    can be configured with the vector dimensions. It is also important to note that
+    LanceDB only understands subclasses of `lancedb.pydantic.LanceModel` 
+    (which itself derives from `pydantic.BaseModel`).
 
     ```python
     from lancedb.pydantic import Vector, LanceModel

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -84,8 +84,7 @@ A Table is a collection of Records in a LanceDB Database. You can follow along o
     ```
 
     ### From Pydantic Models
-    LanceDB supports creating tables by specifying a pyarrow schema or a specialized
-    pydantic model called LanceModel.
+    LanceDB supports to create Apache Arrow Schema from a Pydantic BaseModel via pydantic_to_schema() method.
 
     ```python
     from lancedb.pydantic import Vector, LanceModel

--- a/docs/src/python/python.md
+++ b/docs/src/python/python.md
@@ -26,18 +26,6 @@ pip install lancedb
 
 ## Embeddings
 
-::: lancedb.embeddings.functions.EmbeddingFunctionRegistry
-
-::: lancedb.embeddings.functions.EmbeddingFunction
-
-::: lancedb.embeddings.functions.TextEmbeddingFunction
-
-::: lancedb.embeddings.functions.SentenceTransformerEmbeddings
-
-::: lancedb.embeddings.functions.OpenAIEmbeddings
-
-::: lancedb.embeddings.functions.OpenClipEmbeddings
-
 ::: lancedb.embeddings.with_embeddings
 
 ## Context

--- a/docs/src/python/python.md
+++ b/docs/src/python/python.md
@@ -26,15 +26,19 @@ pip install lancedb
 
 ## Embeddings
 
-::: lancedb.embeddings.with_embeddings
-
 ::: lancedb.embeddings.functions.EmbeddingFunctionRegistry
 
-::: lancedb.embeddings.functions.EmbeddingFunctionModel
+::: lancedb.embeddings.functions.EmbeddingFunction
 
-::: lancedb.embeddings.functions.TextEmbeddingFunctionModel
-    
-::: lancedb.embeddings.functions.SentenceTransformerEmbeddingFunction
+::: lancedb.embeddings.functions.TextEmbeddingFunction
+
+::: lancedb.embeddings.functions.SentenceTransformerEmbeddings
+
+::: lancedb.embeddings.functions.OpenAIEmbeddings
+
+::: lancedb.embeddings.functions.OpenClipEmbeddings
+
+::: lancedb.embeddings.with_embeddings
 
 ## Context
 

--- a/python/lancedb/conftest.py
+++ b/python/lancedb/conftest.py
@@ -36,6 +36,5 @@ class MockTextEmbeddingFunction(TextEmbeddingFunction):
         emb /= np.linalg.norm(emb)
         return emb
 
-    @property
     def ndims(self):
         return 10

--- a/python/lancedb/embeddings/functions.py
+++ b/python/lancedb/embeddings/functions.py
@@ -52,7 +52,7 @@ class EmbeddingFunctionRegistry:
     ...         return [np.random.rand(self.ndims) for _ in range(len(texts))]
     ...
     >>> registry.get("my-embedding-function")
-    <class '__main__.MyEmbeddingFunction'>
+    <class 'lancedb.embeddings.functions.MyEmbeddingFunction'>
     """
 
     @classmethod

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -136,11 +136,9 @@ def test_ingest_iterator(tmp_path):
     def run_tests(schema):
         db = lancedb.connect(tmp_path)
         tbl = db.create_table("table2", make_batches(), schema=schema, mode="overwrite")
-
         tbl.to_pandas()
         assert tbl.search([3.1, 4.1]).limit(1).to_df()["_distance"][0] == 0.0
         assert tbl.search([5.9, 26.5]).limit(1).to_df()["_distance"][0] == 0.0
-
         tbl_len = len(tbl)
         tbl.add(make_batches())
         assert tbl_len == 50

--- a/python/tests/test_embeddings_slow.py
+++ b/python/tests/test_embeddings_slow.py
@@ -12,14 +12,14 @@
 #  limitations under the License.
 import io
 
+import lancedb
 import numpy as np
 import pandas as pd
 import pytest
 import requests
-
-import lancedb
 from lancedb.embeddings import EmbeddingFunctionRegistry
 from lancedb.pydantic import LanceModel, Vector
+
 
 # These are integration tests for embedding functions.
 # They are slow because they require downloading models
@@ -35,7 +35,7 @@ def test_sentence_transformer(alias, tmp_path):
 
     class Words(LanceModel):
         text: str = func.SourceField()
-        vector: Vector(func.ndims) = func.VectorField()
+        vector: Vector(func.ndims()) = func.VectorField()
 
     table = db.create_table("words", schema=Words)
     table.add(
@@ -75,8 +75,8 @@ def test_openclip(tmp_path):
         label: str
         image_uri: str = func.SourceField()
         image_bytes: bytes = func.SourceField()
-        vector: Vector(func.ndims) = func.VectorField()
-        vec_from_bytes: Vector(func.ndims) = func.VectorField()
+        vector: Vector(func.ndims()) = func.VectorField()
+        vec_from_bytes: Vector(func.ndims()) = func.VectorField()
 
     table = db.create_table("images", schema=Images)
     labels = ["cat", "cat", "dog", "dog", "horse", "horse"]

--- a/python/tests/test_embeddings_slow.py
+++ b/python/tests/test_embeddings_slow.py
@@ -12,14 +12,14 @@
 #  limitations under the License.
 import io
 
-import lancedb
 import numpy as np
 import pandas as pd
 import pytest
 import requests
+
+import lancedb
 from lancedb.embeddings import EmbeddingFunctionRegistry
 from lancedb.pydantic import LanceModel, Vector
-
 
 # These are integration tests for embedding functions.
 # They are slow because they require downloading models

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+
 from lancedb.conftest import MockTextEmbeddingFunction
 from lancedb.db import LanceDBConnection
 from lancedb.embeddings import EmbeddingFunctionConfig, EmbeddingFunctionRegistry

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -21,7 +21,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-
 from lancedb.conftest import MockTextEmbeddingFunction
 from lancedb.db import LanceDBConnection
 from lancedb.embeddings import EmbeddingFunctionConfig, EmbeddingFunctionRegistry
@@ -385,7 +384,7 @@ def test_add_with_embedding_function(db):
 
     class MyTable(LanceModel):
         text: str = emb.SourceField()
-        vector: Vector(emb.ndims) = emb.VectorField()
+        vector: Vector(emb.ndims()) = emb.VectorField()
 
     table = LanceTable.create(db, "my_table", schema=MyTable)
 

--- a/rust/vectordb/src/database.rs
+++ b/rust/vectordb/src/database.rs
@@ -231,6 +231,7 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use std::fs::create_dir_all;
+
     use tempfile::tempdir;
 
     use crate::database::Database;


### PR DESCRIPTION
python/python.md contains typos in the class references