### PR TITLE
feat: pass vector column name to remote backend

### DIFF
--- a/python/lancedb/remote/__init__.py
+++ b/python/lancedb/remote/__init__.py
@@ -18,6 +18,8 @@ import attrs
 import pyarrow as pa
 from pydantic import BaseModel
 
+from lancedb.common import VECTOR_COLUMN_NAME
+
 __all__ = ["LanceDBClient", "VectorQuery", "VectorQueryResult"]
 
 
@@ -42,6 +44,8 @@ class VectorQuery(BaseModel):
     nprobes: int = 10
 
     refine_factor: Optional[int] = None
+
+    vector_column: str = VECTOR_COLUMN_NAME
 
 
 @attrs.define


### PR DESCRIPTION
pass vector column name to remote as well.

`vector_column` is already part of `Query` just declearing it as part to `remote.VectorQuery` as well