### PR TITLE
chore(python): get rid of Pydantic deprication warning in embedding fcn

### DIFF
--- a/python/lancedb/embeddings/gemini_text.py
+++ b/python/lancedb/embeddings/gemini_text.py
@@ -20,6 +20,7 @@ import numpy as np
 from .base import TextEmbeddingFunction
 from .registry import register
 from .utils import api_key_not_found_help, TEXT
+from lancedb.pydantic import PYDANTIC_VERSION
 
 
 @register("gemini-text")
@@ -78,8 +79,10 @@ class GeminiText(TextEmbeddingFunction):
     query_task_type: str = "retrieval_query"
     source_task_type: str = "retrieval_document"
 
-    class Config:  # Pydantic 1.x compat
-        keep_untouched = (cached_property,)
+    if PYDANTIC_VERSION < (2, 0):  # Pydantic 1.x compat
+
+        class Config:
+            keep_untouched = (cached_property,)
 
     def ndims(self):
         # TODO: fix hardcoding


### PR DESCRIPTION
```
UserWarning: Valid config keys have changed in V2:
* 'keep_untouched' has been renamed to 'ignored_types' warnings.warn(message, UserWarning)
```