### PR TITLE
feat: improve the rust table query API and documents

### DIFF
--- a/nodejs/src/query.rs
+++ b/nodejs/src/query.rs
@@ -33,7 +33,7 @@ impl Query {
 
     #[napi]
     pub fn vector(&mut self, vector: Float32Array) {
-        let inn = self.inner.clone().query_vector(&vector);
+        let inn = self.inner.clone().nearest_to(&vector);
         self.inner = inn;
     }
 

--- a/rust/ffi/node/src/query.rs
+++ b/rust/ffi/node/src/query.rs
@@ -88,7 +88,7 @@ impl JsQuery {
         builder = builder.prefilter(prefilter);
 
         rt.spawn(async move {
-            let record_batch_stream = builder.execute();
+            let record_batch_stream = builder.into_stream();
             let results = record_batch_stream
                 .and_then(|stream| {
                     stream

--- a/rust/ffi/node/src/query.rs
+++ b/rust/ffi/node/src/query.rs
@@ -88,7 +88,7 @@ impl JsQuery {
         builder = builder.prefilter(prefilter);
 
         rt.spawn(async move {
-            let record_batch_stream = builder.into_stream();
+            let record_batch_stream = builder.execute_stream();
             let results = record_batch_stream
                 .and_then(|stream| {
                     stream

--- a/rust/ffi/node/src/query.rs
+++ b/rust/ffi/node/src/query.rs
@@ -59,7 +59,7 @@ impl JsQuery {
         let query_vector = query_obj.get_opt::<JsArray, _, _>(&mut cx, "_queryVector")?;
         let mut builder = table.query();
         if let Some(query) = query_vector.map(|q| convert::js_array_to_vec(q.deref(), &mut cx)) {
-            builder = builder.query_vector(&query);
+            builder = builder.nearest_to(&query);
             if let Some(metric_type) = query_obj
                 .get_opt::<JsString, _, _>(&mut cx, "_metricType")?
                 .map(|s| s.value(&mut cx))

--- a/rust/ffi/node/src/query.rs
+++ b/rust/ffi/node/src/query.rs
@@ -40,17 +40,6 @@ impl JsQuery {
                 }
                 projection_vec
             });
-        let filter = query_obj
-            .get_opt::<JsString, _, _>(&mut cx, "_filter")?
-            .map(|s| s.value(&mut cx));
-        let refine_factor = query_obj
-            .get_opt_u32(&mut cx, "_refineFactor")
-            .or_throw(&mut cx)?;
-        let nprobes = query_obj.get_usize(&mut cx, "_nprobes").or_throw(&mut cx)?;
-        let metric_type = query_obj
-            .get_opt::<JsString, _, _>(&mut cx, "_metricType")?
-            .map(|s| s.value(&mut cx))
-            .map(|s| MetricType::try_from(s.as_str()).unwrap());
 
         let prefilter = query_obj
             .get::<JsBoolean, _, _>(&mut cx, "_prefilter")?
@@ -65,24 +54,40 @@ impl JsQuery {
 
         let (deferred, promise) = cx.promise();
         let channel = cx.channel();
-        let query_vector = query_obj.get_opt::<JsArray, _, _>(&mut cx, "_queryVector")?;
         let table = js_table.table.clone();
-        let query = query_vector.map(|q| convert::js_array_to_vec(q.deref(), &mut cx));
+
+        let query_vector = query_obj.get_opt::<JsArray, _, _>(&mut cx, "_queryVector")?;
+        let mut builder = table.query();
+        if let Some(query) = query_vector.map(|q| convert::js_array_to_vec(q.deref(), &mut cx)) {
+            builder = builder.query_vector(&query);
+            if let Some(metric_type) = query_obj
+                .get_opt::<JsString, _, _>(&mut cx, "_metricType")?
+                .map(|s| s.value(&mut cx))
+                .map(|s| MetricType::try_from(s.as_str()).unwrap())
+            {
+                builder = builder.metric_type(metric_type);
+            }
+
+            let nprobes = query_obj.get_usize(&mut cx, "_nprobes").or_throw(&mut cx)?;
+            builder = builder.nprobes(nprobes);
+        };
+
+        if let Some(filter) = query_obj
+            .get_opt::<JsString, _, _>(&mut cx, "_filter")?
+            .map(|s| s.value(&mut cx))
+        {
+            builder = builder.filter(filter);
+        }
+        if let Some(select) = select {
+            builder = builder.select(select.as_slice());
+        }
+        if let Some(limit) = limit {
+            builder = builder.limit(limit as usize);
+        };
+
+        builder = builder.prefilter(prefilter);
 
         rt.spawn(async move {
-            let mut builder = table.query();
-            if let Some(query) = query {
-                builder = builder
-                    .query_vector(&query)
-                    .refine_factor(refine_factor)
-                    .nprobes(nprobes)
-                    .metric_type(metric_type);
-            };
-            builder = builder.filter(filter).select(select).prefilter(prefilter);
-            if let Some(limit) = limit {
-                builder = builder.limit(limit as usize);
-            };
-
             let record_batch_stream = builder.execute();
             let results = record_batch_stream
                 .and_then(|stream| {

--- a/rust/vectordb/src/io/object_store.rs
+++ b/rust/vectordb/src/io/object_store.rs
@@ -377,7 +377,7 @@ mod test {
         let q = t
             .search(&[0.1, 0.1, 0.1, 0.1])
             .limit(10)
-            .execute()
+            .into_stream()
             .await
             .unwrap();
 

--- a/rust/vectordb/src/io/object_store.rs
+++ b/rust/vectordb/src/io/object_store.rs
@@ -377,7 +377,7 @@ mod test {
         let q = t
             .search(&[0.1, 0.1, 0.1, 0.1])
             .limit(10)
-            .into_stream()
+            .execute_stream()
             .await
             .unwrap();
 

--- a/rust/vectordb/src/lib.rs
+++ b/rust/vectordb/src/lib.rs
@@ -141,7 +141,7 @@
 //! let table = db.open_table("my_table").await.unwrap();
 //! let results = table
 //!     .search(&[1.0; 128])
-//!     .into_stream()
+//!     .execute_stream()
 //!     .await
 //!     .unwrap()
 //!     .try_collect::<Vec<_>>()

--- a/rust/vectordb/src/lib.rs
+++ b/rust/vectordb/src/lib.rs
@@ -120,7 +120,7 @@
 //! let table = db.open_table("my_table").await.unwrap();
 //! let results = table
 //!     .search(&[1.0; 128])
-//!     .execute()
+//!     .into_stream()
 //!     .await
 //!     .unwrap()
 //!     .try_collect::<Vec<_>>()

--- a/rust/vectordb/src/lib.rs
+++ b/rust/vectordb/src/lib.rs
@@ -90,6 +90,27 @@
 //! # });
 //! ```
 //!
+//! #### Create vector index (IVF_PQ)
+//!
+//! ```no_run
+//! # use std::sync::Arc;
+//! # use vectordb::connection::{Database, Connection};
+//! # use arrow_array::{FixedSizeListArray, types::Float32Type, RecordBatch,
+//! #   RecordBatchIterator, Int32Array};
+//! # use arrow_schema::{Schema, Field, DataType};
+//! # tokio::runtime::Runtime::new().unwrap().block_on(async {
+//! # let tmpdir = tempfile::tempdir().unwrap();
+//! # let db = Database::connect(tmpdir.path().to_str().unwrap()).await.unwrap();
+//! # let tbl = db.open_table("idx_test").await.unwrap();
+//! tbl.create_index(&["vector"])
+//!     .ivf_pq()
+//!     .num_partitions(256)
+//!     .build()
+//!     .await
+//!     .unwrap();
+//! # });
+//! ```
+//!
 //! #### Open table and run search
 //!
 //! ```rust

--- a/rust/vectordb/src/lib.rs
+++ b/rust/vectordb/src/lib.rs
@@ -46,8 +46,8 @@
 //! #### Connect to a database.
 //!
 //! ```rust
-//! use vectordb::{connection::{Database, Connection}, WriteMode};
-//! use arrow_schema::{Field, Schema};
+//! use vectordb::connection::Database;
+//! # use arrow_schema::{Field, Schema};
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! let db = Database::connect("data/sample-lancedb").await.unwrap();
 //! # });
@@ -55,7 +55,7 @@
 //!
 //! LanceDB uses [arrow-rs](https://github.com/apache/arrow-rs) to define schema, data types and array itself.
 //! It treats [`FixedSizeList<Float16/Float32>`](https://docs.rs/arrow/latest/arrow/array/struct.FixedSizeListArray.html)
-//! columns as vectors.
+//! columns as vector columns.
 //!
 //! #### Create a table
 //!

--- a/rust/vectordb/src/query.rs
+++ b/rust/vectordb/src/query.rs
@@ -81,7 +81,7 @@ impl Query {
     /// # Returns
     ///
     /// * A [DatasetRecordBatchStream] with the query's results.
-    pub async fn into_stream(&self) -> Result<DatasetRecordBatchStream> {
+    pub async fn execute_stream(&self) -> Result<DatasetRecordBatchStream> {
         let mut scanner: Scanner = self.dataset.scan();
 
         if let Some(query) = self.query_vector.as_ref() {
@@ -254,7 +254,7 @@ mod tests {
         let ds = Arc::new(Dataset::write(batches, "memory://foo", None).await.unwrap());
 
         let query = Query::new(ds.clone()).nearest_to(&[0.1; 4]);
-        let result = query.limit(10).filter("id % 2 == 0").into_stream().await;
+        let result = query.limit(10).filter("id % 2 == 0").execute_stream().await;
         let mut stream = result.expect("should have result");
         // should only have one batch
         while let Some(batch) = stream.next().await {
@@ -267,7 +267,7 @@ mod tests {
             .limit(10)
             .filter(String::from("id % 2 == 0")) // Work with String too
             .prefilter(true)
-            .into_stream()
+            .execute_stream()
             .await;
         let mut stream = result.expect("should have result");
         // should only have one batch
@@ -284,7 +284,7 @@ mod tests {
         let ds = Arc::new(Dataset::write(batches, "memory://foo", None).await.unwrap());
 
         let query = Query::new(ds.clone());
-        let result = query.filter("id % 2 == 0").into_stream().await;
+        let result = query.filter("id % 2 == 0").execute_stream().await;
         let mut stream = result.expect("should have result");
         // should only have one batch
         while let Some(batch) = stream.next().await {

--- a/rust/vectordb/src/query.rs
+++ b/rust/vectordb/src/query.rs
@@ -114,7 +114,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `column` - The column name
-    pub fn column(mut self, column: &str) -> Query {
+    pub fn column(mut self, column: &str) -> Self {
         self.column = Some(column.to_string());
         self
     }
@@ -124,7 +124,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `limit` - The maximum number of results to return.
-    pub fn limit(mut self, limit: usize) -> Query {
+    pub fn limit(mut self, limit: usize) -> Self {
         self.limit = Some(limit);
         self
     }
@@ -134,7 +134,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `vector` - The vector that will be used for search.
-    pub fn query_vector(mut self, vector: &[f32]) -> Query {
+    pub fn query_vector(mut self, vector: &[f32]) -> Self {
         self.query_vector = Some(Float32Array::from(vector.to_vec()));
         self
     }
@@ -144,7 +144,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `nprobes` - The number of probes to use.
-    pub fn nprobes(mut self, nprobes: usize) -> Query {
+    pub fn nprobes(mut self, nprobes: usize) -> Self {
         self.nprobes = nprobes;
         self
     }
@@ -154,7 +154,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `refine_factor` - The refine factor to use.
-    pub fn refine_factor(mut self, refine_factor: u32) -> Query {
+    pub fn refine_factor(mut self, refine_factor: u32) -> Self {
         self.refine_factor = Some(refine_factor);
         self
     }
@@ -164,7 +164,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `metric_type` - The distance metric to use. By default [MetricType::L2] is used.
-    pub fn metric_type(mut self, metric_type: MetricType) -> Query {
+    pub fn metric_type(mut self, metric_type: MetricType) -> Self {
         self.metric_type = Some(metric_type);
         self
     }
@@ -174,7 +174,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `use_index` - Sets Whether to use an ANN index if available
-    pub fn use_index(mut self, use_index: bool) -> Query {
+    pub fn use_index(mut self, use_index: bool) -> Self {
         self.use_index = use_index;
         self
     }
@@ -184,7 +184,7 @@ impl Query {
     /// # Arguments
     ///
     /// * `filter` - SQL filter
-    pub fn filter(mut self, filter: impl AsRef<str>) -> Query {
+    pub fn filter(mut self, filter: impl AsRef<str>) -> Self {
         self.filter = Some(filter.as_ref().to_string());
         self
     }
@@ -192,12 +192,12 @@ impl Query {
     /// Return only the specified columns.
     ///
     /// Only select the specified columns. If not specified, all columns will be returned.
-    pub fn select(mut self, columns: &[impl AsRef<String>]) -> Query {
+    pub fn select(mut self, columns: &[impl AsRef<str>]) -> Self {
         self.select = Some(columns.iter().map(|c| c.as_ref().to_string()).collect());
         self
     }
 
-    pub fn prefilter(mut self, prefilter: bool) -> Query {
+    pub fn prefilter(mut self, prefilter: bool) -> Self {
         self.prefilter = prefilter;
         self
     }

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -120,7 +120,7 @@ pub trait Table: std::fmt::Display + Send + Sync {
     /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
     /// let tmpdir = tempfile::tempdir().unwrap();
     /// let db = Database::connect(tmpdir.path().to_str().unwrap()).await.unwrap();
-    /// # let tbl = db.open_table("delete_test").await.unwrap();
+    /// # let tbl = db.open_table("idx_test").await.unwrap();
     /// tbl.create_index(&["vector"])
     ///     .ivf_pq()
     ///     .num_partitions(256)
@@ -138,7 +138,7 @@ pub trait Table: std::fmt::Display + Send + Sync {
         self.query().nearest_to(query)
     }
 
-    /// Create a generic Query Builder.
+    /// Create a generic [`Query`] Builder.
     ///
     /// When appropriate, various indices and statistics based pruning will be used to
     /// accelerate the query.

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -155,7 +155,7 @@ pub trait Table: std::fmt::Display + Send + Sync {
     /// let stream = tbl.query().nearest_to(&[1.0, 2.0, 3.0])
     ///     .refine_factor(5)
     ///     .nprobes(10)
-    ///     .into_stream()
+    ///     .execute_stream()
     ///     .await
     ///     .unwrap();
     /// let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
@@ -172,7 +172,7 @@ pub trait Table: std::fmt::Display + Send + Sync {
     ///     .query()
     ///     .filter("id > 5")
     ///     .limit(1000)
-    ///     .into_stream()
+    ///     .execute_stream()
     ///     .await
     ///     .unwrap();
     /// let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
@@ -187,7 +187,7 @@ pub trait Table: std::fmt::Display + Send + Sync {
     /// # let tbl = vectordb::table::NativeTable::open("/tmp/tbl").await.unwrap();
     /// let stream = tbl
     ///     .query()
-    ///     .into_stream()
+    ///     .execute_stream()
     ///     .await
     ///     .unwrap();
     /// let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -132,11 +132,32 @@ pub trait Table: std::fmt::Display + Send + Sync {
     fn create_index(&self, column: &[&str]) -> IndexBuilder;
 
     /// Search the table with a given query vector.
+    ///
+    /// This is a convenience method for preparing an ANN query.
     fn search(&self, query: &[f32]) -> Query {
-        self.query().query_vector(query)
+        self.query().nearest_to(query)
     }
 
-    /// Create a Query builder.
+    /// Create a generic Query Builder.
+    ///
+    /// # Examples
+    ///
+    /// Run a vector search (ANN) query.
+    ///
+    /// ```no_run
+    /// # use arrow_array::RecordBatch;
+    /// # use futures::TryStreamExt;
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// # let tbl = vectordb::table::NativeTable::open("/tmp/tbl").await.unwrap();
+    /// let stream = tbl.query().nearest_to(&[1.0, 2.0, 3.0])
+    ///     .refine_factor(5)
+    ///     .nprobes(10)
+    ///     .into_stream()
+    ///     .await
+    ///     .unwrap();
+    /// let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+    /// # });
+    /// ```
     fn query(&self) -> Query;
 }
 

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -961,22 +961,6 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_search() {
-        let tmp_dir = tempdir().unwrap();
-        let dataset_path = tmp_dir.path().join("test.lance");
-        let uri = dataset_path.to_str().unwrap();
-
-        let batches = make_test_batches();
-        Dataset::write(batches, dataset_path.to_str().unwrap(), None)
-            .await
-            .unwrap();
-
-        let table = NativeTable::open(uri).await.unwrap();
-
-        let query = table.search(&[0.1, 0.2]);
-        assert_eq!(&[0.1, 0.2], query.query_vector.unwrap().values());
-    }
 
     #[derive(Default, Debug)]
     struct NoOpCacheWrapper {

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -362,7 +362,7 @@ impl NativeTable {
     }
 
     pub fn filter(&self, expr: String) -> Query {
-        Query::new(self.clone_inner_dataset().into()).filter(Some(expr))
+        Query::new(self.clone_inner_dataset().into()).filter(expr)
     }
 
     /// Returns the number of rows in this Table
@@ -960,7 +960,6 @@ mod tests {
             }
         }
     }
-
 
     #[derive(Default, Debug)]
     struct NoOpCacheWrapper {

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -140,9 +140,12 @@ pub trait Table: std::fmt::Display + Send + Sync {
 
     /// Create a generic Query Builder.
     ///
+    /// When appropriate, various indices and statistics based pruning will be used to
+    /// accelerate the query.
+    ///
     /// # Examples
     ///
-    /// Run a vector search (ANN) query.
+    /// ## Run a vector search (ANN) query.
     ///
     /// ```no_run
     /// # use arrow_array::RecordBatch;
@@ -152,6 +155,38 @@ pub trait Table: std::fmt::Display + Send + Sync {
     /// let stream = tbl.query().nearest_to(&[1.0, 2.0, 3.0])
     ///     .refine_factor(5)
     ///     .nprobes(10)
+    ///     .into_stream()
+    ///     .await
+    ///     .unwrap();
+    /// let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+    /// # });
+    /// ```
+    ///
+    /// ## Run a SQL-style filter
+    /// ```no_run
+    /// # use arrow_array::RecordBatch;
+    /// # use futures::TryStreamExt;
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// # let tbl = vectordb::table::NativeTable::open("/tmp/tbl").await.unwrap();
+    /// let stream = tbl
+    ///     .query()
+    ///     .filter("id > 5")
+    ///     .limit(1000)
+    ///     .into_stream()
+    ///     .await
+    ///     .unwrap();
+    /// let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+    /// # });
+    /// ```
+    ///
+    /// ## Run a full scan query.
+    /// ```no_run
+    /// # use arrow_array::RecordBatch;
+    /// # use futures::TryStreamExt;
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// # let tbl = vectordb::table::NativeTable::open("/tmp/tbl").await.unwrap();
+    /// let stream = tbl
+    ///     .query()
     ///     .into_stream()
     ///     .await
     ///     .unwrap();

--- a/rust/vectordb/src/utils.rs
+++ b/rust/vectordb/src/utils.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use arrow_schema::Schema;
+
 use lance::dataset::{ReadParams, WriteParams};
 use lance::io::{ObjectStoreParams, WrappingObjectStore};
 
@@ -61,5 +63,88 @@ impl PatchReadParam for ReadParams {
     ) -> Result<ReadParams> {
         self.store_options = self.store_options.patch_with_store_wrapper(wrapper)?;
         Ok(self)
+    }
+}
+
+/// Find one default column to create index.
+pub(crate) fn default_vector_column(schema: &Schema, dim: Option<i32>) -> Result<String> {
+    // Try to find one fixed size list array column.
+    let candidates = schema
+        .fields()
+        .iter()
+        .filter_map(|field| match field.data_type() {
+            arrow_schema::DataType::FixedSizeList(f, d)
+                if f.data_type().is_floating()
+                    && dim.map(|expect| *d == expect).unwrap_or(true) =>
+            {
+                Some(field.name())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        Err(Error::Store {
+            message: "No vector column found to create index".to_string(),
+        })
+    } else if candidates.len() != 1 {
+        Err(Error::Store {
+            message: format!(
+                "More than one vector columns found, \
+                    please specify which column to create index: {:?}",
+                candidates
+            ),
+        })
+    } else {
+        Ok(candidates[0].to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow_schema::{DataType, Field};
+
+    #[test]
+    fn test_guess_default_column() {
+        let schema_no_vector = Schema::new(vec![
+            Field::new("id", DataType::Int16, true),
+            Field::new("tag", DataType::Utf8, false),
+        ]);
+        assert!(default_vector_column(&schema_no_vector, None)
+            .unwrap_err()
+            .to_string()
+            .contains("No vector column"));
+
+        let schema_with_vec_col = Schema::new(vec![
+            Field::new("id", DataType::Int16, true),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, false)), 10),
+                false,
+            ),
+        ]);
+        assert_eq!(
+            default_vector_column(&schema_with_vec_col, None).unwrap(),
+            "vec"
+        );
+
+        let multi_vec_col = Schema::new(vec![
+            Field::new("id", DataType::Int16, true),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, false)), 10),
+                false,
+            ),
+            Field::new(
+                "vec2",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, false)), 50),
+                false,
+            ),
+        ]);
+        assert!(default_vector_column(&multi_vec_col, None)
+            .unwrap_err()
+            .to_string()
+            .contains("More than one"));
     }
 }


### PR DESCRIPTION
* Easy to type
* Handle `String, &str, [String] and [&str]` well without manual conversion
* Fix function name to be verb
* Improve docstring of Rust.
* Promote `query` and `search()` to public `Table` trait