### PR TITLE
fix: propagate filter validation errors

### DIFF
--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -128,6 +128,11 @@ describe('LanceDB client', function () {
       assertResults(results)
       results = await table.where('id % 2 = 0').execute()
       assertResults(results)
+
+      // Should reject a bad filter
+      await expect(table.filter('id % 2 = 0 AND').execute()).to.be.rejectedWith(
+        /.*sql parser error: Expected an expression:, found: EOF.*/
+      )
     })
 
     it('uses a filter / where clause', async function () {

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -363,6 +363,10 @@ mod tests {
             let arr: &Int32Array = b["id"].as_primitive();
             assert!(arr.iter().all(|x| x.unwrap() % 2 == 0));
         }
+
+        // Reject bad filter
+        let result = table.query().filter("id = 0 AND").execute_stream().await;
+        assert!(result.is_err());
     }
 
     fn make_non_empty_batches() -> impl RecordBatchReader + Send + 'static {

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -978,9 +978,17 @@ impl TableInternal for NativeTable {
             Select::All => { /* Do nothing */ }
         }
 
-        query.filter.as_ref().map(|f| scanner.filter(f));
-        query.refine_factor.map(|rf| scanner.refine(rf));
-        query.metric_type.map(|mt| scanner.distance_metric(mt));
+        if let Some(filter) = &query.filter {
+            scanner.filter(filter)?;
+        }
+
+        if let Some(refine_factor) = query.refine_factor {
+            scanner.refine(refine_factor);
+        }
+
+        if let Some(metric_type) = query.metric_type {
+            scanner.distance_metric(metric_type);
+        }
         Ok(scanner.try_into_stream().await?)
     }
 


### PR DESCRIPTION
In Rust and Node, we have been swallowing filter validation errors. If there was an error in parsing the filter, then the filter was silently ignored, returning unfiltered results.

Fixes #1081