### PR TITLE
[broken] upgrade lance to 0.8.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.dependencies]
-lance = { "version" = "=0.8.14", "features" = ["dynamodb"] }
-lance-linalg = { "version" = "=0.8.14" }
-lance-testing = { "version" = "=0.8.14" }
+lance = { "version" = "=0.8.15", "features" = ["dynamodb"] }
+lance-linalg = { "version" = "=0.8.15" }
+lance-index = { "version" = "=0.8.15" }
+lance-testing = { "version" = "=0.8.15" }
 # Note that this one does not include pyarrow
 arrow = { version = "47.0.0", optional = false }
 arrow-array = "47.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.dependencies]
-lance = { "version" = "=0.8.15", "features" = ["dynamodb"] }
-lance-linalg = { "version" = "=0.8.15" }
-lance-index = { "version" = "=0.8.15" }
-lance-testing = { "version" = "=0.8.15" }
+lance = { "version" = "=0.8.16", "features" = ["dynamodb"] }
+lance-linalg = { "version" = "=0.8.16" }
+lance-index = { "version" = "=0.8.16" }
+lance-testing = { "version" = "=0.8.16" }
 # Note that this one does not include pyarrow
 arrow = { version = "47.0.0", optional = false }
 arrow-array = "47.0"

--- a/rust/ffi/node/Cargo.toml
+++ b/rust/ffi/node/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3"
 half = { workspace = true }
 lance = { workspace = true }
 lance-linalg = { workspace = true }
+lance-index = { workspace = true }
 vectordb = { path = "../../vectordb" }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 neon = {version = "0.10.1", default-features = false, features = ["channel-api", "napi-6", "promise-api", "task-api"] }

--- a/rust/ffi/node/src/index/vector.rs
+++ b/rust/ffi/node/src/index/vector.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use lance::index::vector::{ivf::IvfBuildParams, pq::PQBuildParams};
+use lance::index::vector::pq::PQBuildParams;
+use lance_index::vector::ivf::IvfBuildParams;
 use lance_linalg::distance::MetricType;
 use neon::context::FunctionContext;
 use neon::prelude::*;

--- a/rust/ffi/node/src/lib.rs
+++ b/rust/ffi/node/src/lib.rs
@@ -180,7 +180,7 @@ fn database_open_table(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
     let aws_creds = get_aws_creds(&mut cx, 1)?;
 
-    let aws_region = get_aws_region(&mut cx, 4)?;
+    let _aws_region = get_aws_region(&mut cx, 4)?;
 
     let params = ReadParams {
         store_options: Some(ObjectStoreParams{

--- a/rust/ffi/node/src/lib.rs
+++ b/rust/ffi/node/src/lib.rs
@@ -183,9 +183,10 @@ fn database_open_table(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let aws_region = get_aws_region(&mut cx, 4)?;
 
     let params = ReadParams {
-        store_options: Some(ObjectStoreParams::with_aws_credentials(
-            aws_creds, aws_region,
-        )),
+        store_options: Some(ObjectStoreParams{
+            aws_credentials: aws_creds,
+            ..ObjectStoreParams::default()
+        }),
         ..ReadParams::default()
     };
 

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -64,7 +64,7 @@ impl JsTable {
         let database = db.database.clone();
 
         let aws_creds = get_aws_creds(&mut cx, 3)?;
-        let aws_region = get_aws_region(&mut cx, 6)?;
+        let _aws_region = get_aws_region(&mut cx, 6)?;
 
         let params = WriteParams {
             store_params: Some(ObjectStoreParams{
@@ -107,7 +107,7 @@ impl JsTable {
             s => return cx.throw_error(format!("invalid write mode {}", s)),
         };
         let aws_creds = get_aws_creds(&mut cx, 2)?;
-        let aws_region = get_aws_region(&mut cx, 5)?;
+        let _aws_region = get_aws_region(&mut cx, 5)?;
 
         let params = WriteParams {
             store_params: Some(ObjectStoreParams{

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -67,9 +67,10 @@ impl JsTable {
         let aws_region = get_aws_region(&mut cx, 6)?;
 
         let params = WriteParams {
-            store_params: Some(ObjectStoreParams::with_aws_credentials(
-                aws_creds, aws_region,
-            )),
+            store_params: Some(ObjectStoreParams{
+                aws_credentials: aws_creds,
+                ..ObjectStoreParams::default()
+            }),
             mode,
             ..WriteParams::default()
         };
@@ -109,9 +110,10 @@ impl JsTable {
         let aws_region = get_aws_region(&mut cx, 5)?;
 
         let params = WriteParams {
-            store_params: Some(ObjectStoreParams::with_aws_credentials(
-                aws_creds, aws_region,
-            )),
+            store_params: Some(ObjectStoreParams{
+                aws_credentials: aws_creds,
+                ..ObjectStoreParams::default()
+            }),
             mode: write_mode,
             ..WriteParams::default()
         };

--- a/rust/vectordb/Cargo.toml
+++ b/rust/vectordb/Cargo.toml
@@ -22,6 +22,7 @@ snafu = { workspace = true }
 half = { workspace = true }
 lance = { workspace = true }
 lance-linalg = { workspace = true }
+lance-index = { workspace = true }
 lance-testing = { workspace = true }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 log = { workspace = true }

--- a/rust/vectordb/src/index/vector.rs
+++ b/rust/vectordb/src/index/vector.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use lance::format::{Index, Manifest};
-use lance::index::vector::ivf::IvfBuildParams;
 use lance::index::vector::pq::PQBuildParams;
 use lance::index::vector::VectorIndexParams;
+use lance_index::vector::ivf::IvfBuildParams;
 use lance_linalg::distance::MetricType;
 
 pub trait VectorIndexBuilder {
@@ -136,7 +136,6 @@ impl VectorIndex {
 mod tests {
     use super::*;
 
-    use lance::index::vector::ivf::IvfBuildParams;
     use lance::index::vector::pq::PQBuildParams;
     use lance::index::vector::StageParams;
 

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use chrono::Duration;
+use lance_index::IndexType;
 use std::sync::Arc;
 
 use arrow_array::{Float32Array, RecordBatchReader};
@@ -22,7 +23,7 @@ use lance::dataset::optimize::{
     compact_files, CompactionMetrics, CompactionOptions, IndexRemapperOptions,
 };
 use lance::dataset::{Dataset, WriteParams};
-use lance::index::{DatasetIndexExt, IndexType};
+use lance::index::DatasetIndexExt;
 use lance::io::object_store::WrappingObjectStore;
 use std::path::Path;
 


### PR DESCRIPTION
upgrade lance to 0.8.15

lance 0.8.15 removed `aws_region` configurability from `store_options`. This breaks aws auth on the write path for lancedb, as there is no way to pass in `aws_region` any more. We need to fix this before releasing lancedb.