### PR TITLE
chore(python): Reduce posthog event count

### DIFF
--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -785,7 +785,7 @@ class LanceTable(Table):
             and also the "_distance" column which is the distance between the query
             vector and the returned vector.
         """
-        register_event("search")
+        register_event("search_table")
         return LanceQueryBuilder.create(
             self, query, query_type, vector_column_name=vector_column_name
         )
@@ -906,6 +906,8 @@ class LanceTable(Table):
                 f"Table {name} does not exist."
                 f"Please first call db.create_table({name}, data)"
             )
+        register_event("open_table")
+
         return tbl
 
     def delete(self, where: str):

--- a/python/lancedb/utils/events.py
+++ b/python/lancedb/utils/events.py
@@ -64,8 +64,8 @@ class _Events:
         Initializes the Events object with default values for events, rate_limit, and metadata.
         """
         self.events = []  # events list
-        self.max_events = 25  # max events to store in memory
-        self.rate_limit = 60.0  # rate limit (seconds)
+        self.max_events = 10  # max events to store in memory
+        self.rate_limit = 60.0*5  # rate limit (seconds)
         self.time = 0.0
 
         if is_git_dir():

--- a/python/lancedb/utils/events.py
+++ b/python/lancedb/utils/events.py
@@ -64,8 +64,10 @@ class _Events:
         Initializes the Events object with default values for events, rate_limit, and metadata.
         """
         self.events = []  # events list
-        self.max_events = 10  # max events to store in memory
-        self.rate_limit = 60.0*5  # rate limit (seconds)
+        self.throttled_event_names = ["search_table"]
+        self.throttled_events = set()
+        self.max_events = 5  # max events to store in memory
+        self.rate_limit = 60.0  # rate limit (seconds)
         self.time = 0.0
 
         if is_git_dir():
@@ -112,18 +114,21 @@ class _Events:
             return
         if (
             len(self.events) < self.max_events
-        ):  # Events list limited to 25 events (drop any events past this)
+        ):  # Events list limited to self.max_events (drop any events past this)
             params.update(self.metadata)
-            self.events.append(
-                {
-                    "event": event_name,
-                    "properties": params,
-                    "timestamp": datetime.datetime.now(
-                        tz=datetime.timezone.utc
-                    ).isoformat(),
-                    "distinct_id": CONFIG["uuid"],
-                }
-            )
+            event = {
+                "event": event_name,
+                "properties": params,
+                "timestamp": datetime.datetime.now(
+                    tz=datetime.timezone.utc
+                ).isoformat(),
+                "distinct_id": CONFIG["uuid"],
+            }
+            if event_name not in self.throttled_event_names:
+                self.events.append(event)
+            elif event_name not in self.throttled_events:
+                self.throttled_events.add(event_name)
+                self.events.append(event)
 
         # Check rate limit
         t = time.time()
@@ -135,7 +140,6 @@ class _Events:
             "distinct_id": CONFIG["uuid"],  # posthog needs this to accepts the event
             "batch": self.events,
         }
-
         # POST equivalent to requests.post(self.url, json=data).
         # threaded request is used to avoid blocking, retries are disabled, and verbose is disabled
         # to avoid any possible disruption in the console.
@@ -150,6 +154,7 @@ class _Events:
 
         # Flush & Reset
         self.events = []
+        self.throttled_events = set()
         self.time = t
 
 

--- a/python/lancedb/utils/events.py
+++ b/python/lancedb/utils/events.py
@@ -67,7 +67,7 @@ class _Events:
         self.throttled_event_names = ["search_table"]
         self.throttled_events = set()
         self.max_events = 5  # max events to store in memory
-        self.rate_limit = 60.0  # rate limit (seconds)
+        self.rate_limit = 60.0*5  # rate limit (seconds)
         self.time = 0.0
 
         if is_git_dir():

--- a/python/lancedb/utils/events.py
+++ b/python/lancedb/utils/events.py
@@ -67,7 +67,7 @@ class _Events:
         self.throttled_event_names = ["search_table"]
         self.throttled_events = set()
         self.max_events = 5  # max events to store in memory
-        self.rate_limit = 60.0*5  # rate limit (seconds)
+        self.rate_limit = 60.0 * 5  # rate limit (seconds)
         self.time = 0.0
 
         if is_git_dir():


### PR DESCRIPTION
- Register open_table as event 
- Because we're dropping 'seach' event currently, changed the name to 'search_table' and introduced throttling
- Throttled events will be counted once per time batch so that the user is registered but event count doesn't go up by a lot