### PR TITLE
fix: define minimum dependency versions

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,12 +3,12 @@ name = "lancedb"
 version = "0.2.5"
 dependencies = [
     "pylance==0.7.4",
-    "ratelimiter",
-    "retry",
-    "tqdm",
+    "ratelimiter~=1.0",
+    "retry>=0.9.2",
+    "tqdm>=4.1.0",
     "aiohttp",
-    "pydantic",
-    "attrs",
+    "pydantic>=1.10",
+    "attrs>=21.3.0",
     "semver>=3.0",
     "cachetools"
 ]


### PR DESCRIPTION
Closes #513

For each of these, I found the minimum version that would allow the unit tests to pass.