### PR TITLE
chore(python): turn off lazy frame ingestion

### DIFF
--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -73,7 +73,7 @@ def _sanitize_data(
         meta = data.schema.metadata if data.schema.metadata is not None else {}
         meta = {k: v for k, v in meta.items() if k != b"pandas"}
         data = data.replace_schema_metadata(meta)
-    elif pl is not None and isinstance(data, (pl.DataFrame, pl.LazyFrame)):
+    elif pl is not None and isinstance(data, pl.DataFrame):
         data = data.to_arrow()
 
     if isinstance(data, pa.Table):


### PR DESCRIPTION
LazyFrame doesn't allow for iteration in batches so reading it all into memory will likely blow up. So for now we just don't support ingesting LazyFrame directly. if it's small enough, you can explicitly call `collect` and pass in a polars DataFrame