### PR TITLE
Exponential standoff retry support for handling rate limited embedding functions

### DIFF
--- a/python/lancedb/conftest.py
+++ b/python/lancedb/conftest.py
@@ -1,9 +1,10 @@
 import os
 import time
+from typing import Any
 
 import numpy as np
 import pytest
-from typing import Any
+
 from .embeddings import EmbeddingFunctionRegistry, TextEmbeddingFunction
 
 # import lancedb so we don't have to in every example

--- a/python/lancedb/embeddings/base.py
+++ b/python/lancedb/embeddings/base.py
@@ -19,8 +19,11 @@ class EmbeddingFunction(BaseModel, ABC):
     For text data, the two will be the same. For multi-modal data, the source column
     might be images and the vector column might be text.
     3. ndims method which returns the number of dimensions of the vector column
-    """ 
-    max_retries: int = 10 # Setitng 0 disables retires. Maybe this should not be enabled by default,
+    """
+
+    max_retries: int = (
+        10  # Setitng 0 disables retires. Maybe this should not be enabled by default,
+    )
     _ndims: int = PrivateAttr()
 
     @classmethod
@@ -48,13 +51,20 @@ class EmbeddingFunction(BaseModel, ABC):
         """
         Compute the embeddings for a given user query with retries
         """
-        return retry_with_exponential_backoff(self.compute_query_embeddings, max_retries=self.max_retries)(*args, **kwargs,)
-    
+        return retry_with_exponential_backoff(
+            self.compute_query_embeddings, max_retries=self.max_retries
+        )(
+            *args,
+            **kwargs,
+        )
+
     def compute_source_embeddings_with_rety(self, *args, **kwargs) -> List[np.array]:
         """
         Compute the embeddings for the source column in the database with retries
         """
-        return retry_with_exponential_backoff(self.compute_source_embeddings, max_retries=self.max_retries)( *args, **kwargs)
+        return retry_with_exponential_backoff(
+            self.compute_source_embeddings, max_retries=self.max_retries
+        )(*args, **kwargs)
 
     def sanitize_input(self, texts: TEXT) -> Union[List[str], np.ndarray]:
         """

--- a/python/lancedb/embeddings/base.py
+++ b/python/lancedb/embeddings/base.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyarrow as pa
 from pydantic import BaseModel, Field, PrivateAttr
 
-from .utils import TEXT
+from .utils import TEXT, retry_with_exponential_backoff
 
 
 class EmbeddingFunction(BaseModel, ABC):
@@ -19,8 +19,8 @@ class EmbeddingFunction(BaseModel, ABC):
     For text data, the two will be the same. For multi-modal data, the source column
     might be images and the vector column might be text.
     3. ndims method which returns the number of dimensions of the vector column
-    """
-
+    """ 
+    max_retries: int = 10 # Setitng 0 disables retires. Maybe this should not be enabled by default,
     _ndims: int = PrivateAttr()
 
     @classmethod
@@ -43,6 +43,18 @@ class EmbeddingFunction(BaseModel, ABC):
         Compute the embeddings for the source column in the database
         """
         pass
+
+    def compute_query_embeddings_with_rety(self, *args, **kwargs) -> List[np.array]:
+        """
+        Compute the embeddings for a given user query with retries
+        """
+        return retry_with_exponential_backoff(self.compute_query_embeddings, max_retries=self.max_retries)(*args, **kwargs,)
+    
+    def compute_source_embeddings_with_rety(self, *args, **kwargs) -> List[np.array]:
+        """
+        Compute the embeddings for the source column in the database with retries
+        """
+        return retry_with_exponential_backoff(self.compute_source_embeddings, max_retries=self.max_retries)( *args, **kwargs)
 
     def sanitize_input(self, texts: TEXT) -> Union[List[str], np.ndarray]:
         """

--- a/python/lancedb/embeddings/base.py
+++ b/python/lancedb/embeddings/base.py
@@ -22,7 +22,7 @@ class EmbeddingFunction(BaseModel, ABC):
     """
 
     max_retries: int = (
-        10  # Setitng 0 disables retires. Maybe this should not be enabled by default,
+        7  # Setitng 0 disables retires. Maybe this should not be enabled by default,
     )
     _ndims: int = PrivateAttr()
 

--- a/python/lancedb/embeddings/base.py
+++ b/python/lancedb/embeddings/base.py
@@ -47,7 +47,7 @@ class EmbeddingFunction(BaseModel, ABC):
         """
         pass
 
-    def compute_query_embeddings_with_rety(self, *args, **kwargs) -> List[np.array]:
+    def compute_query_embeddings_with_retry(self, *args, **kwargs) -> List[np.array]:
         """
         Compute the embeddings for a given user query with retries
         """
@@ -58,7 +58,7 @@ class EmbeddingFunction(BaseModel, ABC):
             **kwargs,
         )
 
-    def compute_source_embeddings_with_rety(self, *args, **kwargs) -> List[np.array]:
+    def compute_source_embeddings_with_retry(self, *args, **kwargs) -> List[np.array]:
         """
         Compute the embeddings for the source column in the database with retries
         """

--- a/python/lancedb/embeddings/cohere.py
+++ b/python/lancedb/embeddings/cohere.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from .base import TextEmbeddingFunction
 from .registry import register
-from .utils import api_key_not_found_help, retry_with_exponential_backoff
+from .utils import api_key_not_found_help
 
 
 @register("cohere")

--- a/python/lancedb/embeddings/cohere.py
+++ b/python/lancedb/embeddings/cohere.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from .base import TextEmbeddingFunction
 from .registry import register
-from .utils import api_key_not_found_help
+from .utils import api_key_not_found_help, retry_with_exponential_backoff
 
 
 @register("cohere")

--- a/python/lancedb/embeddings/utils.py
+++ b/python/lancedb/embeddings/utils.py
@@ -169,7 +169,7 @@ def retry_with_exponential_backoff(
     initial_delay: float = 1,
     exponential_base: float = 2,
     jitter: bool = True,
-    max_retries: int = 10,
+    max_retries: int = 7,
     # errors: tuple = (),
 ):
     """Retry a function with exponential backoff.

--- a/python/lancedb/embeddings/utils.py
+++ b/python/lancedb/embeddings/utils.py
@@ -14,8 +14,8 @@
 import math
 import random
 import socket
-import time
 import sys
+import time
 import urllib.error
 from typing import Callable, List, Union
 
@@ -170,10 +170,10 @@ def retry_with_exponential_backoff(
     exponential_base: float = 2,
     jitter: bool = True,
     max_retries: int = 10,
-    #errors: tuple = (),
+    # errors: tuple = (),
 ):
     """Retry a function with exponential backoff.
-    
+
     Args:
         func (function): The function to be retried.
         initial_delay (float): Initial delay in seconds (default is 1).
@@ -196,7 +196,7 @@ def retry_with_exponential_backoff(
                 return func(*args, **kwargs)
 
             # Currently retrying on all exceptions as there is no way to know the format of the error msgs used by different APIs
-            # We'll log the error and say that it is assumed that if this portion errors out, it's due to rate limit but the user 
+            # We'll log the error and say that it is assumed that if this portion errors out, it's due to rate limit but the user
             # should check the error message to be sure
             except Exception as e:
                 num_retries += 1
@@ -208,7 +208,6 @@ def retry_with_exponential_backoff(
 
                 delay *= exponential_base * (1 + jitter * random.random())
                 LOGGER.info(f"Retrying in {delay:.2f} seconds due to {e}")
-
                 time.sleep(delay)
 
     return wrapper

--- a/python/lancedb/embeddings/utils.py
+++ b/python/lancedb/embeddings/utils.py
@@ -12,7 +12,9 @@
 #  limitations under the License.
 
 import math
+import random
 import socket
+import time
 import sys
 import urllib.error
 from typing import Callable, List, Union
@@ -160,6 +162,56 @@ class FunctionWrapper:
             yield from tqdm(_chunker(arr), total=math.ceil(length / self._batch_size))
         else:
             yield from _chunker(arr)
+
+
+def retry_with_exponential_backoff(
+    func,
+    initial_delay: float = 1,
+    exponential_base: float = 2,
+    jitter: bool = True,
+    max_retries: int = 10,
+    #errors: tuple = (),
+):
+    """Retry a function with exponential backoff.
+    
+    Args:
+        func (function): The function to be retried.
+        initial_delay (float): Initial delay in seconds (default is 1).
+        exponential_base (float): The base for exponential backoff (default is 2).
+        jitter (bool): Whether to add jitter to the delay (default is True).
+        max_retries (int): Maximum number of retries (default is 10).
+        errors (tuple): Tuple of specific exceptions to retry on (default is (openai.error.RateLimitError,)).
+
+    Returns:
+        function: The decorated function.
+    """
+
+    def wrapper(*args, **kwargs):
+        num_retries = 0
+        delay = initial_delay
+
+        # Loop until a successful response or max_retries is hit or an exception is raised
+        while True:
+            try:
+                return func(*args, **kwargs)
+
+            # Currently retrying on all exceptions as there is no way to know the format of the error msgs used by different APIs
+            # We'll log the error and say that it is assumed that if this portion errors out, it's due to rate limit but the user 
+            # should check the error message to be sure
+            except Exception as e:
+                num_retries += 1
+
+                if num_retries > max_retries:
+                    raise Exception(
+                        f"Maximum number of retries ({max_retries}) exceeded."
+                    )
+
+                delay *= exponential_base * (1 + jitter * random.random())
+                LOGGER.info(f"Retrying in {delay:.2f} seconds due to {e}")
+
+                time.sleep(delay)
+
+    return wrapper
 
 
 def url_retrieve(url: str):

--- a/python/lancedb/query.py
+++ b/python/lancedb/query.py
@@ -103,7 +103,7 @@ class LanceQueryBuilder(ABC):
             if not isinstance(query, (list, np.ndarray)):
                 conf = table.embedding_functions.get(vector_column_name)
                 if conf is not None:
-                    query = conf.function.compute_query_embeddings(query)[0]
+                    query = conf.function.compute_query_embeddings_with_retry(query)[0]
                 else:
                     msg = f"No embedding function for {vector_column_name}"
                     raise ValueError(msg)
@@ -114,7 +114,7 @@ class LanceQueryBuilder(ABC):
             else:
                 conf = table.embedding_functions.get(vector_column_name)
                 if conf is not None:
-                    query = conf.function.compute_query_embeddings(query)[0]
+                    query = conf.function.compute_query_embeddings_with_retry(query)[0]
                     return query, "vector"
                 else:
                     return query, "fts"

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -86,7 +86,9 @@ def _append_vector_col(data: pa.Table, metadata: dict, schema: Optional[pa.Schem
     for vector_column, conf in functions.items():
         func = conf.function
         if vector_column not in data.column_names:
-            col_data = func.compute_source_embeddings_with_rety(data[conf.source_column])
+            col_data = func.compute_source_embeddings_with_rety(
+                data[conf.source_column]
+            )
             if schema is not None:
                 dtype = schema.field(vector_column).type
             else:

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -86,7 +86,7 @@ def _append_vector_col(data: pa.Table, metadata: dict, schema: Optional[pa.Schem
     for vector_column, conf in functions.items():
         func = conf.function
         if vector_column not in data.column_names:
-            col_data = func.compute_source_embeddings_with_rety(
+            col_data = func.compute_source_embeddings_with_retry(
                 data[conf.source_column]
             )
             if schema is not None:

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -86,7 +86,7 @@ def _append_vector_col(data: pa.Table, metadata: dict, schema: Optional[pa.Schem
     for vector_column, conf in functions.items():
         func = conf.function
         if vector_column not in data.column_names:
-            col_data = func.compute_source_embeddings(data[conf.source_column])
+            col_data = func.compute_source_embeddings_with_rety(data[conf.source_column])
             if schema is not None:
                 dtype = schema.field(vector_column).type
             else:


### PR DESCRIPTION
Users ingesting data using rate limited apis don't need to manually make the process sleep for counter rate limits
resolves #579