### PR TITLE
feat(python): allow the entire table to be converted a polars dataframe

### DIFF
--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -67,7 +67,7 @@ We'll cover the basics of using LanceDB on your local machine in this section.
       !!! warning
 
             If the table already exists, LanceDB will raise an error by default.
-            If you want to overwrite the table, you can pass in `mode="overwrite"`
+            If you want to make sure you overwrite the table, pass in `mode="overwrite"`
             to the `createTable` function.
 
 === "Javascript"

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -73,7 +73,7 @@ def _sanitize_data(
         meta = data.schema.metadata if data.schema.metadata is not None else {}
         meta = {k: v for k, v in meta.items() if k != b"pandas"}
         data = data.replace_schema_metadata(meta)
-    elif pl is not None and isinstance(data, pl.DataFrame):
+    elif pl is not None and isinstance(data, (pl.DataFrame, pl.LazyFrame)):
         data = data.to_arrow()
 
     if isinstance(data, pa.Table):
@@ -696,6 +696,30 @@ class LanceTable(Table):
         -------
         pa.Table"""
         return self._dataset.to_table()
+
+    def to_polars(self, batch_size=None) -> "pl.LazyFrame":
+        """Return the table as a polars LazyFrame.
+
+        Parameters
+        ----------
+        batch_size: int, optional
+            Passed to polars. This is the maximum row count for
+            scanned pyarrow record batches
+
+        Note
+        ----
+        1. This requires polars to be installed separately
+        2. Currently we've disabled push-down of the filters from polars
+           because polars pushdown into pyarrow uses pyarrow compute
+           expressions rather than SQl strings (which LanceDB supports)
+
+        Returns
+        -------
+        pl.LazyFrame
+        """
+        return pl.scan_pyarrow_dataset(
+            self.to_lance(), allow_pyarrow_filter=False, batch_size=batch_size
+        )
 
     @property
     def _dataset_uri(self) -> str:


### PR DESCRIPTION
#811 allowed us to ingest polars dataframes directly and turn search results into polars dataframes.

This PR supports converting the entire LanceDB table into a lazy polars DataFrame (i.e., it does not read everything into memory immediately).