### PR TITLE
fix: use static C runtime on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -33,3 +33,8 @@ rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2,+fma,+f16c"
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon,+fp16,+fhm,+dotprod"]
+
+# Not all Windows systems have the C runtime installed, so this avoids library
+# not found errors on systems that are missing it.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
We depend on C static runtime, but not all Windows machines have that. So might be worth statically linking it.

https://github.com/reorproject/reor/issues/36#issuecomment-1948876463