### PR TITLE
chore: add nodejs to bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,21 @@
 [bumpversion]
-current_version = 0.4.14
+current_version = 0.4.15
 commit = True
 message = Bump version: {current_version} → {new_version}
 tag = True
 tag_name = v{new_version}
 
 [bumpversion:file:node/package.json]
+
+[bumpversion:file:nodejs/package.json]
+
+[bumpversion:file:nodejs/npm/darwin-x64/package.json]
+
+[bumpversion:file:nodejs/npm/darwin-arm64/package.json]
+
+[bumpversion:file:nodejs/npm/linux-x64-gnu/package.json]
+
+[bumpversion:file:nodejs/npm/linux-arm64-gnu/package.json]
 
 [bumpversion:file:rust/ffi/node/Cargo.toml]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.15
+current_version = 0.4.14
 commit = True
 message = Bump version: {current_version} → {new_version}
 tag = True

--- a/nodejs/npm/darwin-arm64/package.json
+++ b/nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lancedb/lancedb-darwin-arm64",
-  "version": "0.4.3",
+  "version": "0.4.14",
   "os": [
     "darwin"
   ],

--- a/nodejs/npm/darwin-x64/package.json
+++ b/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lancedb/lancedb-darwin-x64",
-  "version": "0.4.3",
+  "version": "0.4.14",
   "os": [
     "darwin"
   ],

--- a/nodejs/npm/linux-arm64-gnu/package.json
+++ b/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lancedb/lancedb-linux-arm64-gnu",
-  "version": "0.4.3",
+  "version": "0.4.14",
   "os": [
     "linux"
   ],

--- a/nodejs/npm/linux-x64-gnu/package.json
+++ b/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lancedb/lancedb-linux-x64-gnu",
-  "version": "0.4.3",
+  "version": "0.4.14",
   "os": [
     "linux"
   ],

--- a/nodejs/npm/win32-x64-msvc/package.json
+++ b/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lancedb/lancedb-win32-x64-msvc",
-  "version": "0.4.3",
+  "version": "0.4.14",
   "os": [
     "win32"
   ],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lancedb/lancedb",
-  "version": "0.4.3",
+  "version": "0.4.14",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "napi": {
@@ -67,11 +67,11 @@
     "version": "napi version"
   },
   "optionalDependencies": {
-    "@lancedb/lancedb-darwin-arm64": "0.4.3",
-    "@lancedb/lancedb-darwin-x64": "0.4.3",
-    "@lancedb/lancedb-linux-arm64-gnu": "0.4.3",
-    "@lancedb/lancedb-linux-x64-gnu": "0.4.3",
-    "@lancedb/lancedb-win32-x64-msvc": "0.4.3"
+    "@lancedb/lancedb-darwin-arm64": "0.4.14",
+    "@lancedb/lancedb-darwin-x64": "0.4.14",
+    "@lancedb/lancedb-linux-arm64-gnu": "0.4.14",
+    "@lancedb/lancedb-linux-x64-gnu": "0.4.14",
+    "@lancedb/lancedb-win32-x64-msvc": "0.4.14"
   },
   "dependencies": {
     "openai": "^4.29.2",


### PR DESCRIPTION
The previous release failed to release nodejs because the nodejs version wasn't bumped.  This should fix that.