### PR TITLE
feat: add checkout method to table to reuse existing store and connections

### DIFF
--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -153,6 +153,22 @@ impl Table {
         })
     }
 
+    pub async fn checkout_latest(&self) -> Result<Self> {
+        let latest_version_id = self.dataset.latest_version_id().await?;
+        let dataset = if latest_version_id == self.dataset.version().version {
+            self.dataset.clone()
+        } else {
+            Arc::new(self.dataset.checkout_version(latest_version_id).await?)
+        };
+
+        Ok(Table {
+            name: self.name.clone(),
+            uri: self.uri.clone(),
+            dataset,
+            store_wrapper: self.store_wrapper.clone(),
+        })
+    }
+
     fn get_table_name(uri: &str) -> Result<String> {
         let path = Path::new(uri);
         let name = path


### PR DESCRIPTION
Prior to this PR, to get a new version of a table, we need to re-open the table. This has a few downsides w.r.t. performance:
* Object store is recreated, which takes time and throws away existing warm connections
* Commit handler is thrown aways as well, which also may contain warm connections