### PR TITLE
feat: allow prefiltering with index

### DIFF
--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -872,12 +872,6 @@ class LanceTable(Table):
 
     def _execute_query(self, query: Query) -> pa.Table:
         ds = self.to_lance()
-        if query.prefilter:
-            for idx in ds.list_indices():
-                if query.vector_column in idx["fields"]:
-                    raise NotImplementedError(
-                        "Prefiltering for indexed vector column is coming soon."
-                    )
         return ds.to_table(
             columns=query.columns,
             filter=query.filter,

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -288,11 +288,12 @@ def test_replace_index(tmp_path):
         replace=True,
     )
 
+
 def test_prefilter_with_index(tmp_path):
     db = lancedb.connect(uri=tmp_path)
     data = [
-            {"vector": np.random.rand(128), "item": "foo", "price": float(i)}
-            for i in range(1000)
+        {"vector": np.random.rand(128), "item": "foo", "price": float(i)}
+        for i in range(1000)
     ]
     sample_key = data[100]["vector"]
     table = db.create_table(
@@ -303,5 +304,10 @@ def test_prefilter_with_index(tmp_path):
         num_partitions=2,
         num_sub_vectors=4,
     )
-    table = table.search(sample_key).where("price == 500", prefilter=True).limit(5).to_arrow()
+    table = (
+        table.search(sample_key)
+        .where("price == 500", prefilter=True)
+        .limit(5)
+        .to_arrow()
+    )
     assert table.num_rows == 1

--- a/python/tests/test_db.py
+++ b/python/tests/test_db.py
@@ -287,3 +287,21 @@ def test_replace_index(tmp_path):
         num_sub_vectors=4,
         replace=True,
     )
+
+def test_prefilter_with_index(tmp_path):
+    db = lancedb.connect(uri=tmp_path)
+    data = [
+            {"vector": np.random.rand(128), "item": "foo", "price": float(i)}
+            for i in range(1000)
+    ]
+    sample_key = data[100]["vector"]
+    table = db.create_table(
+        "test",
+        data,
+    )
+    table.create_index(
+        num_partitions=2,
+        num_sub_vectors=4,
+    )
+    table = table.search(sample_key).where("price == 500", prefilter=True).limit(5).to_arrow()
+    assert table.num_rows == 1


### PR DESCRIPTION
Support for prefiltering with an index was added in lance version 0.8.7.  We can remove the lancedb check that prevents this. Closes #261 