### PR TITLE
fix(python): Few fts patches

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -587,27 +587,25 @@ class LanceFtsQueryBuilder(LanceQueryBuilder):
         scores = pa.array(scores)
         output_tbl = self._table.to_lance().take(row_ids, columns=self._columns)
         output_tbl = output_tbl.append_column("score", scores)
-
-        if self._with_row_id:
-            # Need to set this to uint explicitly as vector results are in uint64
-            row_ids = pa.array(row_ids, type=pa.uint64())
-            output_tbl = output_tbl.append_column("_rowid", row_ids)
+        # this needs to match vector search results which are uint64
+        row_ids = pa.array(row_ids, type=pa.uint64())
 
         if self._where is not None:
+            tmp_name = "__lancedb__duckdb__indexer__"
+            output_tbl = output_tbl.append_column(
+                tmp_name, pa.array(range(len(output_tbl)))
+            )
             try:
                 # TODO would be great to have Substrait generate pyarrow compute
                 # expressions or conversely have pyarrow support SQL expressions
                 # using Substrait
                 import duckdb
 
-                schema = output_tbl.schema
-                output_tbl = (
-                    duckdb.sql("SELECT * FROM output_tbl")
-                    .filter(self._where)
-                    .to_arrow_table()
-                )
-                # output_tbl's fixed_size_list is now mutated to list
-                output_tbl = output_tbl.cast(schema)
+                indexer = duckdb.sql(
+                    f"SELECT {tmp_name} FROM output_tbl WHERE {self._where}"
+                ).to_arrow_table()[tmp_name]
+                output_tbl = output_tbl.take(indexer).drop([tmp_name])
+                row_ids = row_ids.take(indexer)
 
             except ImportError:
                 import tempfile
@@ -616,16 +614,14 @@ class LanceFtsQueryBuilder(LanceQueryBuilder):
 
                 # TODO Use "memory://" instead once that's supported
                 with tempfile.TemporaryDirectory() as tmp:
-                    # Filtering panicks if row_id is already attached
-                    if self._with_row_id:
-                        raise ValueError(
-                            "Filtering without duckdb is not supported when\
-                            `with_row_id` is set. Please install duckdb:\
-                            ``pip install duckdb``."
-                        )
                     ds = lance.write_dataset(output_tbl, tmp)
-
                     output_tbl = ds.to_table(filter=self._where)
+                    indexer = output_tbl[tmp_name]
+                    row_ids = row_ids.take(indexer)
+                    output_tbl = output_tbl.drop([tmp_name])
+
+        if self._with_row_id:
+            output_tbl = output_tbl.append_column("_rowid", row_ids)
         return output_tbl
 
 

--- a/python/python/tests/test_fts.py
+++ b/python/python/tests/test_fts.py
@@ -145,10 +145,6 @@ def test_search_index_with_filter(table):
         for r in rs:
             assert r["id"] == 1
 
-        # test with row_id. should throw an error without duckdb
-        with pytest.raises(ValueError):
-            table.search("puppy").where("id=1").with_row_id(True).limit(10).to_arrow()
-
     # yes duckdb
     rs2 = table.search("puppy").where("id=1").limit(10).to_list()
     for r in rs2:

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -857,7 +857,7 @@ def test_hybrid_search(db, tmp_path):
 
     assert result1 == result3
 
-    # with with filters
+    # with post filters
     result = (
         table.search("Arrrrggghhhhhhh", query_type="hybrid")
         .where("text='Arrrrggghhhhhhh'")

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -854,7 +854,16 @@ def test_hybrid_search(db, tmp_path):
     result3 = table.search(
         "Our father who art in heaven", query_type="hybrid"
     ).to_pydantic(MyTable)
+
     assert result1 == result3
+
+    # with with filters
+    result = (
+        table.search("Arrrrggghhhhhhh", query_type="hybrid")
+        .where("text='Arrrrggghhhhhhh'")
+        .to_list()
+    )
+    len(result) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
1. filtering with fts mutated the schema, which caused schema mistmatch problems with hybrid search as it combines fts and vector search tables.
2. fts with filter failed with `with_row_id`. This was because row_id was calculated before filtering which caused size mismatch on attaching it after. 
3. The fix for 1 meant that now row_id is attached before filtering but passing a filter to `to_lance` on a dataset that already contains `_rowid` raises a panic from lance. So temporarily, in case where fts is used with a filter AND `with_row_id`, we just force user to using the duckdb pathway.
