### PR TITLE
feat(python): expose prefilter to lancedb

### DIFF
--- a/python/lancedb/embeddings/functions.py
+++ b/python/lancedb/embeddings/functions.py
@@ -26,6 +26,7 @@ import numpy as np
 import pyarrow as pa
 from cachetools import cached
 from pydantic import BaseModel, Field, PrivateAttr
+from tqdm import tqdm
 
 
 class EmbeddingFunctionRegistry:
@@ -514,7 +515,7 @@ class OpenClipEmbeddings(EmbeddingFunction):
                 executor.submit(self.generate_image_embedding, image)
                 for image in images
             ]
-            return [future.result() for future in futures]
+            return [future.result() for future in tqdm(futures)]
 
     def generate_image_embedding(
         self, image: Union[str, bytes, "PIL.Image.Image"]
@@ -557,7 +558,7 @@ class OpenClipEmbeddings(EmbeddingFunction):
         """
         encode a single image tensor and optionally normalize the output
         """
-        image_features = self._model.encode_image(image_tensor)
+        image_features = self._model.encode_image(image_tensor.to(self.device))
         if self.normalize:
             image_features /= image_features.norm(dim=-1, keepdim=True)
         return image_features.cpu().numpy().squeeze()

--- a/python/lancedb/query.py
+++ b/python/lancedb/query.py
@@ -39,7 +39,7 @@ class Query(pydantic.BaseModel):
     filter: Optional[str] = None
 
     # if True then apply the filter before vector search
-    is_prefilter: bool = False
+    prefilter: bool = False
 
     # top k results to return
     k: int
@@ -324,7 +324,7 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
         query = Query(
             vector=vector,
             filter=self._where,
-            is_prefilter=self._prefilter,
+            prefilter=self._prefilter,
             k=self._limit,
             metric=self._metric,
             columns=self._columns,

--- a/python/lancedb/remote/table.py
+++ b/python/lancedb/remote/table.py
@@ -98,6 +98,8 @@ class RemoteTable(Table):
         return LanceVectorQueryBuilder(self, query, vector_column_name)
 
     def _execute_query(self, query: Query) -> pa.Table:
+        if query.is_prefilter:
+            raise NotImplementedError("Cloud support for prefiltering is coming soon")
         result = self._conn._client.query(self._name, query)
         return self._conn._loop.run_until_complete(result).to_arrow()
 

--- a/python/lancedb/remote/table.py
+++ b/python/lancedb/remote/table.py
@@ -98,7 +98,7 @@ class RemoteTable(Table):
         return LanceVectorQueryBuilder(self, query, vector_column_name)
 
     def _execute_query(self, query: Query) -> pa.Table:
-        if query.is_prefilter:
+        if query.prefilter:
             raise NotImplementedError("Cloud support for prefiltering is coming soon")
         result = self._conn._client.query(self._name, query)
         return self._conn._loop.run_until_complete(result).to_arrow()

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -844,9 +844,16 @@ class LanceTable(Table):
 
     def _execute_query(self, query: Query) -> pa.Table:
         ds = self.to_lance()
+        if query.is_prefilter:
+            for idx in ds.list_indices():
+                if query.vector_column in idx["fields"]:
+                    raise NotImplementedError(
+                        "Prefiltering for indexed vector column is coming soon."
+                    )
         return ds.to_table(
             columns=query.columns,
             filter=query.filter,
+            prefilter=query.is_prefilter,
             nearest={
                 "column": query.vector_column,
                 "q": query.vector,

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -844,7 +844,7 @@ class LanceTable(Table):
 
     def _execute_query(self, query: Query) -> pa.Table:
         ds = self.to_lance()
-        if query.is_prefilter:
+        if query.prefilter:
             for idx in ds.list_indices():
                 if query.vector_column in idx["fields"]:
                     raise NotImplementedError(
@@ -853,7 +853,7 @@ class LanceTable(Table):
         return ds.to_table(
             columns=query.columns,
             filter=query.filter,
-            prefilter=query.is_prefilter,
+            prefilter=query.prefilter,
             nearest={
                 "column": query.vector_column,
                 "q": query.vector,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 name = "lancedb"
 version = "0.2.5"
 dependencies = [
-    "pylance==0.7.4",
+    "pylance==0.8.0",
     "ratelimiter~=1.0",
     "retry>=0.9.2",
     "tqdm>=4.1.0",

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -38,7 +38,7 @@ class MockTable:
         return ds.to_table(
             columns=query.columns,
             filter=query.filter,
-            prefilter=query.is_prefilter,
+            prefilter=query.prefilter,
             nearest={
                 "column": query.vector_column,
                 "q": query.vector,

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -38,6 +38,7 @@ class MockTable:
         return ds.to_table(
             columns=query.columns,
             filter=query.filter,
+            prefilter=query.is_prefilter,
             nearest={
                 "column": query.vector_column,
                 "q": query.vector,
@@ -93,6 +94,25 @@ def test_query_builder(table):
 
 def test_query_builder_with_filter(table):
     df = LanceVectorQueryBuilder(table, [0, 0], "vector").where("id = 2").to_df()
+    assert df["id"].values[0] == 2
+    assert all(df["vector"].values[0] == [3, 4])
+
+
+def test_query_builder_with_prefilter(table):
+    df = (
+        LanceVectorQueryBuilder(table, [0, 0], "vector")
+        .where("id = 2")
+        .limit(1)
+        .to_df()
+    )
+    assert len(df) == 0
+
+    df = (
+        LanceVectorQueryBuilder(table, [0, 0], "vector")
+        .where("id = 2", prefilter=True)
+        .limit(1)
+        .to_df()
+    )
     assert df["id"].values[0] == 2
     assert all(df["vector"].values[0] == [3, 4])
 


### PR DESCRIPTION
We have experimental support for prefiltering (without ANN) in pylance. This means that we can now apply a filter BEFORE vector search is performed. This can be done via the `.where(filter_string, prefilter=True)` kwargs of the query.

Limitations:
- When connecting to LanceDB cloud, `prefilter=True` will raise NotImplemented
- When an ANN index is present, `prefilter=True` will raise NotImplemented
- This option is not available for full text search query
- This option is not available for empty search query (just filter/project)

Additional changes in this PR:
- Bump pylance version to v0.8.0 which supports the experimental prefiltering.