### PR TITLE
feat: add lancedb.__version__

### DIFF
--- a/python/lancedb/__init__.py
+++ b/python/lancedb/__init__.py
@@ -11,11 +11,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import importlib.metadata
 from typing import Optional
 
 from .db import URI, DBConnection, LanceDBConnection
 from .remote.db import RemoteDBConnection
 from .schema import vector
+
+__version__ = importlib.metadata.version("lancedb")
 
 
 def connect(


### PR DESCRIPTION
This is read from importlib package version which comes from pyproject.toml. This is so that we don't need to specify the version in multiple places and bumpversion works well.

Closes #468 