### PR TITLE
Node SDK Client middleware for HTTP Requests

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -309,7 +309,7 @@ export interface Connection {
    *
    * The middleware will be called in the order they are added.
    *
-   *  Currently this functionality is only supported for remote Connections.
+   * Currently this functionality is only supported for remote Connections.
    *
    * @param {HttpMiddleware} - Middleware which will instrument the Connection.
    * @returns - this Connection instrumented by the passed middleware

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -556,7 +556,7 @@ export interface Table<T = number[]> {
   /**
    * Instrument the behavior of this Table with middleware.
    *
-   * The middlewares callback implementations will be called in the order they are added.
+   * The middleware will be called in the order they are added.
    *
    * @param {ConnectionMiddleware} - Middleware which will instrument the .
    * @returns - this Table instrumented by the passed middleware

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -24,7 +24,7 @@ import { RemoteConnection } from './remote'
 import { Query } from './query'
 import { isEmbeddingFunction } from './embedding/embedding_function'
 import { type Literal, toSQL } from './util'
-import { type ConnectionMiddleware } from './middleware'
+import { type HttpMiddleware } from './middleware'
 
 const {
   databaseNew,
@@ -305,16 +305,14 @@ export interface Connection {
   dropTable(name: string): Promise<void>
 
   /**
-   * Instrument the behavior of this connection with middleware.
+   * Instrument the behavior of this Connection with middleware.
    *
-   * The middlewares will be added in a chain and their respective instrumentation
-   * callback implementations will be called in the order they are passed into
-   * invocations of this method.
+   * The middlewares callback implementations will be called in the order they are added.
    *
-   * @param {ConnectionMiddleware} - Middleware which will instrument the connection.
-   * @returns - this connection instrumented by the passed middleware
+   * @param {HttpMiddleware} - Middleware which will instrument the Connection.
+   * @returns - this Connection instrumented by the passed middleware
    */
-  withMiddleware(middleware: ConnectionMiddleware): Connection
+  withMiddleware(middleware: HttpMiddleware): Connection
 }
 
 /**
@@ -555,7 +553,15 @@ export interface Table<T = number[]> {
    */
   dropColumns(columnNames: string[]): Promise<void>
 
-  // TODO add methods for middleware
+  /**
+   * Instrument the behavior of this Table with middleware.
+   *
+   * The middlewares callback implementations will be called in the order they are added.
+   *
+   * @param {ConnectionMiddleware} - Middleware which will instrument the .
+   * @returns - this Table instrumented by the passed middleware
+   */
+  withMiddleware(middleware: HttpMiddleware): Table<T>
 }
 
 /**
@@ -811,8 +817,7 @@ export class LocalConnection implements Connection {
     await databaseDropTable.call(this._db, name)
   }
 
-  withMiddleware (middleware: ConnectionMiddleware): Connection {
-    // noop
+  withMiddleware (middleware: HttpMiddleware): Connection {
     return this
   }
 }
@@ -1124,6 +1129,10 @@ export class LocalTable<T = number[]> implements Table<T> {
 
   async dropColumns (columnNames: string[]): Promise<void> {
     return tableDropColumns.call(this._tbl, columnNames)
+  }
+
+  withMiddleware (middleware: HttpMiddleware): Table<T> {
+    return this
   }
 }
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -24,7 +24,7 @@ import { RemoteConnection } from './remote'
 import { Query } from './query'
 import { isEmbeddingFunction } from './embedding/embedding_function'
 import { type Literal, toSQL } from './util'
-import { type ConnectionMiddleware, type MiddlewareContext } from './middleware'
+import { type ConnectionMiddleware } from './middleware'
 
 const {
   databaseNew,
@@ -315,15 +315,6 @@ export interface Connection {
    * @returns - this connection instrumented by the passed middleware
    */
   withMiddleware(middleware: ConnectionMiddleware): Connection
-
-  /**
-   * Set the context that will be passed to any middlewares that instrument this
-   * connection
-   *
-   * @param {MiddlewareContext} - Context that will be passed to middlewares
-   * @returns - this connection configured to pass the context to its middlewares
-   */
-  withMiddlewareContext(ctx: MiddlewareContext): Connection
 }
 
 /**
@@ -821,11 +812,6 @@ export class LocalConnection implements Connection {
   }
 
   withMiddleware (middleware: ConnectionMiddleware): Connection {
-    // noop
-    return this
-  }
-
-  withMiddlewareContext (ctx: MiddlewareContext): Connection {
     // noop
     return this
   }

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -307,7 +307,7 @@ export interface Connection {
   /**
    * Instrument the behavior of this Connection with middleware.
    *
-   * The middlewares callback implementations will be called in the order they are added.
+   * The middleware will be called in the order they are added.
    *
    * @param {HttpMiddleware} - Middleware which will instrument the Connection.
    * @returns - this Connection instrumented by the passed middleware

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -562,7 +562,7 @@ export interface Table<T = number[]> {
    *
    * Currently this functionality is only supported for remote tables.
    *
-   * @param {ConnectionMiddleware} - Middleware which will instrument the .
+   * @param {HttpMiddleware} - Middleware which will instrument the Table.
    * @returns - this Table instrumented by the passed middleware
    */
   withMiddleware(middleware: HttpMiddleware): Table<T>

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -309,6 +309,8 @@ export interface Connection {
    *
    * The middleware will be called in the order they are added.
    *
+   *  Currently this functionality is only supported for remote Connections.
+   *
    * @param {HttpMiddleware} - Middleware which will instrument the Connection.
    * @returns - this Connection instrumented by the passed middleware
    */
@@ -557,6 +559,8 @@ export interface Table<T = number[]> {
    * Instrument the behavior of this Table with middleware.
    *
    * The middleware will be called in the order they are added.
+   *
+   * Currently this functionality is only supported for remote tables.
    *
    * @param {ConnectionMiddleware} - Middleware which will instrument the .
    * @returns - this Table instrumented by the passed middleware

--- a/node/src/middleware.ts
+++ b/node/src/middleware.ts
@@ -22,7 +22,7 @@ export interface HttpMiddleware {
    * the request and return a response without making the request to the remote endpoint.
    * It can also be used to modify the response from the remote endpoint.
    *
-   * @param {RemoteResponse} res - Request ot the remote endpoint
+   * @param {RemoteResponse} res - Request to the remote endpoint
    * @param {onRemoteRequestNext} next - Callback to advance the middleware chain
    * @param {MiddlewareContext} ctx - Local context for ths invocation of the middleware
    */

--- a/node/src/middleware.ts
+++ b/node/src/middleware.ts
@@ -24,7 +24,6 @@ export interface HttpMiddleware {
    *
    * @param {RemoteResponse} res - Request to the remote endpoint
    * @param {onRemoteRequestNext} next - Callback to advance the middleware chain
-   * @param {MiddlewareContext} ctx - Local context for this invocation of the middleware
    */
   onRemoteRequest(
     req: RemoteRequest,

--- a/node/src/middleware.ts
+++ b/node/src/middleware.ts
@@ -43,8 +43,8 @@ export enum Method {
 export interface RemoteRequest {
   uri: string
   method: Method
-  headers: Record<string, string>
-  params?: Record<string, string | number>
+  headers: Map<string, string>
+  params?: Map<string, string>
   body?: any
 }
 
@@ -54,6 +54,6 @@ export interface RemoteRequest {
 export interface RemoteResponse {
   status: number
   statusText: string
-  headers: Record<string, string>
+  headers: Map<string, string>
   body: () => Promise<any>
 }

--- a/node/src/middleware.ts
+++ b/node/src/middleware.ts
@@ -24,7 +24,7 @@ export interface HttpMiddleware {
    *
    * @param {RemoteResponse} res - Request to the remote endpoint
    * @param {onRemoteRequestNext} next - Callback to advance the middleware chain
-   * @param {MiddlewareContext} ctx - Local context for ths invocation of the middleware
+   * @param {MiddlewareContext} ctx - Local context for this invocation of the middleware
    */
   onRemoteRequest(
     req: RemoteRequest,

--- a/node/src/middleware.ts
+++ b/node/src/middleware.ts
@@ -1,0 +1,142 @@
+// Copyright 2024 LanceDB Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Middleware for LanceDB Connection. This allows you to enhance the behaviour of
+ * LanceDB Connection
+ */
+export interface ConnectionMiddleware {
+  /**
+   * A callback that can be used to instrument the behaviour of http requests to remote
+   * tables. It can be used to add headers, modify the request, or even short-circuit
+   * the request and return a response without making the request to the remote endpoint.
+   * It can also be used to modify the response from the remote endpoint.
+   *
+   * @param {RemoteRes} res - Request ot the remote endpoint
+   * @param {onRemoteRequestNext} next - Callback to advance the middleware chain
+   * @param {MiddlewareContext} ctx - Local context for ths invocation of the middleware
+   */
+  onRemoteRequest(
+    req: RemoteRequest,
+    next: onRemoteRequestNext,
+    ctx: MiddlewareContext,
+  ): Promise<RemoteRes>
+};
+
+/**
+   * A callback that can be used to instrument the behaviour of http requests to remote
+   * tables
+   */
+export interface TableMiddleware {
+  /**
+   * A callback that can be used to instrument the behaviour of http requests to remote
+   * tables. It can be used to add headers, modify the request, or even short-circuit
+   * the request and return a response without making the request to the remote endpoint.
+   * It can also be used to modify the response from the remote endpoint.
+   *
+   * @param {RemoteRes} res - Request ot the remote endpoint
+   * @param {onRemoteRequestNext} next - Callback to advance the middleware chain
+   * @param {MiddlewareContext} ctx - Local context for ths invocation of the middleware
+   */
+  onRemoteRequest(
+    req: RemoteRequest,
+    next: onRemoteRequestNext,
+    ctx: MiddlewareContext
+  ): Promise<RemoteRes>
+}
+
+/**
+ * next callback to middleware methods that instrument http requests
+ */
+export type onRemoteRequestNext = (
+  req: RemoteRequest,
+  ctx: MiddlewareContext,
+) => Promise<RemoteRes>
+
+/**
+ * Local context for invocation of middleware. Can be used to pass values from caller
+ * to middleware callback invocations, or from a middleware to another middleware
+ * further in the chain
+ */
+export interface MiddlewareContext {
+  /**
+   * Get a value from the context
+   * @param key - Key of value
+   * @returns Value for the key, or null if there is no value for the key
+   */
+  get(key: string): any | null
+
+  /**
+   * Set a value in the current context
+   * @param key - key of value to set
+   * @param value - the value to set
+   */
+  set(key: string, value: any): MiddlewareContext
+
+  /**
+   * Remove a value from the current context
+   * @param key - Key of the value to remove from context
+   */
+  delete(key: string): MiddlewareContext
+}
+
+export enum Method {
+  GET,
+  POST
+}
+
+/**
+ * A LanceDB Remote HTTP Request
+ */
+export interface RemoteRequest {
+  uri: string
+  method: Method
+  headers: Record<string, string>
+  params?: Record<string, string | number>
+}
+
+/**
+ * A LanceDB Remote HTTP Response
+ */
+export interface RemoteRes {
+  status: number
+  headers: Record<string, string>
+  body: () => Promise<any>
+}
+
+/**
+ * A basic implementation of MiddlewareContext.
+ */
+export class SimpleMiddlewareContext implements MiddlewareContext {
+  private context: Record<string, any> = {}
+
+  get (key: string): any | null {
+    const val: any = this.context[key]
+    if (val === undefined) {
+      return null
+    }
+    return val
+  }
+
+  set (key: string, value: any): MiddlewareContext {
+    this.context[key] = value
+    return this
+  }
+
+  delete (key: string): MiddlewareContext {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete this.context[key]
+    return this
+  }
+}

--- a/node/src/middleware.ts
+++ b/node/src/middleware.ts
@@ -45,7 +45,7 @@ export interface RemoteRequest {
   method: Method
   headers: Record<string, string>
   params?: Record<string, string | number>
-  data?: any
+  body?: any
 }
 
 /**

--- a/node/src/middleware.ts
+++ b/node/src/middleware.ts
@@ -13,83 +13,24 @@
 // limitations under the License.
 
 /**
- * Middleware for LanceDB Connection. This allows you to enhance the behaviour of
- * LanceDB Connection
+ * Middleware for Remote LanceDB Connection or Table
  */
-export interface ConnectionMiddleware {
+export interface HttpMiddleware {
   /**
-   * A callback that can be used to instrument the behaviour of http requests to remote
+   * A callback that can be used to instrument the behavior of http requests to remote
    * tables. It can be used to add headers, modify the request, or even short-circuit
    * the request and return a response without making the request to the remote endpoint.
    * It can also be used to modify the response from the remote endpoint.
    *
-   * @param {RemoteRes} res - Request ot the remote endpoint
+   * @param {RemoteResponse} res - Request ot the remote endpoint
    * @param {onRemoteRequestNext} next - Callback to advance the middleware chain
    * @param {MiddlewareContext} ctx - Local context for ths invocation of the middleware
    */
   onRemoteRequest(
     req: RemoteRequest,
-    next: onRemoteRequestNext,
-    ctx: MiddlewareContext,
-  ): Promise<RemoteRes>
+    next: (req: RemoteRequest) => Promise<RemoteResponse>,
+  ): Promise<RemoteResponse>
 };
-
-/**
-   * A callback that can be used to instrument the behaviour of http requests to remote
-   * tables
-   */
-export interface TableMiddleware {
-  /**
-   * A callback that can be used to instrument the behaviour of http requests to remote
-   * tables. It can be used to add headers, modify the request, or even short-circuit
-   * the request and return a response without making the request to the remote endpoint.
-   * It can also be used to modify the response from the remote endpoint.
-   *
-   * @param {RemoteRes} res - Request ot the remote endpoint
-   * @param {onRemoteRequestNext} next - Callback to advance the middleware chain
-   * @param {MiddlewareContext} ctx - Local context for ths invocation of the middleware
-   */
-  onRemoteRequest(
-    req: RemoteRequest,
-    next: onRemoteRequestNext,
-    ctx: MiddlewareContext
-  ): Promise<RemoteRes>
-}
-
-/**
- * next callback to middleware methods that instrument http requests
- */
-export type onRemoteRequestNext = (
-  req: RemoteRequest,
-  ctx: MiddlewareContext,
-) => Promise<RemoteRes>
-
-/**
- * Local context for invocation of middleware. Can be used to pass values from caller
- * to middleware callback invocations, or from a middleware to another middleware
- * further in the chain
- */
-export interface MiddlewareContext {
-  /**
-   * Get a value from the context
-   * @param key - Key of value
-   * @returns Value for the key, or null if there is no value for the key
-   */
-  get(key: string): any | null
-
-  /**
-   * Set a value in the current context
-   * @param key - key of value to set
-   * @param value - the value to set
-   */
-  set(key: string, value: any): MiddlewareContext
-
-  /**
-   * Remove a value from the current context
-   * @param key - Key of the value to remove from context
-   */
-  delete(key: string): MiddlewareContext
-}
 
 export enum Method {
   GET,
@@ -104,39 +45,15 @@ export interface RemoteRequest {
   method: Method
   headers: Record<string, string>
   params?: Record<string, string | number>
+  data?: any
 }
 
 /**
  * A LanceDB Remote HTTP Response
  */
-export interface RemoteRes {
+export interface RemoteResponse {
   status: number
+  statusText: string
   headers: Record<string, string>
   body: () => Promise<any>
-}
-
-/**
- * A basic implementation of MiddlewareContext.
- */
-export class SimpleMiddlewareContext implements MiddlewareContext {
-  private context: Record<string, any> = {}
-
-  get (key: string): any | null {
-    const val: any = this.context[key]
-    if (val === undefined) {
-      return null
-    }
-    return val
-  }
-
-  set (key: string, value: any): MiddlewareContext {
-    this.context[key] = value
-    return this
-  }
-
-  delete (key: string): MiddlewareContext {
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete this.context[key]
-    return this
-  }
 }

--- a/node/src/remote/client.ts
+++ b/node/src/remote/client.ts
@@ -69,7 +69,7 @@ async function callWithMiddlewares (
     return await middlewares[i - 1].onRemoteRequest(
       req,
       async (req) => {
-        return await call(i, req)
+        return await call(i + 1, req)
       }
     )
   }
@@ -206,7 +206,7 @@ export class HttpLancedbClient {
         ...(this._dbName !== undefined ? { 'x-lancedb-database': this._dbName } : {})
       },
       params,
-      data
+      body: data
     }
 
     let response

--- a/node/src/remote/client.ts
+++ b/node/src/remote/client.ts
@@ -43,7 +43,7 @@ async function callWithMiddlewares (
       if (req.method === Method.POST) {
         res = await axios.post(
           req.uri,
-          req.data,
+          req.body,
           {
             headers: { ...req.headers },
             params: req.params,
@@ -69,7 +69,7 @@ async function callWithMiddlewares (
     return await middlewares[i - 1].onRemoteRequest(
       req,
       async (req) => {
-        return await call(i + 1, req)
+        return await call(i, req)
       }
     )
   }

--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -85,7 +85,7 @@ export class RemoteConnection implements Connection {
     limit: number = 10
   ): Promise<string[]> {
     const response = await this._client.get('/v1/table/', {
-      limit,
+      limit: `${limit}`,
       page_token: pageToken
     })
     const body = await response.body()


### PR DESCRIPTION
Adds client-side middleware to LanceDB Node SDK to instrument HTTP Requests

Example - adding `x-request-id` request header:
```js
class HttpMiddleware {
    constructor({ requestId }) {
        this.requestId = requestId
    }

    onRemoteRequest(req, next) {
        req.headers['x-request-id'] = this.requestId
        return next(req)
    }
}

const db = await lancedb.connect({
  uri: 'db://remote-123',
  apiKey: 'sk_...',
})

let tables = await db.withMiddleware(new HttpMiddleware({ requestId: '123' })).tableNames();

```