### PR TITLE
ci: fix broken npm publication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,8 +37,16 @@ jobs:
           path: |
             node/vectordb-*.tgz
 
-  node-macos-x86:
-    runs-on: macos-13
+  node-macos:
+    strategy:
+      matrix:
+        config:
+          - arch: x86_64-apple-darwin
+            runner: macos-13
+          - arch: aarch64-apple-darwin
+            # xlarge is implicitly arm64.
+            runner: macos-13-xlarge
+    runs-on: ${{ matrix.config.runner }}
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -51,35 +59,14 @@ jobs:
           cd node
           npm ci
       - name: Build MacOS native node modules
-        run: bash ci/build_macos_artifacts.sh x86_64-apple-darwin
+        run: bash ci/build_macos_artifacts.sh ${{ matrix.config.arch }}
       - name: Upload Darwin Artifacts
         uses: actions/upload-artifact@v3
         with:
           name: native-darwin
           path: |
             node/dist/lancedb-vectordb-darwin*.tgz
-
-  node-macos-arm64:
-    runs-on: macos-13-xlarge
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install system dependencies
-        run: brew install protobuf
-      - name: Install npm dependencies
-        run: |
-          cd node
-          npm ci
-      - name: Build MacOS native node modules
-        run: bash ci/build_macos_artifacts.sh aarch64-apple-darwin
-      - name: Upload Darwin Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: native-darwin
-          path: |
-            node/dist/lancedb-vectordb-darwin*.tgz            
+         
 
   node-linux:
     name: node-linux (${{ matrix.config.arch}}-unknown-linux-gnu


### PR DESCRIPTION
Most recent release failed because `release` depends on `node-macos`, but we renamed `node-macos` to `node-macos-{x86,arm64}`. This fixes that by consolidating them back to a single `node-macos` job, which also has the side effect of making the file shorter.