### PR TITLE
fix: upgrade lance to 0.7.5 and add tests for searching empty dataset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.dependencies]
-lance = { "version" = "=0.7.4", "features" = ["dynamodb"] }
-lance-linalg = { "version" = "=0.7.4" }
+lance = { "version" = "=0.7.5", "features" = ["dynamodb"] }
+lance-linalg = { "version" = "=0.7.5" }
 # Note that this one does not include pyarrow
 arrow = { version = "43.0.0", optional = false }
 arrow-array = "43.0"


### PR DESCRIPTION
This PR upgrade lance to `0.7.5`, which include fixes for searching an empty dataset.

This PR also adds two tests in node SDK to make sure searching empty dataset do no throw