### PR TITLE
docs: show source of documented functions

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,7 +37,7 @@ plugins:
           docstring_style: numpy
         rendering:
           heading_level: 4
-          show_source: false
+          show_source: true
           show_symbol_type_in_heading: true
           show_signature_annotations: true
           show_root_heading: true


### PR DESCRIPTION
Proposal to resolve #563.
This globally sets `show_source: true` (per file setting is also possible, [see here](https://mkdocstrings.github.io/usage/).
Example of how docs would look:
![image](https://github.com/lancedb/lancedb/assets/54589/f4d41290-8fd5-4833-8747-6697e39dea88)
Expanded:
![image](https://github.com/lancedb/lancedb/assets/54589/9ec7d585-9dee-40ab-bd18-c24a49dacb94)