### PR TITLE
Disable posthog on docs & reduce sentry trace factor

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -150,8 +150,6 @@ nav:
 
 extra_css:
   - styles/global.css
-extra_javascript:
-  - scripts/posthog.js
 
 extra:
   analytics:

--- a/python/lancedb/utils/sentry_log.py
+++ b/python/lancedb/utils/sentry_log.py
@@ -63,7 +63,7 @@ def set_sentry():
         """
         if "exc_info" in hint:
             exc_type, exc_value, tb = hint["exc_info"]
-            ignored_errors = ["out of memory", "no space left on device", "found none in ranking dict", "testing"]
+            ignored_errors = ["out of memory", "no space left on device", "testing"]
             if any(error in str(exc_value).lower() for error in ignored_errors):
                 return None
 

--- a/python/lancedb/utils/sentry_log.py
+++ b/python/lancedb/utils/sentry_log.py
@@ -63,7 +63,8 @@ def set_sentry():
         """
         if "exc_info" in hint:
             exc_type, exc_value, tb = hint["exc_info"]
-            if "out of memory" in str(exc_value).lower():
+            ignored_errors = ["out of memory", "no space left on device", "found none in ranking dict", "testing"]
+            if any(error in str(exc_value).lower() for error in ignored_errors):
                 return None
 
         if is_git_dir():

--- a/python/lancedb/utils/sentry_log.py
+++ b/python/lancedb/utils/sentry_log.py
@@ -97,7 +97,7 @@ def set_sentry():
             dsn="https://c63ef8c64e05d1aa1a96513361f3ca2f@o4505950840946688.ingest.sentry.io/4505950933614592",
             debug=False,
             include_local_variables=False,
-            traces_sample_rate=1.0,
+            traces_sample_rate=0.5,
             environment="production",  # 'dev' or 'production'
             before_send=before_send,
             ignore_errors=[KeyboardInterrupt, FileNotFoundError, bdb.BdbQuit],


### PR DESCRIPTION
- posthog charges per event and docs events are registered very frequently. We can keep tracking them on GA
- Reduced sentry trace factor 
