### PR TITLE
docs: Add meta tag for image preview

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -206,6 +206,7 @@ extra_css:
 
 extra_javascript:
   - "extra_js/init_ask_ai_widget.js"
+  - "extra_js/meta_tag.js"
 
 extra:
   analytics:

--- a/docs/src/extra_js/meta_tag.js
+++ b/docs/src/extra_js/meta_tag.js
@@ -1,0 +1,6 @@
+window.addEventListener('load', function() {
+    var meta = document.createElement('meta');
+    meta.setAttribute('property', 'og:image');
+    meta.setAttribute('content', '/assets/lancedb_and_lance.png');
+    document.head.appendChild(meta);
+  });


### PR DESCRIPTION
I think this should work. Need to deploy it to be sure as it can be tested locally. Can be tested here.

2 things about this solution:
* All pages have a same meta tag, i.e, lancedb banner
* If needed, we can automatically use the first image of each page and generate meta tags using the ultralytics mkdocs plugin that we did for this purpose - https://github.com/ultralytics/mkdocs