### PR TITLE
chore: bump lance version in python/rust lancedb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.dependencies]
-lance = { "version" = "=0.8.5", "features" = ["dynamodb"] }
-lance-linalg = { "version" = "=0.8.5" }
-lance-testing = { "version" = "=0.8.5" }
+lance = { "version" = "=0.8.6", "features" = ["dynamodb"] }
+lance-linalg = { "version" = "=0.8.6" }
+lance-testing = { "version" = "=0.8.6" }
 # Note that this one does not include pyarrow
 arrow = { version = "47.0.0", optional = false }
 arrow-array = "47.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "lancedb"
 version = "0.3.1"
 dependencies = [
     "deprecation",
-    "pylance==0.8.5",
+    "pylance==0.8.6",
     "ratelimiter~=1.0",
     "retry>=0.9.2",
     "tqdm>=4.1.0",


### PR DESCRIPTION
To include latest v0.8.6