### PR TITLE
feat(python): add phrase query option for fts

### DIFF
--- a/python/tests/test_fts.py
+++ b/python/tests/test_fts.py
@@ -169,13 +169,13 @@ def test_syntax(table):
     table.create_fts_index("text")
     with pytest.raises(ValueError, match="Syntax Error"):
         table.search("they could have been dogs OR cats").limit(10).to_list()
+    table.search("they could have been dogs OR cats").phrase_query().limit(10).to_list()
     # this should work
     table.search('"they could have been dogs OR cats"').limit(10).to_list()
     # this should work too
     table.search('''"the cats OR dogs were not really 'pets' at all"''').limit(
         10
     ).to_list()
-    with pytest.raises(ValueError, match="Syntax Error"):
-        table.search('''"the cats OR dogs were not really "pets" at all"''').limit(
-            10
-        ).to_list()
+    table.search('the cats OR dogs were not really "pets" at all').phrase_query().limit(
+        10
+    ).to_list()

--- a/python/tests/test_fts.py
+++ b/python/tests/test_fts.py
@@ -179,3 +179,6 @@ def test_syntax(table):
     table.search('the cats OR dogs were not really "pets" at all').phrase_query().limit(
         10
     ).to_list()
+    table.search('the cats OR dogs were not really "pets" at all').phrase_query().limit(
+        10
+    ).to_list()


### PR DESCRIPTION
addresses #797 

Problem: tantivy does not expose option to explicitly

Proposed solution here: 

1. Add a `.phrase_query()` option
2. Under the hood, LanceDB takes care of wrapping the input in quotes and replace nested double quotes with single quotes

I've also filed an upstream issue, if they support phrase queries natively then we can get rid of our manual custom processing here.