### PR TITLE
Add openai api key not found help

### DIFF
--- a/python/lancedb/embeddings/gemini_text.py
+++ b/python/lancedb/embeddings/gemini_text.py
@@ -124,5 +124,5 @@ class GeminiText(TextEmbeddingFunction):
         genai = self.safe_import("google.generativeai", "google.generativeai")
 
         if not os.environ.get("GOOGLE_API_KEY"):
-            raise ValueError(api_key_not_found_help("google"))
+            api_key_not_found_help("google")
         return genai

--- a/python/lancedb/embeddings/openai.py
+++ b/python/lancedb/embeddings/openai.py
@@ -10,6 +10,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import os
 from functools import cached_property
 from typing import List, Union
 
@@ -17,6 +18,7 @@ import numpy as np
 
 from .base import TextEmbeddingFunction
 from .registry import register
+from .utils import api_key_not_found_help
 
 
 @register("openai")
@@ -51,4 +53,7 @@ class OpenAIEmbeddings(TextEmbeddingFunction):
     @cached_property
     def _openai_client(self):
         openai = self.safe_import("openai")
+
+        if not os.environ.get("OPENAI_API_KEY"):
+            raise ValueError(api_key_not_found_help("openai"))
         return openai.OpenAI()

--- a/python/lancedb/embeddings/openai.py
+++ b/python/lancedb/embeddings/openai.py
@@ -55,5 +55,5 @@ class OpenAIEmbeddings(TextEmbeddingFunction):
         openai = self.safe_import("openai")
 
         if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError(api_key_not_found_help("openai"))
+            api_key_not_found_help("openai")
         return openai.OpenAI()

--- a/python/lancedb/embeddings/utils.py
+++ b/python/lancedb/embeddings/utils.py
@@ -216,7 +216,6 @@ def retry_with_exponential_backoff(
     exponential_base: float = 2,
     jitter: bool = True,
     max_retries: int = 7,
-    # errors: tuple = (),
 ):
     """Retry a function with exponential backoff.
 
@@ -226,7 +225,6 @@ def retry_with_exponential_backoff(
         exponential_base (float): The base for exponential backoff (default is 2).
         jitter (bool): Whether to add jitter to the delay (default is True).
         max_retries (int): Maximum number of retries (default is 10).
-        errors (tuple): Tuple of specific exceptions to retry on (default is (openai.error.RateLimitError,)).
 
     Returns:
         function: The decorated function.


### PR DESCRIPTION
This pull request adds check for the presence of an environment variable `OPENAI_API_KEY` and removes an unused parameter in `retry_with_exponential_backoff` function.