### PR TITLE
fix(node): pass AWS credentials to db level operations

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -174,7 +174,13 @@ export async function connect (
     // Remote connection
     return new RemoteConnection(opts)
   }
-  const db = await databaseNew(opts.uri)
+  const db = await databaseNew(
+    opts.uri,
+    opts.awsCredentials?.accessKeyId,
+    opts.awsCredentials?.secretKey,
+    opts.awsCredentials?.sessionToken,
+    opts.awsRegion
+  )
   return new LocalConnection(db, opts)
 }
 
@@ -443,7 +449,7 @@ export interface Table<T = number[]> {
    */
   indexStats: (indexUuid: string) => Promise<IndexStats>
 
-  filter (value: string): Query<T>
+  filter(value: string): Query<T>
 
   schema: Promise<Schema>
 }

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -163,6 +163,7 @@ export async function connect (
       {
         uri: '',
         awsCredentials: undefined,
+        awsRegion: defaultAwsRegion,
         apiKey: undefined,
         region: defaultAwsRegion
       },

--- a/rust/ffi/node/src/lib.rs
+++ b/rust/ffi/node/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use lance::io::ObjectStoreParams;
 use neon::prelude::*;
-use object_store::aws::{self, AwsCredential, AwsCredentialProvider};
+use object_store::aws::{AwsCredential, AwsCredentialProvider};
 use object_store::CredentialProvider;
 use once_cell::sync::OnceCell;
 use tokio::runtime::Runtime;

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -24,7 +24,7 @@ use neon::types::buffer::TypedArray;
 use vectordb::TableRef;
 
 use crate::error::ResultExt;
-use crate::{convert, get_aws_creds, get_aws_region, runtime, JsDatabase};
+use crate::{convert, get_aws_credential_provider, get_aws_region, runtime, JsDatabase};
 
 pub(crate) struct JsTable {
     pub table: TableRef,
@@ -64,7 +64,7 @@ impl JsTable {
         let (deferred, promise) = cx.promise();
         let database = db.database.clone();
 
-        let aws_creds = get_aws_creds(&mut cx, 3)?;
+        let aws_creds = get_aws_credential_provider(&mut cx, 3)?;
         let aws_region = get_aws_region(&mut cx, 6)?;
 
         let params = WriteParams {
@@ -106,7 +106,7 @@ impl JsTable {
             "overwrite" => WriteMode::Overwrite,
             s => return cx.throw_error(format!("invalid write mode {}", s)),
         };
-        let aws_creds = get_aws_creds(&mut cx, 2)?;
+        let aws_creds = get_aws_credential_provider(&mut cx, 2)?;
         let aws_region = get_aws_region(&mut cx, 5)?;
 
         let params = WriteParams {

--- a/rust/vectordb/src/connection.rs
+++ b/rust/vectordb/src/connection.rs
@@ -123,6 +123,13 @@ impl ConnectOptions {
         self
     }
 
+    /// [`AwsCredential`] to use when connecting to S3.
+    ///
+    pub fn aws_creds(mut self, aws_creds: AwsCredential) -> Self {
+        self.aws_creds = Some(aws_creds);
+        self
+    }
+
     pub fn index_cache_size(mut self, index_cache_size: u32) -> Self {
         self.index_cache_size = index_cache_size;
         self
@@ -240,12 +247,13 @@ impl Database {
 
                 let plain_uri = url.to_string();
                 let os_params: ObjectStoreParams = if let Some(aws_creds) = &options.aws_creds {
-                    let credential_provider: Arc<dyn CredentialProvider<Credential = AwsCredential>> =
-                        Arc::new(StaticCredentialProvider::new(AwsCredential {
-                            key_id: aws_creds.key_id.clone(),
-                            secret_key: aws_creds.secret_key.clone(),
-                            token: aws_creds.token.clone(),
-                        }));
+                    let credential_provider: Arc<
+                        dyn CredentialProvider<Credential = AwsCredential>,
+                    > = Arc::new(StaticCredentialProvider::new(AwsCredential {
+                        key_id: aws_creds.key_id.clone(),
+                        secret_key: aws_creds.secret_key.clone(),
+                        token: aws_creds.token.clone(),
+                    }));
                     ObjectStoreParams::with_aws_credentials(
                         Some(credential_provider),
                         options.region.clone(),

--- a/rust/vectordb/src/connection.rs
+++ b/rust/vectordb/src/connection.rs
@@ -21,8 +21,10 @@ use std::sync::Arc;
 
 use arrow_array::RecordBatchReader;
 use lance::dataset::WriteParams;
-use lance::io::{ObjectStore, WrappingObjectStore};
-use object_store::local::LocalFileSystem;
+use lance::io::{ObjectStore, ObjectStoreParams, WrappingObjectStore};
+use object_store::{
+    aws::AwsCredential, local::LocalFileSystem, CredentialProvider, StaticCredentialProvider,
+};
 use snafu::prelude::*;
 
 use crate::error::{CreateDirSnafu, Error, InvalidTableNameSnafu, Result};
@@ -86,6 +88,9 @@ pub struct ConnectOptions {
     /// Lance Cloud host override
     pub host_override: Option<String>,
 
+    /// User provided AWS credentials
+    pub aws_creds: Option<AwsCredential>,
+
     /// The maximum number of indices to cache in memory. Defaults to 256.
     pub index_cache_size: u32,
 }
@@ -98,6 +103,7 @@ impl ConnectOptions {
             api_key: None,
             region: None,
             host_override: None,
+            aws_creds: None,
             index_cache_size: 256,
         }
     }
@@ -176,6 +182,12 @@ impl Database {
     ///
     /// * A [Database] object.
     pub async fn connect(uri: &str) -> Result<Database> {
+        let options = ConnectOptions::new(uri);
+        Self::connect_with_options(&options).await
+    }
+
+    pub async fn connect_with_options(options: &ConnectOptions) -> Result<Database> {
+        let uri = &options.uri;
         let parse_res = url::Url::parse(uri);
 
         match parse_res {
@@ -227,7 +239,22 @@ impl Database {
                 };
 
                 let plain_uri = url.to_string();
-                let (object_store, base_path) = ObjectStore::from_uri(&plain_uri).await?;
+                let os_params: ObjectStoreParams = if let Some(aws_creds) = &options.aws_creds {
+                    let credential_provider: Arc<dyn CredentialProvider<Credential = AwsCredential>> =
+                        Arc::new(StaticCredentialProvider::new(AwsCredential {
+                            key_id: aws_creds.key_id.clone(),
+                            secret_key: aws_creds.secret_key.clone(),
+                            token: aws_creds.token.clone(),
+                        }));
+                    ObjectStoreParams::with_aws_credentials(
+                        Some(credential_provider),
+                        options.region.clone(),
+                    )
+                } else {
+                    ObjectStoreParams::default()
+                };
+                let (object_store, base_path) =
+                    ObjectStore::from_uri_and_params(&plain_uri, &os_params).await?;
                 if object_store.is_local() {
                     Self::try_create_dir(&plain_uri).context(CreateDirSnafu { path: plain_uri })?;
                 }


### PR DESCRIPTION
Passed the following tests

```ts
const keyId = process.env.AWS_ACCESS_KEY_ID;
const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
const sessionToken = process.env.AWS_SESSION_TOKEN;
const region = process.env.AWS_REGION;

const db = await lancedb.connect({
  uri: "s3://bucket/path",
  awsCredentials: {
    accessKeyId: keyId,
    secretKey: secretKey,
    sessionToken: sessionToken,
  },
  awsRegion: region,
} as lancedb.ConnectionOptions);

  console.log(await db.createTable("test", [{ vector: [1, 2, 3] }]));
  console.log(await db.tableNames());
  console.log(await db.dropTable("test"))
```