### PR TITLE
ci: fix docs references

### DIFF
--- a/docs/src/python/python.md
+++ b/docs/src/python/python.md
@@ -30,11 +30,11 @@ pip install lancedb
 
 ::: lancedb.embeddings.functions.EmbeddingFunctionRegistry
 
-::: lancedb.embeddings.functions.EmbeddingFunctionModel
+::: lancedb.embeddings.functions.EmbeddingFunction
 
-::: lancedb.embeddings.functions.TextEmbeddingFunctionModel
+::: lancedb.embeddings.functions.TextEmbeddingFunction
     
-::: lancedb.embeddings.functions.SentenceTransformerEmbeddingFunction
+::: lancedb.embeddings.functions.SentenceTransformerEmbeddings
 
 ## Context
 


### PR DESCRIPTION
Fix incorrect class references in python docs