### PR TITLE
refactor: rust vectordb API stabilization of the Connection trait

### DIFF
--- a/nodejs/src/connection.rs
+++ b/nodejs/src/connection.rs
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use napi::bindgen_prelude::*;
 use napi_derive::*;
 
 use crate::table::Table;
-use vectordb::connection::{Connection as LanceDBConnection, CreateTableOptions, OpenTableOptions};
+use vectordb::connection::Connection as LanceDBConnection;
 use vectordb::ipc::ipc_file_to_batches;
 
 #[napi]
 pub struct Connection {
-    conn: Arc<dyn LanceDBConnection>,
+    conn: LanceDBConnection,
 }
 
 #[napi]
@@ -32,7 +30,7 @@ impl Connection {
     #[napi(factory)]
     pub async fn new(uri: String) -> napi::Result<Self> {
         Ok(Self {
-            conn: vectordb::connect(&uri).await.map_err(|e| {
+            conn: vectordb::connect(&uri).execute().await.map_err(|e| {
                 napi::Error::from_reason(format!("Failed to connect to database: {}", e))
             })?,
         })
@@ -59,7 +57,8 @@ impl Connection {
             .map_err(|e| napi::Error::from_reason(format!("Failed to read IPC file: {}", e)))?;
         let tbl = self
             .conn
-            .create_table(&name, Box::new(batches), CreateTableOptions::default())
+            .create_table(&name, Box::new(batches))
+            .execute()
             .await
             .map_err(|e| napi::Error::from_reason(format!("{}", e)))?;
         Ok(Table::new(tbl))
@@ -69,7 +68,8 @@ impl Connection {
     pub async fn open_table(&self, name: String) -> napi::Result<Table> {
         let tbl = self
             .conn
-            .open_table(&name, OpenTableOptions::default())
+            .open_table(&name)
+            .execute()
             .await
             .map_err(|e| napi::Error::from_reason(format!("{}", e)))?;
         Ok(Table::new(tbl))

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -15,6 +15,7 @@
 use arrow_ipc::writer::FileWriter;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use vectordb::table::AddDataOptions;
 use vectordb::{ipc::ipc_file_to_batches, table::TableRef};
 
 use crate::index::IndexBuilder;
@@ -48,12 +49,15 @@ impl Table {
     pub async fn add(&self, buf: Buffer) -> napi::Result<()> {
         let batches = ipc_file_to_batches(buf.to_vec())
             .map_err(|e| napi::Error::from_reason(format!("Failed to read IPC file: {}", e)))?;
-        self.table.add(Box::new(batches), None).await.map_err(|e| {
-            napi::Error::from_reason(format!(
-                "Failed to add batches to table {}: {}",
-                self.table, e
-            ))
-        })
+        self.table
+            .add(Box::new(batches), AddDataOptions::default())
+            .await
+            .map_err(|e| {
+                napi::Error::from_reason(format!(
+                    "Failed to add batches to table {}: {}",
+                    self.table, e
+                ))
+            })
     }
 
     #[napi]

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -87,7 +87,6 @@ impl JsTable {
                     CreateTableOptions {
                         write_options: WriteTableOptions {
                             lance_write_params: Some(params),
-                            ..Default::default()
                         },
                         ..Default::default()
                     },
@@ -135,7 +134,6 @@ impl JsTable {
             let opts = AddDataOptions {
                 write_options: WriteTableOptions {
                     lance_write_params: Some(params),
-                    ..Default::default()
                 },
                 ..Default::default()
             };

--- a/rust/vectordb/examples/simple.rs
+++ b/rust/vectordb/examples/simple.rs
@@ -19,6 +19,8 @@ use arrow_array::{FixedSizeListArray, Int32Array, RecordBatch, RecordBatchIterat
 use arrow_schema::{DataType, Field, Schema};
 use futures::TryStreamExt;
 
+use vectordb::connection::{CreateTableOptions, OpenTableOptions};
+use vectordb::table::AddDataOptions;
 use vectordb::Connection;
 use vectordb::{connect, Result, Table, TableRef};
 
@@ -58,7 +60,7 @@ async fn open_with_existing_tbl() -> Result<()> {
     let db = connect(uri).await?;
     // --8<-- [start:open_with_existing_file]
     let _ = db
-        .open_table_with_params("my_table", Default::default())
+        .open_table("my_table", OpenTableOptions::default())
         .await
         .unwrap();
     // --8<-- [end:open_with_existing_file]
@@ -102,7 +104,7 @@ async fn create_table(db: Arc<dyn Connection>) -> Result<TableRef> {
         schema.clone(),
     );
     let tbl = db
-        .create_table("my_table", Box::new(batches), None)
+        .create_table("my_table", Box::new(batches), CreateTableOptions::default())
         .await
         .unwrap();
     // --8<-- [end:create_table]
@@ -126,7 +128,9 @@ async fn create_table(db: Arc<dyn Connection>) -> Result<TableRef> {
         schema.clone(),
     );
     // --8<-- [start:add]
-    tbl.add(Box::new(new_batches), None).await.unwrap();
+    tbl.add(Box::new(new_batches), AddDataOptions::default())
+        .await
+        .unwrap();
     // --8<-- [end:add]
 
     Ok(tbl)
@@ -139,8 +143,12 @@ async fn create_empty_table(db: Arc<dyn Connection>) -> Result<TableRef> {
         Field::new("item", DataType::Utf8, true),
     ]));
     let batches = RecordBatchIterator::new(vec![], schema.clone());
-    db.create_table("empty_table", Box::new(batches), None)
-        .await
+    db.create_table(
+        "empty_table",
+        Box::new(batches),
+        CreateTableOptions::default(),
+    )
+    .await
     // --8<-- [end:create_empty_table]
 }
 

--- a/rust/vectordb/src/connection.rs
+++ b/rust/vectordb/src/connection.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! LanceDB Database
-//!
 
 use std::fs::create_dir_all;
 use std::path::Path;
@@ -56,11 +55,13 @@ impl Default for CreateTableMode {
 /// Describes what happens when a vector either contains NaN or
 /// does not have enough values
 #[derive(Clone, Debug)]
-pub enum BadVectorHandling {
+enum BadVectorHandling {
     /// An error is returned
     Error,
+    #[allow(dead_code)] // https://github.com/lancedb/lancedb/issues/992
     /// The offending row is droppped
     Drop,
+    #[allow(dead_code)] // https://github.com/lancedb/lancedb/issues/992
     /// The invalid/missing items are replaced by fill_value
     Fill(f32),
 }
@@ -85,9 +86,13 @@ pub struct OpenTableOptions {
     ///
     /// The default value is 256
     ///
-    /// The exact meaning will depend on the type of index:
+    /// The exact meaning of an "entry" will depend on the type of index:
     /// * IVF - there is one entry for each IVF partition
     /// * BTREE - there is one entry for the entire index
+    ///
+    /// This cache applies to the entire opened table, across all indices.
+    /// Setting this value higher will increase performance on larger datasets
+    /// at the expense of more RAM
     pub index_cache_size: u64,
     /// Advanced parameters that can be used to customize table reads
     ///
@@ -216,7 +221,6 @@ impl ConnectOptions {
     }
 
     /// [`AwsCredential`] to use when connecting to S3.
-    ///
     pub fn aws_creds(mut self, aws_creds: AwsCredential) -> Self {
         self.aws_creds = Some(aws_creds);
         self

--- a/rust/vectordb/src/connection.rs
+++ b/rust/vectordb/src/connection.rs
@@ -52,7 +52,7 @@ impl CreateTableMode {
     pub fn exist_ok(
         callback: impl FnOnce(OpenTableBuilder) -> OpenTableBuilder + Send + 'static,
     ) -> Self {
-        CreateTableMode::ExistOk(Box::new(callback))
+        Self::ExistOk(Box::new(callback))
     }
 }
 
@@ -101,7 +101,7 @@ impl CreateTableBuilder<true> {
     ) -> Self {
         Self {
             parent,
-            name: name,
+            name,
             data: Some(data),
             schema: None,
             mode: CreateTableMode::default(),
@@ -126,7 +126,7 @@ impl CreateTableBuilder<false> {
     fn new(parent: Arc<dyn ConnectionInternal>, name: String, schema: SchemaRef) -> Self {
         Self {
             parent,
-            name: name,
+            name,
             data: None,
             schema: Some(schema),
             mode: CreateTableMode::default(),

--- a/rust/vectordb/src/connection.rs
+++ b/rust/vectordb/src/connection.rs
@@ -64,9 +64,10 @@ impl Default for CreateTableMode {
 
 /// Describes what happens when a vector either contains NaN or
 /// does not have enough values
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 enum BadVectorHandling {
     /// An error is returned
+    #[default]
     Error,
     #[allow(dead_code)] // https://github.com/lancedb/lancedb/issues/992
     /// The offending row is droppped
@@ -74,12 +75,6 @@ enum BadVectorHandling {
     #[allow(dead_code)] // https://github.com/lancedb/lancedb/issues/992
     /// The invalid/missing items are replaced by fill_value
     Fill(f32),
-}
-
-impl Default for BadVectorHandling {
-    fn default() -> Self {
-        Self::Error
-    }
 }
 
 /// A builder for configuring a [`Connection::create_table`] operation

--- a/rust/vectordb/src/data/sanitize.rs
+++ b/rust/vectordb/src/data/sanitize.rs
@@ -174,7 +174,6 @@ fn coerce_schema_batch(
 }
 
 /// Coerce the reader (input data) to match the given [Schema].
-///
 pub fn coerce_schema(
     reader: impl RecordBatchReader + Send + 'static,
     schema: Arc<Schema>,

--- a/rust/vectordb/src/io/object_store.rs
+++ b/rust/vectordb/src/io/object_store.rs
@@ -370,7 +370,6 @@ mod test {
         let create_opts = CreateTableOptions {
             write_options: WriteTableOptions {
                 lance_write_params: Some(param),
-                ..Default::default()
             },
             ..Default::default()
         };

--- a/rust/vectordb/src/lib.rs
+++ b/rust/vectordb/src/lib.rs
@@ -179,7 +179,7 @@ pub mod query;
 pub mod table;
 pub mod utils;
 
-pub use connection::{Connection, Database};
+pub use connection::Connection;
 pub use error::{Error, Result};
 pub use table::{Table, TableRef};
 

--- a/rust/vectordb/src/query.rs
+++ b/rust/vectordb/src/query.rs
@@ -60,7 +60,6 @@ impl Query {
     /// # Arguments
     ///
     /// * `dataset` - Lance dataset.
-    ///
     pub(crate) fn new(dataset: Arc<Dataset>) -> Self {
         Self {
             dataset,

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -1102,7 +1102,6 @@ mod tests {
                 lance_write_params: Some(param),
             },
             mode: AddDataMode::Append,
-            ..Default::default()
         };
 
         let new_batches = RecordBatchIterator::new(batches.clone(), schema.clone());

--- a/rust/vectordb/src/table.rs
+++ b/rust/vectordb/src/table.rs
@@ -96,18 +96,13 @@ pub struct WriteOptions {
     pub lance_write_params: Option<WriteParams>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum AddDataMode {
     /// Rows will be appended to the table (the default)
+    #[default]
     Append,
     /// The existing table will be overwritten with the new data
     Overwrite,
-}
-
-impl Default for AddDataMode {
-    fn default() -> Self {
-        Self::Append
-    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/rust/vectordb/src/utils.rs
+++ b/rust/vectordb/src/utils.rs
@@ -32,20 +32,17 @@ impl PatchStoreParam for Option<ObjectStoreParams> {
 }
 
 pub trait PatchWriteParam {
-    fn patch_with_store_wrapper(
-        self,
-        wrapper: Arc<dyn WrappingObjectStore>,
-    ) -> Result<Option<WriteParams>>;
+    fn patch_with_store_wrapper(self, wrapper: Arc<dyn WrappingObjectStore>)
+        -> Result<WriteParams>;
 }
 
-impl PatchWriteParam for Option<WriteParams> {
+impl PatchWriteParam for WriteParams {
     fn patch_with_store_wrapper(
-        self,
+        mut self,
         wrapper: Arc<dyn WrappingObjectStore>,
-    ) -> Result<Option<WriteParams>> {
-        let mut params = self.unwrap_or_default();
-        params.store_params = params.store_params.patch_with_store_wrapper(wrapper)?;
-        Ok(Some(params))
+    ) -> Result<WriteParams> {
+        self.store_params = self.store_params.patch_with_store_wrapper(wrapper)?;
+        Ok(self)
     }
 }
 


### PR DESCRIPTION
This is the start of a more comprehensive refactor and stabilization of the Rust API.  The `Connection` trait is cleaned up to not require `lance` and to match the `Connection` trait in other APIs.  In addition, the concrete implementation `Database` is hidden.

BREAKING CHANGE: The struct `crate::connection::Database` is now gone.  Several examples opened a connection using `Database::connect` or `Database::connect_with_params`.  Users should now use `vectordb::connect`.

BREAKING CHANGE: The `connect`, `create_table`, and `open_table` methods now all return a builder object.  This means that a call like `conn.open_table(..., opt1, opt2)` will now become `conn.open_table(...).opt1(opt1).opt2(opt2).execute()`  In addition, the structure of options has changed slightly.  However, no options capability has been removed.