### PR TITLE
feat(node): support table.schema for LocalTable

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -24,7 +24,7 @@ import { isEmbeddingFunction } from './embedding/embedding_function'
 import { type Literal, toSQL } from './util'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { databaseNew, databaseTableNames, databaseOpenTable, databaseDropTable, tableCreate, tableAdd, tableCreateScalarIndex, tableCreateVectorIndex, tableCountRows, tableDelete, tableUpdate, tableCleanupOldVersions, tableCompactFiles, tableListIndices, tableIndexStats } = require('../native.js')
+const { databaseNew, databaseTableNames, databaseOpenTable, databaseDropTable, tableCreate, tableAdd, tableCreateScalarIndex, tableCreateVectorIndex, tableCountRows, tableDelete, tableUpdate, tableCleanupOldVersions, tableCompactFiles, tableListIndices, tableIndexStats, tableSchema } = require('../native.js')
 
 export { Query }
 export type { EmbeddingFunction }
@@ -354,6 +354,8 @@ export interface Table<T = number[]> {
    * Get statistics about an index.
    */
   indexStats: (indexUuid: string) => Promise<IndexStats>
+
+  schema: Promise<Schema>
 }
 
 export interface UpdateArgs {
@@ -681,6 +683,10 @@ export class LocalTable<T = number[]> implements Table<T> {
 
   async indexStats (indexUuid: string): Promise<IndexStats> {
     return tableIndexStats.call(this._tbl, indexUuid)
+  }
+
+  get schema (): Promise<Schema> {
+    return tableSchema.call(this._tbl)
   }
 }
 

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -498,6 +498,26 @@ describe('LanceDB client', function () {
       assert.equal(results.length, 2)
     })
   })
+
+  describe.only('when inspecting the schema', function () {
+    it('should return the schema', async function () {
+      const uri = await createTestDB()
+      const db = await lancedb.connect(uri)
+      assert.equal(db.uri, uri)
+      const table = await db.createTable({
+        name: 'some_table',
+        schema: new Schema(
+          [
+            new Field('id', new Int32()),
+            new Field('vector', new FixedSizeList(128, new Field('float32', new Float32()))),
+            new Field('s', new Utf8())
+          ]
+        )
+      })
+      const schema = await table.schema
+      console.log({ schema })
+    })
+  })
 })
 
 describe('Remote LanceDB client', function () {

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -516,7 +516,6 @@ describe('LanceDB client', function () {
         schema: expectedSchema
       })
       const schema = await table.schema
-      console.log({ schema })
       assert.deepEqual(expectedSchema, schema)
     })
   })

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -499,23 +499,25 @@ describe('LanceDB client', function () {
     })
   })
 
-  describe.only('when inspecting the schema', function () {
+  describe('when inspecting the schema', function () {
     it('should return the schema', async function () {
       const uri = await createTestDB()
       const db = await lancedb.connect(uri)
-      assert.equal(db.uri, uri)
+      // the fsl inner field must be named 'item' and be nullable
+      const expectedSchema = new Schema(
+        [
+          new Field('id', new Int32()),
+          new Field('vector', new FixedSizeList(128, new Field('item', new Float32(), true))),
+          new Field('s', new Utf8())
+        ]
+      )
       const table = await db.createTable({
         name: 'some_table',
-        schema: new Schema(
-          [
-            new Field('id', new Int32()),
-            new Field('vector', new FixedSizeList(128, new Field('float32', new Float32()))),
-            new Field('s', new Utf8())
-          ]
-        )
+        schema: expectedSchema
       })
       const schema = await table.schema
       console.log({ schema })
+      assert.deepEqual(expectedSchema, schema)
     })
   })
 })

--- a/rust/ffi/node/src/arrow.rs
+++ b/rust/ffi/node/src/arrow.rs
@@ -36,7 +36,7 @@ fn validate_vector_column(record_batch: &RecordBatch) -> Result<()> {
 pub(crate) fn arrow_buffer_to_record_batch(slice: &[u8]) -> Result<(Vec<RecordBatch>, SchemaRef)> {
     let mut batches: Vec<RecordBatch> = Vec::new();
     let file_reader = FileReader::try_new(Cursor::new(slice), None)?;
-    let schema = file_reader.schema().clone();
+    let schema = file_reader.schema();
     for b in file_reader {
         let record_batch = b?;
         validate_vector_column(&record_batch)?;

--- a/rust/ffi/node/src/convert.rs
+++ b/rust/ffi/node/src/convert.rs
@@ -17,7 +17,6 @@ use neon::types::buffer::TypedArray;
 
 use crate::error::ResultExt;
 
-
 pub(crate) fn vec_str_to_array<'a, C: Context<'a>>(
     vec: &Vec<String>,
     cx: &mut C,

--- a/rust/ffi/node/src/lib.rs
+++ b/rust/ffi/node/src/lib.rs
@@ -250,5 +250,6 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "tableCreateVectorIndex",
         index::vector::table_create_vector_index,
     )?;
+    cx.export_function("tableSchema", JsTable::js_schema)?;
     Ok(())
 }

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -441,7 +441,7 @@ impl JsTable {
 
         rt.spawn(async move {            
             deferred.settle_with(&channel, move |mut cx| {
-                let schema = table.schema().clone();
+                let schema = table.schema();
                 let batches = vec![RecordBatch::new_empty(schema)];
                 let buffer = record_batch_to_buffer(batches).or_throw(&mut cx)?;
                 convert::new_js_buffer(buffer, &mut cx, is_electron)

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrow_array::{RecordBatchIterator, RecordBatch};
+use arrow_array::{RecordBatch, RecordBatchIterator};
 use lance::dataset::optimize::CompactionOptions;
 use lance::dataset::{WriteMode, WriteParams};
 use lance::io::object_store::ObjectStoreParams;
@@ -23,7 +23,7 @@ use neon::types::buffer::TypedArray;
 use vectordb::Table;
 
 use crate::error::ResultExt;
-use crate::{get_aws_creds, get_aws_region, runtime, JsDatabase, convert};
+use crate::{convert, get_aws_creds, get_aws_region, runtime, JsDatabase};
 
 pub(crate) struct JsTable {
     pub table: Table,
@@ -439,7 +439,7 @@ impl JsTable {
             .or_throw(&mut cx)?
             .value(&mut cx);
 
-        rt.spawn(async move {            
+        rt.spawn(async move {
             deferred.settle_with(&channel, move |mut cx| {
                 let schema = table.schema();
                 let batches = vec![RecordBatch::new_empty(schema)];


### PR DESCRIPTION
Close #773 

we pass an empty table over IPC so we don't need to manually deal with serde. Then we just return the schema attribute from the empty table.