### PR TITLE
fix: prevent duplicate data in FTS index

### DIFF
--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -602,9 +602,9 @@ class LanceTable(Table):
 
         fs, path = fs_from_uri(self._get_fts_index_path())
         index_exists = fs.get_file_info(path).type != pa_fs.FileType.NotFound
-        if index_exists and not replace:
-            raise ValueError(f"Index already exists. Use replace=True to overwrite.")
-        elif index_exists:
+        if index_exists: 
+            if not replace:
+                raise ValueError(f"Index already exists. Use replace=True to overwrite.")
             fs.delete_dir(path)
 
         index = create_index(self._get_fts_index_path(), field_names)

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -602,9 +602,11 @@ class LanceTable(Table):
 
         fs, path = fs_from_uri(self._get_fts_index_path())
         index_exists = fs.get_file_info(path).type != pa_fs.FileType.NotFound
-        if index_exists: 
+        if index_exists:
             if not replace:
-                raise ValueError(f"Index already exists. Use replace=True to overwrite.")
+                raise ValueError(
+                    f"Index already exists. Use replace=True to overwrite."
+                )
             fs.delete_dir(path)
 
         index = create_index(self._get_fts_index_path(), field_names)

--- a/python/tests/test_fts.py
+++ b/python/tests/test_fts.py
@@ -84,7 +84,16 @@ def test_create_index_from_table(tmp_path, table):
     assert "text" in df.columns
 
     # Check whether it can be updated
-    table.add([{"vector": np.random.randn(128), "text": "gorilla", "text2": "gorilla"}])
+    table.add(
+        [
+            {
+                "vector": np.random.randn(128),
+                "text": "gorilla",
+                "text2": "gorilla",
+                "nested": {"text": "gorilla"},
+            }
+        ]
+    )
 
     with pytest.raises(ValueError, match="already exists"):
         table.create_fts_index("text")

--- a/python/tests/test_fts.py
+++ b/python/tests/test_fts.py
@@ -83,6 +83,15 @@ def test_create_index_from_table(tmp_path, table):
     assert len(df) == 10
     assert "text" in df.columns
 
+    # Check whether it can be updated
+    table.add([{"vector": np.random.randn(128), "text": "gorilla", "text2": "gorilla"}])
+
+    with pytest.raises(ValueError, match="already exists"):
+        table.create_fts_index("text")
+
+    table.create_fts_index("text", replace=True)
+    assert len(table.search("gorilla").limit(1).to_pandas()) == 1
+
 
 def test_create_index_multiple_columns(tmp_path, table):
     table.create_fts_index(["text", "text2"])


### PR DESCRIPTION
This forces the user to replace the whole FTS directory when re-creating the index, prevent duplicate data from being created. Previously, the whole dataset was re-added to the existing index, duplicating existing rows in the index.

This (in combination with lancedb/lance#1707) caused #726, since the duplicate data emitted duplicate indices for `take()` and an upstream issue caused those queries to fail.

This solution isn't ideal, since it makes the FTS index temporarily unavailable while the index is built. In the future, we should have multiple FTS index directories, which would allow atomic commits of new indexes (as well as multiple indexes for different columns).

Fixes #498.
Fixes #726.