### PR TITLE
[Python] Fix attrs dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "tqdm",
     "aiohttp",
     "pydantic",
-    "attr",
+    "attrs",
     "semver>=3.0",
     "cachetools"
 ]


### PR DESCRIPTION
The `attr` project is unrelated to `attrs` that also provides the `attr` namespace (see also <https://hynek.me/articles/import-attrs/>).

It used to _usually_ work, because attrs is a dependency of aiohttp and somehow took precedence over `attr`'s `attr`.

Yes, sorry, it's a mess.