### PR TITLE
chore(rust): provide a  Connection trait to match python and nodejs SDK

### DIFF
--- a/rust/ffi/node/src/lib.rs
+++ b/rust/ffi/node/src/lib.rs
@@ -22,8 +22,9 @@ use object_store::CredentialProvider;
 use once_cell::sync::OnceCell;
 use tokio::runtime::Runtime;
 
-use vectordb::database::Database;
+use vectordb::connection::Database;
 use vectordb::table::ReadParams;
+use vectordb::Connection;
 
 use crate::error::ResultExt;
 use crate::query::JsQuery;
@@ -38,7 +39,7 @@ mod query;
 mod table;
 
 struct JsDatabase {
-    database: Arc<Database>,
+    database: Arc<dyn Connection + 'static>,
 }
 
 impl Finalize for JsDatabase {}

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -77,7 +77,7 @@ impl JsTable {
         rt.spawn(async move {
             let batch_reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
             let table_rst = database
-                .create_table(&table_name, batch_reader, Some(params))
+                .create_table(&table_name, Box::new(batch_reader), Some(params))
                 .await;
 
             deferred.settle_with(&channel, move |mut cx| {

--- a/rust/vectordb/src/connection.rs
+++ b/rust/vectordb/src/connection.rs
@@ -192,8 +192,6 @@ impl Database {
         Ok(())
     }
 
-
-
     /// Get the URI of a table in the database.
     fn table_uri(&self, name: &str) -> Result<String> {
         let path = Path::new(&self.uri);

--- a/rust/vectordb/src/io/object_store.rs
+++ b/rust/vectordb/src/io/object_store.rs
@@ -335,7 +335,7 @@ impl WrappingObjectStore for MirroringObjectStoreWrapper {
 #[cfg(all(test, not(windows)))]
 mod test {
     use super::*;
-    use crate::connection::{Database, Connection};
+    use crate::connection::{Connection, Database};
     use arrow_array::PrimitiveArray;
     use futures::TryStreamExt;
     use lance::{dataset::WriteParams, io::object_store::ObjectStoreParams};

--- a/rust/vectordb/src/io/object_store.rs
+++ b/rust/vectordb/src/io/object_store.rs
@@ -335,7 +335,7 @@ impl WrappingObjectStore for MirroringObjectStoreWrapper {
 #[cfg(all(test, not(windows)))]
 mod test {
     use super::*;
-    use crate::Database;
+    use crate::connection::{Database, Connection};
     use arrow_array::PrimitiveArray;
     use futures::TryStreamExt;
     use lance::{dataset::WriteParams, io::object_store::ObjectStoreParams};
@@ -365,7 +365,7 @@ mod test {
         datagen = datagen.col(Box::new(RandomVector::default().named("vector".into())));
 
         let res = db
-            .create_table("test", datagen.batch(100), Some(param.clone()))
+            .create_table("test", Box::new(datagen.batch(100)), Some(param.clone()))
             .await;
 
         // leave this here for easy debugging

--- a/rust/vectordb/src/lib.rs
+++ b/rust/vectordb/src/lib.rs
@@ -46,7 +46,7 @@
 //! #### Connect to a database.
 //!
 //! ```rust
-//! use vectordb::{Database, Table, WriteMode};
+//! use vectordb::{connection::{Database, Connection}, Table, WriteMode};
 //! use arrow_schema::{Field, Schema};
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! let db = Database::connect("data/sample-lancedb").await.unwrap();
@@ -66,7 +66,7 @@
 //! use arrow_schema::{DataType, Schema, Field};
 //! use arrow_array::{RecordBatch, RecordBatchIterator};
 //! # use arrow_array::{FixedSizeListArray, Float32Array, Int32Array, types::Float32Type};
-//! # use vectordb::Database;
+//! # use vectordb::connection::{Database, Connection};
 //!
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! # let tmpdir = tempfile::tempdir().unwrap();
@@ -86,7 +86,7 @@
 //!         ]).unwrap()
 //!    ].into_iter().map(Ok),
 //!     schema.clone());
-//! db.create_table("my_table", batches, None).await.unwrap();
+//! db.create_table("my_table", Box::new(batches), None).await.unwrap();
 //! # });
 //! ```
 //!
@@ -98,7 +98,7 @@
 //! # use arrow_schema::{DataType, Schema, Field};
 //! # use arrow_array::{RecordBatch, RecordBatchIterator};
 //! # use arrow_array::{FixedSizeListArray, Float32Array, Int32Array, types::Float32Type};
-//! # use vectordb::Database;
+//! # use vectordb::connection::{Database, Connection};
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! # let tmpdir = tempfile::tempdir().unwrap();
 //! # let db = Database::connect(tmpdir.path().to_str().unwrap()).await.unwrap();
@@ -116,7 +116,7 @@
 //! #       ]).unwrap()
 //! #   ].into_iter().map(Ok),
 //! #    schema.clone());
-//! # db.create_table("my_table", batches, None).await.unwrap();
+//! # db.create_table("my_table", Box::new(batches), None).await.unwrap();
 //! let table = db.open_table("my_table").await.unwrap();
 //! let results = table
 //!     .search(Some(vec![1.0; 128]))
@@ -131,8 +131,8 @@
 //!
 //! ```
 
+pub mod connection;
 pub mod data;
-pub mod database;
 pub mod error;
 pub mod index;
 pub mod io;
@@ -140,7 +140,7 @@ pub mod query;
 pub mod table;
 pub mod utils;
 
-pub use database::Database;
+pub use connection::Connection;
 pub use table::Table;
 
 pub use lance::dataset::WriteMode;


### PR DESCRIPTION
In NodeJS and Python,  LanceDB establishes a connection to a db. In Rust core, it is called Database. 
We should be consistent with the naming. 