### PR TITLE
fix(python): Add python azure blob read support

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -81,6 +81,9 @@ embeddings = [
     "awscli>=1.29.57",
     "botocore>=1.31.57",
 ]
+azure = [
+    "adlfs>=2024.2.0"
+]
 
 [tool.maturin]
 python-source = "python"


### PR DESCRIPTION
I know there's a larger effort to have the python client based on the core rust implementation, but in the meantime there have been several issues (#1072 and #485) with some of the azure blob storage calls due to pyarrow not natively supporting an azure backend. To this end, I've added an optional import of the fsspec implementation of azure blob storage [`adlfs`](https://pypi.org/project/adlfs/) and passed it to `pyarrow.fs`. I've modified the existing test and manually verified it with some real credentials to make sure it behaves as expected.

It should be now as simple as:

```python
import lancedb

db = lancedb.connect("az://blob_name/path")
table = db.open_table("test")
table.search(...)
```

Thank you for this cool project and we're excited to start using this for real shortly! 🎉  And thanks to @dwhitena for bringing it to my attention with his prediction guard posts.