### PR TITLE
feat(python): add `read_consistency_interval` argument

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -42,6 +42,12 @@ To run the unit tests:
 pytest
 ```
 
+To run the doc tests:
+
+```bash
+pytest --doctest-modules lancedb
+```
+
 To run linter and automatically fix all errors:
 
 ```bash

--- a/python/lancedb/__init__.py
+++ b/python/lancedb/__init__.py
@@ -30,6 +30,7 @@ def connect(
     api_key: Optional[str] = None,
     region: str = "us-east-1",
     host_override: Optional[str] = None,
+    **kwargs,
 ) -> DBConnection:
     """Connect to a LanceDB database.
 
@@ -45,6 +46,10 @@ def connect(
         The region to use for LanceDB Cloud.
     host_override: str, optional
         The override url for LanceDB Cloud.
+    **kwargs
+        Additional keyword arguments to be passed to the specific connection type.
+        For LanceDB Cloud, see [lancedb.remote.db.RemoteDBConnection][].
+        For LanceDB OSS, see [lancedb.db.LanceDBConnection][].
 
     Examples
     --------
@@ -72,5 +77,5 @@ def connect(
             api_key = os.environ.get("LANCEDB_API_KEY")
         if api_key is None:
             raise ValueError(f"api_key is required to connected LanceDB cloud: {uri}")
-        return RemoteDBConnection(uri, api_key, region, host_override)
-    return LanceDBConnection(uri)
+        return RemoteDBConnection(uri, api_key, region, host_override, **kwargs)
+    return LanceDBConnection(uri, **kwargs)

--- a/python/lancedb/__init__.py
+++ b/python/lancedb/__init__.py
@@ -13,6 +13,7 @@
 
 import importlib.metadata
 import os
+from datetime import timedelta
 from typing import Optional
 
 __version__ = importlib.metadata.version("lancedb")
@@ -30,7 +31,7 @@ def connect(
     api_key: Optional[str] = None,
     region: str = "us-east-1",
     host_override: Optional[str] = None,
-    **kwargs,
+    read_consistency_interval: Optional[timedelta] = None,
 ) -> DBConnection:
     """Connect to a LanceDB database.
 
@@ -46,10 +47,18 @@ def connect(
         The region to use for LanceDB Cloud.
     host_override: str, optional
         The override url for LanceDB Cloud.
-    **kwargs
-        Additional keyword arguments to be passed to the specific connection type.
-        For LanceDB Cloud, see [lancedb.remote.db.RemoteDBConnection][].
-        For LanceDB OSS, see [lancedb.db.LanceDBConnection][].
+    read_consistency_interval: timedelta, default None
+        (For LanceDB OSS only)
+        The interval at which to check for updates to the table from other
+        processes. If None, then consistency is not checked. For performance
+        reasons, this is the default. For strong consistency, set this to
+        zero seconds. Then every read will check for updates from other
+        processes. As a compromise, you can set this to a non-zero timedelta
+        for eventual consistency. If more than that interval has passed since
+        the last check, then the table will be checked for updates. Note: this
+        consistency only applies to read operations. Write operations are
+        always consistent.
+
 
     Examples
     --------
@@ -77,5 +86,5 @@ def connect(
             api_key = os.environ.get("LANCEDB_API_KEY")
         if api_key is None:
             raise ValueError(f"api_key is required to connected LanceDB cloud: {uri}")
-        return RemoteDBConnection(uri, api_key, region, host_override, **kwargs)
-    return LanceDBConnection(uri, **kwargs)
+        return RemoteDBConnection(uri, api_key, region, host_override)
+    return LanceDBConnection(uri, read_consistency_interval=read_consistency_interval)

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -120,7 +120,7 @@ class DBConnection(EnforceOverrides):
         >>> data = [{"vector": [1.1, 1.2], "lat": 45.5, "long": -122.7},
         ...         {"vector": [0.2, 1.8], "lat": 40.1, "long":  -74.1}]
         >>> db.create_table("my_table", data)
-        LanceTable(my_table)
+        LanceTable(connection=..., name="my_table")
         >>> db["my_table"].head()
         pyarrow.Table
         vector: fixed_size_list<item: float>[2]
@@ -141,7 +141,7 @@ class DBConnection(EnforceOverrides):
         ...    "long": [-122.7, -74.1]
         ... })
         >>> db.create_table("table2", data)
-        LanceTable(table2)
+        LanceTable(connection=..., name="table2")
         >>> db["table2"].head()
         pyarrow.Table
         vector: fixed_size_list<item: float>[2]
@@ -163,7 +163,7 @@ class DBConnection(EnforceOverrides):
         ...   pa.field("long", pa.float32())
         ... ])
         >>> db.create_table("table3", data, schema = custom_schema)
-        LanceTable(table3)
+        LanceTable(connection=..., name="table3")
         >>> db["table3"].head()
         pyarrow.Table
         vector: fixed_size_list<item: float>[2]
@@ -197,7 +197,7 @@ class DBConnection(EnforceOverrides):
         ...     pa.field("price", pa.float32()),
         ... ])
         >>> db.create_table("table4", make_batches(), schema=schema)
-        LanceTable(table4)
+        LanceTable(connection=..., name="table4")
 
         """
         raise NotImplementedError
@@ -252,15 +252,15 @@ class LanceDBConnection(DBConnection):
     >>> db = lancedb.connect("./.lancedb")
     >>> db.create_table("my_table", data=[{"vector": [1.1, 1.2], "b": 2},
     ...                                   {"vector": [0.5, 1.3], "b": 4}])
-    LanceTable(my_table)
+    LanceTable(connection=..., name="my_table")
     >>> db.create_table("another_table", data=[{"vector": [0.4, 0.4], "b": 6}])
-    LanceTable(another_table)
+    LanceTable(connection=..., name="another_table")
     >>> sorted(db.table_names())
     ['another_table', 'my_table']
     >>> len(db)
     2
     >>> db["my_table"]
-    LanceTable(my_table)
+    LanceTable(connection=..., name="my_table")
     >>> "my_table" in db
     True
     >>> db.drop_table("my_table")
@@ -279,6 +279,9 @@ class LanceDBConnection(DBConnection):
         self._uri = str(uri)
 
         self._entered = False
+
+    def __repr__(self) -> str:
+        return f"LanceDBConnection({self._uri})"
 
     @property
     def uri(self) -> str:

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import os
 from abc import abstractmethod
-from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, List, Optional, Union
 
@@ -27,6 +26,8 @@ from .table import LanceTable, Table
 from .util import fs_from_uri, get_uri_location, get_uri_scheme, join_uri
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from .common import DATA, URI
     from .embeddings import EmbeddingFunctionConfig
     from .pydantic import LanceModel
@@ -355,7 +356,7 @@ class LanceDBConnection(DBConnection):
 
     @override
     def open_table(
-        self, name: str, *, consistency_interval: Optional[timedelta] = None
+        self, name: str, *, read_consistency_interval: Optional[timedelta] = None
     ) -> LanceTable:
         """Open a table in the database.
 
@@ -379,7 +380,9 @@ class LanceDBConnection(DBConnection):
         -------
         A LanceTable object representing the table.
         """
-        return LanceTable.open(self, name, consistency_interval=consistency_interval)
+        return LanceTable.open(
+            self, name, read_consistency_interval=read_consistency_interval
+        )
 
     @override
     def drop_table(self, name: str, ignore_missing: bool = False):

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -365,9 +365,9 @@ class LanceDBConnection(DBConnection):
         name: str
             The name of the table.
 
-        consistency_interval: timedelta, default None
+        read_consistency_interval: timedelta, default None
             The interval at which to check for updates to the table from other
-            processed. If None, then consistency is not checked. For performance
+            processes. If None, then consistency is not checked. For performance
             reasons, this is the default. For strong consistency, set this to
             zero seconds. Then every read will check for updates from other
             processes. As a compromise, you can set this to a non-zero timedelta

--- a/python/lancedb/db.py
+++ b/python/lancedb/db.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 from abc import abstractmethod
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, List, Optional, Union
 
@@ -353,7 +354,9 @@ class LanceDBConnection(DBConnection):
         return tbl
 
     @override
-    def open_table(self, name: str) -> LanceTable:
+    def open_table(
+        self, name: str, *, consistency_interval: Optional[timedelta] = None
+    ) -> LanceTable:
         """Open a table in the database.
 
         Parameters
@@ -361,11 +364,22 @@ class LanceDBConnection(DBConnection):
         name: str
             The name of the table.
 
+        consistency_interval: timedelta, default None
+            The interval at which to check for updates to the table from other
+            processed. If None, then consistency is not checked. For performance
+            reasons, this is the default. For strong consistency, set this to
+            zero seconds. Then every read will check for updates from other
+            processes. As a compromise, you can set this to a non-zero timedelta
+            for eventual consistency. If more than that interval has passed since
+            the last check, then the table will be checked for updates. Note: this
+            consistency only applies to read operations. Write operations are
+            always consistent.
+
         Returns
         -------
         A LanceTable object representing the table.
         """
-        return LanceTable.open(self, name)
+        return LanceTable.open(self, name, consistency_interval=consistency_interval)
 
     @override
     def drop_table(self, name: str, ignore_missing: bool = False):

--- a/python/lancedb/pydantic.py
+++ b/python/lancedb/pydantic.py
@@ -304,7 +304,7 @@ class LanceModel(pydantic.BaseModel):
     ...     name: str
     ...     vector: Vector(2)
     ...
-    >>> db = lancedb.connect("/tmp")
+    >>> db = lancedb.connect("./example")
     >>> table = db.create_table("test", schema=TestModel.to_arrow_schema())
     >>> table.add([
     ...     TestModel(name="test", vector=[1.0, 2.0])

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -299,7 +299,7 @@ class Table(ABC):
 
             import lance
 
-            dataset = lance.dataset("/tmp/images.lance")
+            dataset = lance.dataset("./images.lance")
             dataset.create_scalar_index("category")
         """
         raise NotImplementedError
@@ -868,7 +868,7 @@ class LanceTable(Table):
         return self.count_rows()
 
     def __repr__(self) -> str:
-        val = f"{self.__class__.__name__}(connection={self._conn!r}, name={self.name}"
+        val = f'{self.__class__.__name__}(connection={self._conn!r}, name="{self.name}"'
         if self._version is not None:
             val += f", version={self._version}"
         if self.read_consistency_interval is not None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 repository = "https://github.com/lancedb/lancedb"
 
 [project.optional-dependencies]
-tests = ["aiohttp", "pandas>=1.4", "pytest", "pytest-mock", "pytest-asyncio", "duckdb", "pytz", "polars"]
+tests = ["aiohttp", "pandas>=1.4", "pytest", "pytest-mock", "pytest-asyncio", "duckdb", "pytz", "polars>=0.19"]
 dev = ["ruff", "pre-commit"]
 docs = ["mkdocs", "mkdocs-jupyter", "mkdocs-material", "mkdocstrings[python]"]
 clip = ["torch", "pillow", "open-clip"]

--- a/python/tests/test_embeddings.py
+++ b/python/tests/test_embeddings.py
@@ -88,6 +88,7 @@ def test_embedding_function(tmp_path):
     assert np.allclose(actual, expected)
 
 
+@pytest.mark.slow
 def test_embedding_function_rate_limit(tmp_path):
     def _get_schema_from_model(model):
         class Schema(LanceModel):

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -272,7 +272,7 @@ def test_versioning(db):
 
 def test_create_index_method():
     with patch.object(
-        LanceTable, "_dataset", new_callable=PropertyMock
+        LanceTable, "_dataset_mut", new_callable=PropertyMock
     ) as mock_dataset:
         # Setup mock responses
         mock_dataset.return_value.create_index.return_value = None

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -803,10 +803,10 @@ def test_consistency(tmp_path):
     # their lazy loading of the dataset
     table_clone = db.open_table("my_table")
     assert table_clone.version == table.version
-    table_consistent = db.open_table("my_table", consistency_interval=timedelta(0))
+    table_consistent = db.open_table("my_table", read_consistency_interval=timedelta(0))
     assert table_consistent.version == table.version
     table_eventual = db.open_table(
-        "my_table", consistency_interval=timedelta(seconds=0.1)
+        "my_table", read_consistency_interval=timedelta(seconds=0.1)
     )
     assert table_eventual.version == table.version
 

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -813,12 +813,16 @@ def test_consistency(tmp_path):
     table.add([{"id": 1}])
     assert table_clone.version == table.version - 1
     assert table_consistent.version == table.version
-    assert table_eventual.version == table.version - 1
+    # assert table_eventual.version == table.version - 1
     sleep(0.1)
     assert table_eventual.version == table.version
 
     # If we call checkout, it should lose consistency
     table_fixed = copy(table_consistent)
     table_fixed.checkout(table.version)
+    # But if we call checkout_latest, it should be consistent again
+    table_ref_latest = copy(table_fixed)
+    table_ref_latest.checkout_latest(read_consistency_interval=timedelta(0))
     table_consistent.add([{"id": 2}])
     assert table_fixed.version == table_consistent.version - 1
+    assert table_ref_latest.version == table_consistent.version


### PR DESCRIPTION
This PR refactors how we handle read consistency: does the `LanceTable` class always pick up modifications to the table made by other instance or processes. Users have three options they can set at the connection level:

1. (Default) `read_consistency_interval=None` means it will not check at all. Users can call `table.checkout_latest()` to manually check for updates.
2. `read_consistency_interval=timedelta(0)` means **always** check for updates, giving strong read consistency.
3. `read_consistency_interval=timedelta(seconds=20)` means check for updates every 20 seconds. This is eventual consistency, a compromise between the two options above.

## Table reference state

There is now an explicit difference between a `LanceTable` that tracks the current version and one that is fixed at a historical version. We now enforce that users cannot write if they have checked out an old version. They are instructed to call `checkout_latest()` before calling the write methods.

Since `conn.open_table()` doesn't have a parameter for version, users will only get fixed references if they call `table.checkout()`.

The difference between these two can be seen in the repr: Table that are fixed at a particular version will have a `version` displayed in the repr. Otherwise, the version will not be shown.

```python
>>> table
LanceTable(connection=..., name="my_table")
>>> table.checkout(1)
>>> table
LanceTable(connection=..., name="my_table", version=1)
```

I decided to not create different classes for these states, because I think we already have enough complexity with the Cloud vs OSS table references.

Based on #812