### PR TITLE
feat: LocalTable for vectordb now supports filters without vector search

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -489,6 +489,16 @@ export class LocalTable<T = number[]> implements Table<T> {
   }
 
   /**
+   * Creates a filter query to find all rows matching the specified criteria
+   * @param value The filter criteria (like SQL where clause syntax)
+   */
+  filter (value: string): Query<T> {
+    return new Query(undefined, this._tbl, this._embeddings).filter(value)
+  }
+
+  where = this.filter
+
+  /**
    * Insert records into this Table.
    *
    * @param data Records to be inserted into the Table

--- a/node/src/query.ts
+++ b/node/src/query.ts
@@ -23,7 +23,7 @@ const { tableSearch } = require('../native.js')
  * A builder for nearest neighbor queries for LanceDB.
  */
 export class Query<T = number[]> {
-  private readonly _query: T
+  private readonly _query?: T
   private readonly _tbl?: any
   private _queryVector?: number[]
   private _limit: number
@@ -35,7 +35,7 @@ export class Query<T = number[]> {
   private _prefilter: boolean
   protected readonly _embeddings?: EmbeddingFunction<T>
 
-  constructor (query: T, tbl?: any, embeddings?: EmbeddingFunction<T>) {
+  constructor (query?: T, tbl?: any, embeddings?: EmbeddingFunction<T>) {
     this._tbl = tbl
     this._query = query
     this._limit = 10
@@ -113,10 +113,12 @@ export class Query<T = number[]> {
      * Execute the query and return the results as an Array of Objects
      */
   async execute<T = Record<string, unknown>> (): Promise<T[]> {
-    if (this._embeddings !== undefined) {
-      this._queryVector = (await this._embeddings.embed([this._query]))[0]
-    } else {
-      this._queryVector = this._query as number[]
+    if (this._query !== undefined) {
+      if (this._embeddings !== undefined) {
+        this._queryVector = (await this._embeddings.embed([this._query]))[0]
+      } else {
+        this._queryVector = this._query as number[]
+      }
     }
 
     const isElectron = this.isElectron()

--- a/node/src/query.ts
+++ b/node/src/query.ts
@@ -26,7 +26,7 @@ export class Query<T = number[]> {
   private readonly _query?: T
   private readonly _tbl?: any
   private _queryVector?: number[]
-  private _limit: number
+  private _limit?: number
   private _refineFactor?: number
   private _nprobes: number
   private _select?: string[]
@@ -38,7 +38,7 @@ export class Query<T = number[]> {
   constructor (query?: T, tbl?: any, embeddings?: EmbeddingFunction<T>) {
     this._tbl = tbl
     this._query = query
-    this._limit = 10
+    this._limit = undefined
     this._nprobes = 20
     this._refineFactor = undefined
     this._select = undefined

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -86,6 +86,22 @@ describe('LanceDB client', function () {
       assert.equal(results[0].id, 1)
     })
 
+    it('uses a filter / where clause without vector search', async function () {
+      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+      const assertResults = (results: Array<Record<string, unknown>>) => {
+        assert.equal(results.length, 1)
+        assert.equal(results[0].id, 2)
+      }
+
+      const uri = await createTestDB()
+      const con = await lancedb.connect(uri)
+      const table = (await con.openTable('vectors')) as LocalTable
+      let results = await table.filter('id == 2').execute()
+      assertResults(results)
+      results = await table.where('id == 2').execute()
+      assertResults(results)
+    })
+
     it('uses a filter / where clause', async function () {
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       const assertResults = (results: Array<Record<string, unknown>>) => {

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -78,27 +78,30 @@ describe('LanceDB client', function () {
     })
 
     it('limits # of results', async function () {
-      const uri = await createTestDB()
+      const uri = await createTestDB(2, 100)
       const con = await lancedb.connect(uri)
       const table = await con.openTable('vectors')
-      const results = await table.search([0.1, 0.3]).limit(1).execute()
+      let results = await table.search([0.1, 0.3]).limit(1).execute()
       assert.equal(results.length, 1)
       assert.equal(results[0].id, 1)
+
+      // there is a default limit if unspecified
+      results = await table.search([0.1, 0.3]).execute()
+      assert.equal(results.length, 10)
     })
 
     it('uses a filter / where clause without vector search', async function () {
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       const assertResults = (results: Array<Record<string, unknown>>) => {
-        assert.equal(results.length, 1)
-        assert.equal(results[0].id, 2)
+        assert.equal(results.length, 50)
       }
 
-      const uri = await createTestDB()
+      const uri = await createTestDB(2, 100)
       const con = await lancedb.connect(uri)
       const table = (await con.openTable('vectors')) as LocalTable
-      let results = await table.filter('id == 2').execute()
+      let results = await table.filter('id % 2 = 0').execute()
       assertResults(results)
-      results = await table.where('id == 2').execute()
+      results = await table.where('id % 2 = 0').execute()
       assertResults(results)
     })
 

--- a/rust/ffi/node/src/query.rs
+++ b/rust/ffi/node/src/query.rs
@@ -61,13 +61,13 @@ impl JsQuery {
 
         let (deferred, promise) = cx.promise();
         let channel = cx.channel();
-        let query_vector = query_obj.get::<JsArray, _, _>(&mut cx, "_queryVector")?;
-        let query = convert::js_array_to_vec(query_vector.deref(), &mut cx);
+        let query_vector = query_obj.get_opt::<JsArray, _, _>(&mut cx, "_queryVector")?;
         let table = js_table.table.clone();
+        let query = query_vector.map(|q| convert::js_array_to_vec(q.deref(), &mut cx));
 
         rt.spawn(async move {
             let builder = table
-                .search(Float32Array::from(query))
+                .search(query.map(|q| Float32Array::from(q)))
                 .limit(limit as usize)
                 .refine_factor(refine_factor)
                 .nprobes(nprobes)

--- a/rust/vectordb/src/io/object_store.rs
+++ b/rust/vectordb/src/io/object_store.rs
@@ -359,7 +359,7 @@ mod test {
         assert_eq!(t.count_rows().await.unwrap(), 100);
 
         let q = t
-            .search(PrimitiveArray::from_iter_values(vec![0.1, 0.1, 0.1, 0.1]))
+            .search(Some(PrimitiveArray::from_iter_values(vec![0.1, 0.1, 0.1, 0.1])))
             .limit(10)
             .execute()
             .await

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -308,8 +308,12 @@ impl Table {
     /// # Returns
     ///
     /// * A [Query] object.
-    pub fn search(&self, query_vector: Float32Array) -> Query {
+    pub fn search(&self, query_vector: Option<Float32Array>) -> Query {
         Query::new(self.dataset.clone(), query_vector)
+    }
+
+    pub fn filter(&self, expr: String) -> Query {
+        Query::new(self.dataset.clone(), None).filter(Some(expr))
     }
 
     /// Returns the number of rows in this Table
@@ -844,8 +848,8 @@ mod tests {
         let table = Table::open(uri).await.unwrap();
 
         let vector = Float32Array::from_iter_values([0.1, 0.2]);
-        let query = table.search(vector.clone());
-        assert_eq!(vector, query.query_vector);
+        let query = table.search(Some(vector.clone()));
+        assert_eq!(vector, query.query_vector.unwrap());
     }
 
     #[derive(Default, Debug)]


### PR DESCRIPTION
Note this currently the filter/where is only implemented for LocalTable so that it requires an explicit cast to "enable" (see new unit test). The alternative is to add it to the Table interface, but since it's not available on RemoteTable this may cause some user experience issues.