### PR TITLE
feat(js): support list of string input

### DIFF
--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -218,19 +218,23 @@ describe('LanceDB client', function () {
       assert.equal(await table.countRows(), 2)
     })
 
-    it('creates a new table from javascript objects with list of strings', async function () {
+    it('creates a new table from javascript objects with variable sized list', async function () {
       const dir = await track().mkdir('lancejs')
       const con = await lancedb.connect(dir)
 
       const data = [
-        { id: 1, vector: [0.1, 0.2], list_of_str: ['a', 'b', 'c'] },
-        { id: 2, vector: [1.1, 1.2], list_of_str: ['x', 'y'] }
+        { id: 1, vector: [0.1, 0.2], list_of_str: ['a', 'b', 'c'], list_of_num: [1, 2, 3] },
+        { id: 2, vector: [1.1, 1.2], list_of_str: ['x', 'y'], list_of_num: [4, 5, 6] }
       ]
 
-      const tableName = 'with_list_of_string'
-      const table = await con.createTable(tableName, data)
+      const tableName = 'with_variable_sized_list'
+      const table = await con.createTable(tableName, data) as LocalTable
       assert.equal(table.name, tableName)
       assert.equal(await table.countRows(), 2)
+      const rs = await table.filter('id>1').execute()
+      assert.equal(rs.length, 1)
+      assert.deepEqual(rs[0].list_of_str, ['x', 'y'])
+      assert.isTrue(rs[0].list_of_num instanceof Float64Array)
     })
 
     it('fails to create a new table when the vector column is missing', async function () {

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -218,6 +218,21 @@ describe('LanceDB client', function () {
       assert.equal(await table.countRows(), 2)
     })
 
+    it('creates a new table from javascript objects with list of strings', async function () {
+      const dir = await track().mkdir('lancejs')
+      const con = await lancedb.connect(dir)
+
+      const data = [
+        { id: 1, vector: [0.1, 0.2], list_of_str: ['a', 'b', 'c'] },
+        { id: 2, vector: [1.1, 1.2], list_of_str: ['x', 'y'] }
+      ]
+
+      const tableName = 'with_list_of_string'
+      const table = await con.createTable(tableName, data)
+      assert.equal(table.name, tableName)
+      assert.equal(await table.countRows(), 2)
+    })
+
     it('fails to create a new table when the vector column is missing', async function () {
       const dir = await track().mkdir('lancejs')
       const con = await lancedb.connect(dir)


### PR DESCRIPTION
Add support for adding lists of string input (e.g., list of categorical labels)

Follow-up items: #757 #758