### PR TITLE
allow passing api key as env var

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -77,7 +77,11 @@ export interface ConnectionOptions {
   /** AWS region to connect to. Default is {@link defaultAwsRegion}. */
   awsRegion?: string
 
-  // API key for the remote connections
+  /**
+   * API key for the remote connections
+   *
+   * Can also be passed by setting environment variable `LANCEDB_API_KEY`
+   */
   apiKey?: string
 
   /** Region to connect */

--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -38,6 +38,9 @@ export class RemoteConnection implements Connection {
     if (!opts.uri.startsWith('db://')) {
       throw new Error(`Invalid remote DB URI: ${opts.uri}`)
     }
+    if (opts.apiKey == null || opts.apiKey === '') {
+      opts = Object.assign({}, opts, { apiKey: process.env.LANCEDB_API_KEY })
+    }
     if (opts.apiKey === undefined || opts.region === undefined) {
       throw new Error('API key and region are not supported for remote connections')
     }

--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -42,7 +42,9 @@ export class RemoteConnection implements Connection {
       opts = Object.assign({}, opts, { apiKey: process.env.LANCEDB_API_KEY })
     }
     if (opts.apiKey === undefined || opts.region === undefined) {
-      throw new Error('API key and region are not supported for remote connections')
+      throw new Error(
+        'API key and region are must be passed for remote connections. ' +
+        'API key can also be set through LANCEDB_API_KEY env variable.')
     }
 
     this._dbName = opts.uri.slice('db://'.length)

--- a/python/lancedb/__init__.py
+++ b/python/lancedb/__init__.py
@@ -12,6 +12,7 @@
 #  limitations under the License.
 
 import importlib.metadata
+import os
 from typing import Optional
 
 __version__ = importlib.metadata.version("lancedb")
@@ -39,6 +40,7 @@ def connect(
     api_key: str, optional
         If presented, connect to LanceDB cloud.
         Otherwise, connect to a database on file system or cloud storage.
+        Can be set via environment variable `LANCEDB_API_KEY`.
     region: str, default "us-east-1"
         The region to use for LanceDB Cloud.
     host_override: str, optional
@@ -66,6 +68,8 @@ def connect(
         A connection to a LanceDB database.
     """
     if isinstance(uri, str) and uri.startswith("db://"):
+        if api_key is None:
+            api_key = os.environ.get("LANCEDB_API_KEY")
         if api_key is None:
             raise ValueError(f"api_key is required to connected LanceDB cloud: {uri}")
         return RemoteDBConnection(uri, api_key, region, host_override)


### PR DESCRIPTION
Allow passing API key as env var:
```shell
export LANCEDB_API_KEY=sh_123...
```

with this set, apiKey argument can omitted from `connect`
```js
    const db = await vectordb.connect({
        uri: "db://test-proj-01-ae8343",
        region: "us-east-1",
  })
```
```py
    db = lancedb.connect(
        uri="db://test-proj-01-ae8343",
        region="us-east-1",
    )
```