### PR TITLE
feat: add a filterable count_rows to all the lancedb APIs

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -372,7 +372,7 @@ export interface Table<T = number[]> {
   /**
    * Returns the number of rows in this table.
    */
-  countRows: () => Promise<number>
+  countRows: (filter?: string) => Promise<number>
 
   /**
    * Delete rows from this table.
@@ -840,8 +840,8 @@ export class LocalTable<T = number[]> implements Table<T> {
   /**
    * Returns the number of rows in this table.
    */
-  async countRows (): Promise<number> {
-    return tableCountRows.call(this._tbl)
+  async countRows (filter?: string): Promise<number> {
+    return tableCountRows.call(this._tbl, filter)
   }
 
   /**

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -294,6 +294,7 @@ describe('LanceDB client', function () {
       })
       assert.equal(table.name, 'vectors')
       assert.equal(await table.countRows(), 10)
+      assert.equal(await table.countRows("vectors IS NULL"), 0)
       assert.deepEqual(await con.tableNames(), ['vectors'])
     })
 
@@ -369,6 +370,7 @@ describe('LanceDB client', function () {
       const table = await con.createTable('f16', data)
       assert.equal(table.name, 'f16')
       assert.equal(await table.countRows(), total)
+      assert.equal(await table.countRows("id < 5"), 5)
       assert.deepEqual(await con.tableNames(), ['f16'])
       assert.deepEqual(await table.schema, schema)
 
@@ -780,7 +782,7 @@ describe('LanceDB client', function () {
     class TextEmbedding implements EmbeddingFunction<string> {
       sourceColumn: string
 
-      constructor (targetColumn: string) {
+      constructor(targetColumn: string) {
         this.sourceColumn = targetColumn
       }
 

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -294,7 +294,7 @@ describe('LanceDB client', function () {
       })
       assert.equal(table.name, 'vectors')
       assert.equal(await table.countRows(), 10)
-      assert.equal(await table.countRows('vectors IS NULL'), 0)
+      assert.equal(await table.countRows('vector IS NULL'), 0)
       assert.deepEqual(await con.tableNames(), ['vectors'])
     })
 
@@ -782,7 +782,7 @@ describe('LanceDB client', function () {
     class TextEmbedding implements EmbeddingFunction<string> {
       sourceColumn: string
 
-      constructor (targetColumn: string) {
+      constructor(targetColumn: string) {
         this.sourceColumn = targetColumn
       }
 
@@ -791,7 +791,7 @@ describe('LanceDB client', function () {
         ['bar', [3.1, 3.2]]
       ])
 
-      async embed (data: string[]): Promise<number[][]> {
+      async embed(data: string[]): Promise<number[][]> {
         return data.map(
           (datum) => this._embedding_map.get(datum) ?? [0.0, 0.0]
         )
@@ -924,7 +924,7 @@ describe('Query object', function () {
   })
 })
 
-async function createTestDB (
+async function createTestDB(
   numDimensions: number = 2,
   numRows: number = 2
 ): Promise<string> {

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -782,7 +782,7 @@ describe('LanceDB client', function () {
     class TextEmbedding implements EmbeddingFunction<string> {
       sourceColumn: string
 
-      constructor(targetColumn: string) {
+      constructor (targetColumn: string) {
         this.sourceColumn = targetColumn
       }
 
@@ -791,7 +791,7 @@ describe('LanceDB client', function () {
         ['bar', [3.1, 3.2]]
       ])
 
-      async embed(data: string[]): Promise<number[][]> {
+      async embed (data: string[]): Promise<number[][]> {
         return data.map(
           (datum) => this._embedding_map.get(datum) ?? [0.0, 0.0]
         )
@@ -924,7 +924,7 @@ describe('Query object', function () {
   })
 })
 
-async function createTestDB(
+async function createTestDB (
   numDimensions: number = 2,
   numRows: number = 2
 ): Promise<string> {

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -294,7 +294,7 @@ describe('LanceDB client', function () {
       })
       assert.equal(table.name, 'vectors')
       assert.equal(await table.countRows(), 10)
-      assert.equal(await table.countRows("vectors IS NULL"), 0)
+      assert.equal(await table.countRows('vectors IS NULL'), 0)
       assert.deepEqual(await con.tableNames(), ['vectors'])
     })
 
@@ -370,7 +370,7 @@ describe('LanceDB client', function () {
       const table = await con.createTable('f16', data)
       assert.equal(table.name, 'f16')
       assert.equal(await table.countRows(), total)
-      assert.equal(await table.countRows("id < 5"), 5)
+      assert.equal(await table.countRows('id < 5'), 5)
       assert.deepEqual(await con.tableNames(), ['f16'])
       assert.deepEqual(await table.schema, schema)
 
@@ -782,7 +782,7 @@ describe('LanceDB client', function () {
     class TextEmbedding implements EmbeddingFunction<string> {
       sourceColumn: string
 
-      constructor(targetColumn: string) {
+      constructor (targetColumn: string) {
         this.sourceColumn = targetColumn
       }
 

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -57,8 +57,8 @@ impl Table {
     }
 
     #[napi]
-    pub async fn count_rows(&self) -> napi::Result<usize> {
-        self.table.count_rows().await.map_err(|e| {
+    pub async fn count_rows(&self, filter: Option<String>) -> napi::Result<usize> {
+        self.table.count_rows(filter).await.map_err(|e| {
             napi::Error::from_reason(format!(
                 "Failed to count rows in table {}: {}",
                 self.table, e

--- a/nodejs/vectordb/native.d.ts
+++ b/nodejs/vectordb/native.d.ts
@@ -73,7 +73,7 @@ export class Table {
   /** Return Schema as empty Arrow IPC file. */
   schema(): Buffer
   add(buf: Buffer): Promise<void>
-  countRows(): Promise<bigint>
+  countRows(filter?: string): Promise<bigint>
   delete(predicate: string): Promise<void>
   createIndex(): IndexBuilder
   query(): Query

--- a/nodejs/vectordb/table.ts
+++ b/nodejs/vectordb/table.ts
@@ -50,8 +50,8 @@ export class Table {
   }
 
   /** Count the total number of rows in the dataset. */
-  async countRows(): Promise<bigint> {
-    return await this.inner.countRows();
+  async countRows(filter?: string): Promise<bigint> {
+    return await this.inner.countRows(filter);
   }
 
   /** Delete the rows that satisfy the predicate. */

--- a/python/lancedb/remote/table.py
+++ b/python/lancedb/remote/table.py
@@ -37,6 +37,9 @@ class RemoteTable(Table):
     def __repr__(self) -> str:
         return f"RemoteTable({self._conn.db_name}.{self._name})"
 
+    def __len__(self) -> int:
+        self.count_rows(None)
+
     @cached_property
     def schema(self) -> pa.Schema:
         """The [Arrow Schema](https://arrow.apache.org/docs/python/api/datatypes.html#)
@@ -407,6 +410,13 @@ class RemoteTable(Table):
         """compact_files() is not supported on the LanceDB cloud"""
         raise NotImplementedError(
             "compact_files() is not supported on the LanceDB cloud"
+        )
+
+    def count_rows(self, filter: Optional[str] = None) -> int:
+        # payload = {"filter": filter}
+        # self._conn._client.post(f"/v1/table/{self._name}/count_rows/", data=payload)
+        return NotImplementedError(
+            "count_rows() is not yet supported on the LanceDB cloud"
         )
 
 

--- a/python/lancedb/table.py
+++ b/python/lancedb/table.py
@@ -177,6 +177,18 @@ class Table(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def count_rows(self, filter: Optional[str] = None) -> int:
+        """
+        Count the number of rows in the table.
+
+        Parameters
+        ----------
+        filter: str, optional
+            A SQL where clause to filter the rows to count.
+        """
+        raise NotImplementedError
+
     def to_pandas(self) -> "pd.DataFrame":
         """Return the table as a pandas DataFrame.
 
@@ -926,14 +938,6 @@ class LanceTable(Table):
         self._ref.dataset = ds
 
     def count_rows(self, filter: Optional[str] = None) -> int:
-        """
-        Count the number of rows in the table.
-
-        Parameters
-        ----------
-        filter: str, optional
-            A SQL where clause to filter the rows to count.
-        """
         return self._dataset.count_rows(filter)
 
     def __len__(self):

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -135,9 +135,15 @@ impl JsTable {
         let js_table = cx.this().downcast_or_throw::<JsBox<Self>, _>(&mut cx)?;
         let filter = cx
             .argument_opt(0)
-            .map(|filt| {
-                filt.downcast_or_throw::<JsString, _>(&mut cx)
-                    .map(|js_filt| js_filt.deref().value(&mut cx))
+            .and_then(|filt| {
+                if filt.is_a::<JsUndefined, _>(&mut cx) || filt.is_a::<JsNull, _>(&mut cx) {
+                    None
+                } else {
+                    Some(
+                        filt.downcast_or_throw::<JsString, _>(&mut cx)
+                            .map(|js_filt| js_filt.deref().value(&mut cx)),
+                    )
+                }
             })
             .transpose()?;
         let rt = runtime(&mut cx)?;

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -133,13 +133,20 @@ impl JsTable {
 
     pub(crate) fn js_count_rows(mut cx: FunctionContext) -> JsResult<JsPromise> {
         let js_table = cx.this().downcast_or_throw::<JsBox<Self>, _>(&mut cx)?;
+        let filter = cx
+            .argument_opt(0)
+            .map(|filt| {
+                filt.downcast_or_throw::<JsString, _>(&mut cx)
+                    .map(|js_filt| js_filt.deref().value(&mut cx))
+            })
+            .transpose()?;
         let rt = runtime(&mut cx)?;
         let (deferred, promise) = cx.promise();
         let channel = cx.channel();
         let table = js_table.table.clone();
 
         rt.spawn(async move {
-            let num_rows_result = table.count_rows().await;
+            let num_rows_result = table.count_rows(filter).await;
 
             deferred.settle_with(&channel, move |mut cx| {
                 let num_rows = num_rows_result.or_throw(&mut cx)?;

--- a/rust/vectordb/src/index.rs
+++ b/rust/vectordb/src/index.rs
@@ -197,7 +197,7 @@ impl IndexBuilder {
                 let num_partitions = if let Some(n) = self.num_partitions {
                     n
                 } else {
-                    suggested_num_partitions(self.table.count_rows().await?)
+                    suggested_num_partitions(self.table.count_rows(None).await?)
                 };
                 let num_sub_vectors: u32 = if let Some(n) = self.num_sub_vectors {
                     n

--- a/rust/vectordb/src/io/object_store.rs
+++ b/rust/vectordb/src/io/object_store.rs
@@ -372,7 +372,7 @@ mod test {
         // leave this here for easy debugging
         let t = res.unwrap();
 
-        assert_eq!(t.count_rows().await.unwrap(), 100);
+        assert_eq!(t.count_rows(None).await.unwrap(), 100);
 
         let q = t
             .search(&[0.1, 0.1, 0.1, 0.1])

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -951,7 +951,7 @@ mod tests {
         let table = NativeTable::create(&uri, "test", batches, None, None)
             .await
             .unwrap();
-        assert_eq!(table.count_rows().await.unwrap(), 10);
+        assert_eq!(table.count_rows(None).await.unwrap(), 10);
 
         // Create new data with i=5..15
         let new_batches = Box::new(make_test_batches_with_offset(5));
@@ -961,7 +961,7 @@ mod tests {
         merge_insert_builder.when_not_matched_insert_all();
         merge_insert_builder.execute(new_batches).await.unwrap();
         // Only 5 rows should actually be inserted
-        assert_eq!(table.count_rows().await.unwrap(), 15);
+        assert_eq!(table.count_rows(None).await.unwrap(), 15);
 
         // Create new data with i=15..25 (no id matches)
         let new_batches = Box::new(make_test_batches_with_offset(15));
@@ -970,7 +970,7 @@ mod tests {
         merge_insert_builder.when_matched_update_all();
         merge_insert_builder.execute(new_batches).await.unwrap();
         // No new rows should have been inserted
-        assert_eq!(table.count_rows().await.unwrap(), 15);
+        assert_eq!(table.count_rows(None).await.unwrap(), 15);
     }
 
     #[tokio::test]


### PR DESCRIPTION
A `count_rows` method that takes a filter was recently added to `LanceTable`.  This PR adds it everywhere else except `RemoteTable` (that will come soon).