### PR TITLE
[docs]: Fix typos and clarity in hybrid search docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,8 +91,8 @@ nav:
     - Vector Search: search.md
     - Full-text search: fts.md
     - Hybrid search:
-      - hybrid_search/hybrid_search.md
-      - AirBNB financial data example: notebooks/hybrid_search.ipynb
+      - Overview: hybrid_search/hybrid_search.md
+      - Airbnb financial data example: notebooks/hybrid_search.ipynb
     - Filtering: sql.md
     - Versioning & Reproducibility: notebooks/reproducibility.ipynb
     - Configuring Storage: guides/storage.md
@@ -155,8 +155,8 @@ nav:
     - Vector Search: search.md
     - Full-text search: fts.md
     - Hybrid search:
-      - hybrid_search/hybrid_search.md
-      - AirBNB financial data example: notebooks/hybrid_search.ipynb
+      - Overview: hybrid_search/hybrid_search.md
+      - Airbnb financial data example: notebooks/hybrid_search.ipynb
     - Filtering: sql.md
     - Versioning & Reproducibility: notebooks/reproducibility.ipynb
     - Configuring Storage: guides/storage.md

--- a/docs/src/hybrid_search/hybrid_search.md
+++ b/docs/src/hybrid_search/hybrid_search.md
@@ -1,6 +1,6 @@
 # Hybrid Search
 
-LanceDB supports both semantic and keyword-based search. In real world applications, it is often useful to combine these two approaches to get the best best results. For example, you may want to search for a document that is semantically similar to a query document, but also contains a specific keyword. This is an example of *hybrid search*, a search algorithm that combines multiple search techniques.
+LanceDB supports both semantic and keyword-based search (also termed full-text search, or FTS). In real world applications, it is often useful to combine these two approaches to get the best best results. For example, you may want to search for a document that is semantically similar to a query document, but also contains a specific keyword. This is an example of *hybrid search*, a search algorithm that combines multiple search techniques.
 
 ## Hybrid search in LanceDB
 You can perform hybrid search in LanceDB by combining the results of semantic and full-text search via a reranking algorithm of your choice. LanceDB provides multiple rerankers out of the box. However, you can always write a custom reranker if your use case need more sophisticated logic .

--- a/docs/src/notebooks/hybrid_search.ipynb
+++ b/docs/src/notebooks/hybrid_search.ipynb
@@ -5,13 +5,13 @@
    "id": "0daef1cd-9130-46b8-8eb8-1b721860e239",
    "metadata": {},
    "source": [
-    "# [Example] AirBNB fincial data search\n",
+    "# Example - Airbnb financial data search\n",
     "\n",
     "<a href=\"https://colab.research.google.com/github/lancedb/lancedb/blob/main/docs/src/notebooks/hybrid_search.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a> \n",
     "\n",
-    "LanceDB supports both semantic and keyword-based search. In real world applications, it is often useful to combine these two approaches to get the best best results. For example, you may want to search for a document that is semantically similar to a query document, but also contains a specific keyword. This is an example of hybrid search, a search algorithm that combines multiple search techniques.\n",
+    "The code below is an example of hybrid search, a search algorithm that combines FTS and vector search in LanceDB.\n",
     "\n",
-    "Let's get stared with an Example. In this notebook we'll use AirBNB financial data document to search for \"the specific reasons for higher operating costs\" in that particular year"
+    "Let's get stared with an example. In this notebook we'll use Airbnb financial data documents to search for \"the specific reasons for higher operating costs\" in a particular year."
    ]
   },
   {


### PR DESCRIPTION
- Fixed typos and added some clarity to the hybrid search docs
- Changed "Airbnb" case to be as per the [official company name](https://en.wikipedia.org/wiki/Airbnb) (the "bnb" shouldn't be capitalized", and the text in the document aligns with this
- Fixed headers in nav bar