### PR TITLE
feat: add timezone handling for datetime in pydantic

### DIFF
--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -118,6 +118,84 @@ This guide will show how to create tables, insert data into them, and update the
     table = db.create_table(table_name, schema=Content)
     ```
 
+    #### Nested schemas
+
+    Sometimes your data model may contain nested objects.
+    For example, you may want to store the document string
+    and the document soure name as a nested Document object:
+
+    ```python
+    class Document(BaseModel):
+        content: str
+        source: str
+    ```
+
+    This can be used as the type of a LanceDB table column:
+
+    ```python
+    class NestedSchema(LanceModel):
+        id: str
+        vector: Vector(1536)
+        document: Document
+
+    tbl = db.create_table("nested_table", schema=NestedSchema, mode="overwrite")
+    ```
+
+    This creates a struct column called "document" that has two subfields 
+    called "content" and "source":
+
+    ```
+    In [28]: tbl.schema
+    Out[28]:
+    id: string not null
+    vector: fixed_size_list<item: float>[1536] not null
+        child 0, item: float
+    document: struct<content: string not null, source: string not null> not null
+        child 0, content: string not null
+        child 1, source: string not null    
+    ```
+
+    #### Validators
+
+    Note that neither pydantic nor pyarrow automatically validates that input data
+    is of the *correct* timezone, but this is easy to add as a custom field validator:
+
+    ```python
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    from lancedb.pydantic import LanceModel
+    from pydantic import Field, field_validator, ValidationError, ValidationInfo
+
+    tzname = "America/New_York"
+    tz = ZoneInfo(tzname)
+
+    class TestModel(LanceModel):
+        dt_with_tz: datetime = Field(json_schema_extra={"tz": tzname})
+
+        @field_validator('dt_with_tz')
+        @classmethod
+        def tz_must_match(cls, dt: datetime) -> datetime:
+            assert dt.tzinfo == tz
+            return dt        
+
+    ok = TestModel(dt_with_tz=datetime.now(tz))
+
+    try:
+        TestModel(dt_with_tz=datetime.now(ZoneInfo("Asia/Shanghai")))
+        assert 0 == 1, "this should raise ValidationError"
+    except ValidationError:
+        print("A ValidationError was raised.")
+        pass
+    ```
+
+    When you run this code it should print "A ValidationError was raised."
+
+    #### Pydantic custom types
+
+    LanceDB does NOT yet support converting pydantic custom types. If this is something you need,
+    please file a feature request on the [LanceDB Github repo](https://github.com/lancedb/lancedb/issues/new).
+
     ### Using Iterators / Writing Large Datasets
 
     It is recommended to use itertators to add large datasets in batches when creating your table in one go. This does not create multiple versions of your dataset unlike manually adding batches using `table.add()`
@@ -153,7 +231,7 @@ This guide will show how to create tables, insert data into them, and update the
     You can also use iterators of other types like Pandas dataframe or Pylists directly in the above example.
 
     ## Creating Empty Table
-    You can also create empty tables in python. Initialize it with schema and later ingest data into it.
+    You can create empty tables in python. Initialize it with schema and later ingest data into it.
 
     ```python
     import lancedb

--- a/python/lancedb/pydantic.py
+++ b/python/lancedb/pydantic.py
@@ -166,11 +166,11 @@ def _py_type_to_arrow_type(py_type: Type[Any], field: FieldInfo) -> pa.DataType:
     elif py_type == datetime:
         tz = get_extras(field, "tz")
         return pa.timestamp("us", tz=tz)
-    elif py_type.__origin__ in (list, tuple):
+    elif getattr(py_type, "__origin__", None) in (list, tuple):
         child = py_type.__args__[0]
-        return pa.list_(_py_type_to_arrow_type(child))
+        return pa.list_(_py_type_to_arrow_type(child, field))
     raise TypeError(
-        f"Converting Pydantic type to Arrow Type: unsupported type {py_type}"
+        f"Converting Pydantic type to Arrow Type: unsupported type {py_type}."
     )
 
 

--- a/python/lancedb/pydantic.py
+++ b/python/lancedb/pydantic.py
@@ -165,7 +165,7 @@ def _py_type_to_arrow_type(py_type: Type[Any], field: FieldInfo) -> pa.DataType:
         return pa.date32()
     elif py_type == datetime:
         tz = get_extras(field, "tz")
-        return pa.timestamp("us", tz=tz)    
+        return pa.timestamp("us", tz=tz)
     elif py_type.__origin__ in (list, tuple):
         child = py_type.__args__[0]
         return pa.list_(_py_type_to_arrow_type(child))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 repository = "https://github.com/lancedb/lancedb"
 
 [project.optional-dependencies]
-tests = ["pandas>=1.4", "pytest", "pytest-mock", "pytest-asyncio", "requests", "duckdb"]
+tests = ["pandas>=1.4", "pytest", "pytest-mock", "pytest-asyncio", "requests", "duckdb", "pytz"]
 dev = ["ruff", "pre-commit", "black"]
 docs = ["mkdocs", "mkdocs-jupyter", "mkdocs-material", "mkdocstrings[python]"]
 clip = ["torch", "pillow", "open-clip"]

--- a/python/tests/test_pydantic.py
+++ b/python/tests/test_pydantic.py
@@ -39,14 +39,14 @@ def test_pydantic_to_arrow():
         id: int
         s: str
         vec: list[float]
-        li: List[int]
-        lili: List[List[float]]
-        litu: List[Tuple[float, float]]
+        li: list[int]
+        lili: list[list[float]]
+        litu: list[tuple[float, float]]
         opt: Optional[str] = None
         st: StructModel
         dt: date
         dtt: datetime
-        dt_with_tz: datetime = Field(tz="Asia/Shanghai")
+        dt_with_tz: datetime = Field(json_schema_extra={"tz": "Asia/Shanghai"})
         # d: dict
 
     m = TestModel(
@@ -88,6 +88,10 @@ def test_pydantic_to_arrow():
     assert schema == expect_schema
 
 
+@pytest.mark.skipif(
+    sys.version_info > (3, 8),
+    reason="using native type alias requires python3.9 or higher",
+)
 def test_pydantic_to_arrow_py38():
     class StructModel(pydantic.BaseModel):
         a: str
@@ -104,7 +108,7 @@ def test_pydantic_to_arrow_py38():
         st: StructModel
         dt: date
         dtt: datetime
-        dt_with_tz: datetime = Field(tz="Asia/Shanghai")
+        dt_with_tz: datetime = Field(json_schema_extra={"tz": "Asia/Shanghai"})
         # d: dict
 
     m = TestModel(

--- a/python/tests/test_pydantic.py
+++ b/python/tests/test_pydantic.py
@@ -59,9 +59,8 @@ def test_pydantic_to_arrow():
         st=StructModel(a="a", b=1.0),
         dt=date.today(),
         dtt=datetime.now(),
-        dtttz=datetime.now(pytz.timezone("Asia/Shanghai"))),
+        dt_with_tz=datetime.now(pytz.timezone("Asia/Shanghai")),
     )
-        
 
     schema = pydantic_to_schema(TestModel)
 
@@ -105,7 +104,7 @@ def test_pydantic_to_arrow_py38():
         st: StructModel
         dt: date
         dtt: datetime
-<<<<<<< HEAD
+        dt_with_tz: datetime = Field(tz="Asia/Shanghai")
         # d: dict
 
     m = TestModel(
@@ -118,9 +117,8 @@ def test_pydantic_to_arrow_py38():
         st=StructModel(a="a", b=1.0),
         dt=date.today(),
         dtt=datetime.now(),
+        dt_with_tz=datetime.now(pytz.timezone("Asia/Shanghai")),
     )
-=======
->>>>>>> e1589c8 (feat: add timezone handling for datetime in pydantic)
 
     schema = pydantic_to_schema(TestModel)
 
@@ -142,6 +140,7 @@ def test_pydantic_to_arrow_py38():
             ),
             pa.field("dt", pa.date32(), False),
             pa.field("dtt", pa.timestamp("us"), False),
+            pa.field("dt_with_tz", pa.timestamp("us", tz="Asia/Shanghai"), False),
         ]
     )
     assert schema == expect_schema

--- a/python/tests/test_pydantic.py
+++ b/python/tests/test_pydantic.py
@@ -13,6 +13,7 @@
 
 
 import json
+import pytz
 import sys
 from datetime import date, datetime
 from typing import List, Optional, Tuple
@@ -45,6 +46,7 @@ def test_pydantic_to_arrow():
         st: StructModel
         dt: date
         dtt: datetime
+        dt_with_tz: datetime = Field(tz="Asia/Shanghai")
         # d: dict
 
     m = TestModel(
@@ -57,7 +59,9 @@ def test_pydantic_to_arrow():
         st=StructModel(a="a", b=1.0),
         dt=date.today(),
         dtt=datetime.now(),
+        dtttz=datetime.now(pytz.timezone("Asia/Shanghai"))),
     )
+        
 
     schema = pydantic_to_schema(TestModel)
 
@@ -79,6 +83,7 @@ def test_pydantic_to_arrow():
             ),
             pa.field("dt", pa.date32(), False),
             pa.field("dtt", pa.timestamp("us"), False),
+            pa.field("dt_with_tz", pa.timestamp("us", tz="Asia/Shanghai"), False),
         ]
     )
     assert schema == expect_schema
@@ -100,6 +105,7 @@ def test_pydantic_to_arrow_py38():
         st: StructModel
         dt: date
         dtt: datetime
+<<<<<<< HEAD
         # d: dict
 
     m = TestModel(
@@ -113,6 +119,8 @@ def test_pydantic_to_arrow_py38():
         dt=date.today(),
         dtt=datetime.now(),
     )
+=======
+>>>>>>> e1589c8 (feat: add timezone handling for datetime in pydantic)
 
     schema = pydantic_to_schema(TestModel)
 

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -142,6 +142,7 @@ def test_add(db):
 
 
 def test_add_pydantic_model(db):
+<<<<<<< HEAD
     # https://github.com/lancedb/lancedb/issues/562
 
     class Metadata(BaseModel):
@@ -180,6 +181,23 @@ def test_add_pydantic_model(db):
 
     really_flattened = tbl.search([0.0, 0.0]).limit(1).to_pandas(flatten=True)
     assert len(really_flattened.columns) == 7
+=======
+    class TestModel(LanceModel):
+        vector: Vector(16)
+        li: List[int]
+        dt: datetime
+        dt_with_tz: datetime = Field(tz="Asia/Kolkata")
+
+    data = TestModel(
+        vector=list(range(16)),
+        li=[1, 2, 3],
+        dt=datetime.now(),
+        dt_with_tz=datetime.now(tz=pytz.timezone("Asia/Kolkata")),
+    )
+    table = LanceTable.create(db, "test", data=[data])
+    assert len(table) == 1
+    assert table.schema == TestModel.to_arrow_schema()
+>>>>>>> e1589c8 (feat: add timezone handling for datetime in pydantic)
 
 
 def _add(table, schema):

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -142,7 +142,6 @@ def test_add(db):
 
 
 def test_add_pydantic_model(db):
-<<<<<<< HEAD
     # https://github.com/lancedb/lancedb/issues/562
 
     class Metadata(BaseModel):
@@ -181,23 +180,6 @@ def test_add_pydantic_model(db):
 
     really_flattened = tbl.search([0.0, 0.0]).limit(1).to_pandas(flatten=True)
     assert len(really_flattened.columns) == 7
-=======
-    class TestModel(LanceModel):
-        vector: Vector(16)
-        li: List[int]
-        dt: datetime
-        dt_with_tz: datetime = Field(tz="Asia/Kolkata")
-
-    data = TestModel(
-        vector=list(range(16)),
-        li=[1, 2, 3],
-        dt=datetime.now(),
-        dt_with_tz=datetime.now(tz=pytz.timezone("Asia/Kolkata")),
-    )
-    table = LanceTable.create(db, "test", data=[data])
-    assert len(table) == 1
-    assert table.schema == TestModel.to_arrow_schema()
->>>>>>> e1589c8 (feat: add timezone handling for datetime in pydantic)
 
 
 def _add(table, schema):


### PR DESCRIPTION
If you add timezone information in the Field annotation for a datetime then that will now be passed to the pyarrow data type.

I'm not sure how pyarrow enforces timezones, right now, it silently coerces to the timezone given in the column regardless of whether the input had the matching timezone or not. This is probably not the right behavior. Though we could just make it so the user has to make the pydantic model do the validation instead of doing that at the pyarrow conversion layer.