### PR TITLE
chore: set error handling to immediate

### DIFF
--- a/ci/build_macos_artifacts.sh
+++ b/ci/build_macos_artifacts.sh
@@ -1,6 +1,7 @@
 # Builds the macOS artifacts (node binaries).
 # Usage: ./ci/build_macos_artifacts.sh [target]
 # Targets supported: x86_64-apple-darwin aarch64-apple-darwin
+set -e
 
 prebuild_rust() {
     # Building here for the sake of easier debugging.


### PR DESCRIPTION
there's build failure for the rust artifact but the macos arm64 build for npm publish still passed. So we had a silent failure for 2 releases. By setting error to immediate this should cause fail immediately.