### PR TITLE
docs: add a reference to @lancedb/lance in the docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -147,7 +147,8 @@ nav:
       - 💭 FAQs: faq.md
       - ⚙️ API reference:
           - 🐍 Python: python/python.md
-          - 👾 JavaScript: javascript/modules.md
+          - 👾 JavaScript (vectordb): javascript/modules.md
+          - 👾 JavaScript (lancedb): javascript/modules.md
           - 🦀 Rust: https://docs.rs/lancedb/latest/lancedb/
       - ☁️ LanceDB Cloud:
           - Overview: cloud/index.md
@@ -205,7 +206,8 @@ nav:
   - API reference:
       - Overview: api_reference.md
       - Python: python/python.md
-      - Javascript: javascript/modules.md
+      - Javascript (vectordb): javascript/modules.md
+      - Javascript (lancedb): js/modules.md
       - Rust: https://docs.rs/lancedb/latest/lancedb/index.html
   - LanceDB Cloud:
       - Overview: cloud/index.md

--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -3,5 +3,6 @@
 The API reference for the LanceDB client SDKs are available at the following locations:
 
 - [Python](python/python.md)
-- [JavaScript](javascript/modules.md)
+- [JavaScript (legacy vectordb package)](javascript/modules.md)
+- [JavaScript (newer @lancedb/lancedb package)](js/modules.md)
 - [Rust](https://docs.rs/lancedb/latest/lancedb/index.html)

--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -71,6 +71,16 @@
     --8<-- "docs/src/basic_legacy.ts:open_db"
     ```
 
+    !!! note "`@lancedb/lancedb` vs. `vectordb`"
+
+        The Javascript SDK was originally released as `vectordb`.  In an effort to
+        reduce maintenance we are aligning our SDKs.  The new, aligned, Javascript
+        API is being released as `lancedb`.  If you are starting new work we encourage
+        you to try out `lancedb`.  Once the new API is feature complete we will begin
+        slowly deprecating `vectordb` in favor of `lancedb`. There is a
+        [migration guide](migration.md) detailing the differences which will assist
+        you in this process.
+
 === "Rust"
 
     ```rust

--- a/docs/src/js/.nojekyll
+++ b/docs/src/js/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/src/js/README.md
+++ b/docs/src/js/README.md
@@ -1,3 +1,5 @@
+@lancedb/lancedb / [Exports](modules.md)
+
 # LanceDB JavaScript SDK
 
 A JavaScript library for [LanceDB](https://github.com/lancedb/lancedb).

--- a/docs/src/js/classes/Connection.md
+++ b/docs/src/js/classes/Connection.md
@@ -1,0 +1,239 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / Connection
+
+# Class: Connection
+
+A LanceDB Connection that allows you to open tables and create new ones.
+
+Connection could be local against filesystem or remote against a server.
+
+A Connection is intended to be a long lived object and may hold open
+resources such as HTTP connection pools.  This is generally fine and
+a single connection should be shared if it is going to be used many
+times. However, if you are finished with a connection, you may call
+close to eagerly free these resources.  Any call to a Connection
+method after it has been closed will result in an error.
+
+Closing a connection is optional.  Connections will automatically
+be closed when they are garbage collected.
+
+Any created tables are independent and will continue to work even if
+the underlying connection has been closed.
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Connection.md#constructor)
+
+### Properties
+
+- [inner](Connection.md#inner)
+
+### Methods
+
+- [close](Connection.md#close)
+- [createEmptyTable](Connection.md#createemptytable)
+- [createTable](Connection.md#createtable)
+- [display](Connection.md#display)
+- [dropTable](Connection.md#droptable)
+- [isOpen](Connection.md#isopen)
+- [openTable](Connection.md#opentable)
+- [tableNames](Connection.md#tablenames)
+
+## Constructors
+
+### constructor
+
+• **new Connection**(`inner`): [`Connection`](Connection.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `inner` | `Connection` |
+
+#### Returns
+
+[`Connection`](Connection.md)
+
+#### Defined in
+
+[connection.ts:72](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L72)
+
+## Properties
+
+### inner
+
+• `Readonly` **inner**: `Connection`
+
+#### Defined in
+
+[connection.ts:70](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L70)
+
+## Methods
+
+### close
+
+▸ **close**(): `void`
+
+Close the connection, releasing any underlying resources.
+
+It is safe to call this method multiple times.
+
+Any attempt to use the connection after it is closed will result in an error.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[connection.ts:88](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L88)
+
+___
+
+### createEmptyTable
+
+▸ **createEmptyTable**(`name`, `schema`, `options?`): `Promise`\<[`Table`](Table.md)\>
+
+Creates a new empty Table
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+| `schema` | `Schema`\<`any`\> | The schema of the table |
+| `options?` | `Partial`\<[`CreateTableOptions`](../interfaces/CreateTableOptions.md)\> | - |
+
+#### Returns
+
+`Promise`\<[`Table`](Table.md)\>
+
+#### Defined in
+
+[connection.ts:151](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L151)
+
+___
+
+### createTable
+
+▸ **createTable**(`name`, `data`, `options?`): `Promise`\<[`Table`](Table.md)\>
+
+Creates a new Table and initialize it with new data.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table. |
+| `data` | `Table`\<`any`\> \| `Record`\<`string`, `unknown`\>[] | Non-empty Array of Records to be inserted into the table |
+| `options?` | `Partial`\<[`CreateTableOptions`](../interfaces/CreateTableOptions.md)\> | - |
+
+#### Returns
+
+`Promise`\<[`Table`](Table.md)\>
+
+#### Defined in
+
+[connection.ts:123](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L123)
+
+___
+
+### display
+
+▸ **display**(): `string`
+
+Return a brief description of the connection
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[connection.ts:93](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L93)
+
+___
+
+### dropTable
+
+▸ **dropTable**(`name`): `Promise`\<`void`\>
+
+Drop an existing table.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table to drop. |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[connection.ts:173](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L173)
+
+___
+
+### isOpen
+
+▸ **isOpen**(): `boolean`
+
+Return true if the connection has not been closed
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[connection.ts:77](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L77)
+
+___
+
+### openTable
+
+▸ **openTable**(`name`): `Promise`\<[`Table`](Table.md)\>
+
+Open a table in the database.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the table |
+
+#### Returns
+
+`Promise`\<[`Table`](Table.md)\>
+
+#### Defined in
+
+[connection.ts:112](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L112)
+
+___
+
+### tableNames
+
+▸ **tableNames**(`options?`): `Promise`\<`string`[]\>
+
+List all the table names in this database.
+
+Tables will be returned in lexicographical order.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `Partial`\<[`TableNamesOptions`](../interfaces/TableNamesOptions.md)\> | options to control the paging / start point |
+
+#### Returns
+
+`Promise`\<`string`[]\>
+
+#### Defined in
+
+[connection.ts:104](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L104)

--- a/docs/src/js/classes/Index.md
+++ b/docs/src/js/classes/Index.md
@@ -1,0 +1,121 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / Index
+
+# Class: Index
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Index.md#constructor)
+
+### Properties
+
+- [inner](Index.md#inner)
+
+### Methods
+
+- [btree](Index.md#btree)
+- [ivfPq](Index.md#ivfpq)
+
+## Constructors
+
+### constructor
+
+• **new Index**(`inner`): [`Index`](Index.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `inner` | `Index` |
+
+#### Returns
+
+[`Index`](Index.md)
+
+#### Defined in
+
+[indices.ts:118](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L118)
+
+## Properties
+
+### inner
+
+• `Private` `Readonly` **inner**: `Index`
+
+#### Defined in
+
+[indices.ts:117](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L117)
+
+## Methods
+
+### btree
+
+▸ **btree**(): [`Index`](Index.md)
+
+Create a btree index
+
+A btree index is an index on a scalar columns.  The index stores a copy of the column
+in sorted order.  A header entry is created for each block of rows (currently the
+block size is fixed at 4096).  These header entries are stored in a separate
+cacheable structure (a btree).  To search for data the header is used to determine
+which blocks need to be read from disk.
+
+For example, a btree index in a table with 1Bi rows requires sizeof(Scalar) * 256Ki
+bytes of memory and will generally need to read sizeof(Scalar) * 4096 bytes to find
+the correct row ids.
+
+This index is good for scalar columns with mostly distinct values and does best when
+the query is highly selective.
+
+The btree index does not currently have any parameters though parameters such as the
+block size may be added in the future.
+
+#### Returns
+
+[`Index`](Index.md)
+
+#### Defined in
+
+[indices.ts:175](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L175)
+
+___
+
+### ivfPq
+
+▸ **ivfPq**(`options?`): [`Index`](Index.md)
+
+Create an IvfPq index
+
+This index stores a compressed (quantized) copy of every vector.  These vectors
+are grouped into partitions of similar vectors.  Each partition keeps track of
+a centroid which is the average value of all vectors in the group.
+
+During a query the centroids are compared with the query vector to find the closest
+partitions.  The compressed vectors in these partitions are then searched to find
+the closest vectors.
+
+The compression scheme is called product quantization.  Each vector is divided into
+subvectors and then each subvector is quantized into a small number of bits.  the
+parameters `num_bits` and `num_subvectors` control this process, providing a tradeoff
+between index size (and thus search speed) and index accuracy.
+
+The partitioning process is called IVF and the `num_partitions` parameter controls how
+many groups to create.
+
+Note that training an IVF PQ index on a large dataset is a slow operation and
+currently is also a memory intensive operation.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options?` | `Partial`\<[`IvfPqOptions`](../interfaces/IvfPqOptions.md)\> |
+
+#### Returns
+
+[`Index`](Index.md)
+
+#### Defined in
+
+[indices.ts:144](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L144)

--- a/docs/src/js/classes/MakeArrowTableOptions.md
+++ b/docs/src/js/classes/MakeArrowTableOptions.md
@@ -1,0 +1,75 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / MakeArrowTableOptions
+
+# Class: MakeArrowTableOptions
+
+Options to control the makeArrowTable call.
+
+## Table of contents
+
+### Constructors
+
+- [constructor](MakeArrowTableOptions.md#constructor)
+
+### Properties
+
+- [dictionaryEncodeStrings](MakeArrowTableOptions.md#dictionaryencodestrings)
+- [schema](MakeArrowTableOptions.md#schema)
+- [vectorColumns](MakeArrowTableOptions.md#vectorcolumns)
+
+## Constructors
+
+### constructor
+
+• **new MakeArrowTableOptions**(`values?`): [`MakeArrowTableOptions`](MakeArrowTableOptions.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `values?` | `Partial`\<[`MakeArrowTableOptions`](MakeArrowTableOptions.md)\> |
+
+#### Returns
+
+[`MakeArrowTableOptions`](MakeArrowTableOptions.md)
+
+#### Defined in
+
+[arrow.ts:100](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L100)
+
+## Properties
+
+### dictionaryEncodeStrings
+
+• **dictionaryEncodeStrings**: `boolean` = `false`
+
+If true then string columns will be encoded with dictionary encoding
+
+Set this to true if your string columns tend to repeat the same values
+often.  For more precise control use the `schema` property to specify the
+data type for individual columns.
+
+If `schema` is provided then this property is ignored.
+
+#### Defined in
+
+[arrow.ts:98](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L98)
+
+___
+
+### schema
+
+• `Optional` **schema**: `Schema`\<`any`\>
+
+#### Defined in
+
+[arrow.ts:67](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L67)
+
+___
+
+### vectorColumns
+
+• **vectorColumns**: `Record`\<`string`, [`VectorColumnOptions`](VectorColumnOptions.md)\>
+
+#### Defined in
+
+[arrow.ts:85](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L85)

--- a/docs/src/js/classes/Query.md
+++ b/docs/src/js/classes/Query.md
@@ -1,0 +1,368 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / Query
+
+# Class: Query
+
+A builder for LanceDB queries.
+
+## Hierarchy
+
+- [`QueryBase`](QueryBase.md)\<`NativeQuery`, [`Query`](Query.md)\>
+
+  ↳ **`Query`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Query.md#constructor)
+
+### Properties
+
+- [inner](Query.md#inner)
+
+### Methods
+
+- [[asyncIterator]](Query.md#[asynciterator])
+- [execute](Query.md#execute)
+- [limit](Query.md#limit)
+- [nativeExecute](Query.md#nativeexecute)
+- [nearestTo](Query.md#nearestto)
+- [select](Query.md#select)
+- [toArray](Query.md#toarray)
+- [toArrow](Query.md#toarrow)
+- [where](Query.md#where)
+
+## Constructors
+
+### constructor
+
+• **new Query**(`tbl`): [`Query`](Query.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `tbl` | `Table` |
+
+#### Returns
+
+[`Query`](Query.md)
+
+#### Overrides
+
+[QueryBase](QueryBase.md).[constructor](QueryBase.md#constructor)
+
+#### Defined in
+
+[query.ts:329](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L329)
+
+## Properties
+
+### inner
+
+• `Protected` **inner**: `Query`
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[inner](QueryBase.md#inner)
+
+#### Defined in
+
+[query.ts:59](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L59)
+
+## Methods
+
+### [asyncIterator]
+
+▸ **[asyncIterator]**(): `AsyncIterator`\<`RecordBatch`\<`any`\>, `any`, `undefined`\>
+
+#### Returns
+
+`AsyncIterator`\<`RecordBatch`\<`any`\>, `any`, `undefined`\>
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[[asyncIterator]](QueryBase.md#[asynciterator])
+
+#### Defined in
+
+[query.ts:154](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L154)
+
+___
+
+### execute
+
+▸ **execute**(): [`RecordBatchIterator`](RecordBatchIterator.md)
+
+Execute the query and return the results as an
+
+#### Returns
+
+[`RecordBatchIterator`](RecordBatchIterator.md)
+
+**`See`**
+
+ - AsyncIterator
+of
+ - RecordBatch.
+
+By default, LanceDb will use many threads to calculate results and, when
+the result set is large, multiple batches will be processed at one time.
+This readahead is limited however and backpressure will be applied if this
+stream is consumed slowly (this constrains the maximum memory used by a
+single query)
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[execute](QueryBase.md#execute)
+
+#### Defined in
+
+[query.ts:149](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L149)
+
+___
+
+### limit
+
+▸ **limit**(`limit`): [`Query`](Query.md)
+
+Set the maximum number of results to return.
+
+By default, a plain search has no limit.  If this method is not
+called then every valid row from the table will be returned.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `limit` | `number` |
+
+#### Returns
+
+[`Query`](Query.md)
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[limit](QueryBase.md#limit)
+
+#### Defined in
+
+[query.ts:129](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L129)
+
+___
+
+### nativeExecute
+
+▸ **nativeExecute**(): `Promise`\<`RecordBatchIterator`\>
+
+#### Returns
+
+`Promise`\<`RecordBatchIterator`\>
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[nativeExecute](QueryBase.md#nativeexecute)
+
+#### Defined in
+
+[query.ts:134](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L134)
+
+___
+
+### nearestTo
+
+▸ **nearestTo**(`vector`): [`VectorQuery`](VectorQuery.md)
+
+Find the nearest vectors to the given query vector.
+
+This converts the query from a plain query to a vector query.
+
+This method will attempt to convert the input to the query vector
+expected by the embedding model.  If the input cannot be converted
+then an error will be thrown.
+
+By default, there is no embedding model, and the input should be
+an array-like object of numbers (something that can be used as input
+to Float32Array.from)
+
+If there is only one vector column (a column whose data type is a
+fixed size list of floats) then the column does not need to be specified.
+If there is more than one vector column you must use
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `vector` | `unknown` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+**`See`**
+
+ - [VectorQuery#column](VectorQuery.md#column)  to specify which column you would like
+to compare with.
+
+If no index has been created on the vector column then a vector query
+will perform a distance comparison between the query vector and every
+vector in the database and then sort the results.  This is sometimes
+called a "flat search"
+
+For small databases, with a few hundred thousand vectors or less, this can
+be reasonably fast.  In larger databases you should create a vector index
+on the column.  If there is a vector index then an "approximate" nearest
+neighbor search (frequently called an ANN search) will be performed.  This
+search is much faster, but the results will be approximate.
+
+The query can be further parameterized using the returned builder.  There
+are various ANN search parameters that will let you fine tune your recall
+accuracy vs search latency.
+
+Vector searches always have a `limit`.  If `limit` has not been called then
+a default `limit` of 10 will be used.
+ - [Query#limit](Query.md#limit)
+
+#### Defined in
+
+[query.ts:370](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L370)
+
+___
+
+### select
+
+▸ **select**(`columns`): [`Query`](Query.md)
+
+Return only the specified columns.
+
+By default a query will return all columns from the table.  However, this can have
+a very significant impact on latency.  LanceDb stores data in a columnar fashion.  This
+means we can finely tune our I/O to select exactly the columns we need.
+
+As a best practice you should always limit queries to the columns that you need.  If you
+pass in an array of column names then only those columns will be returned.
+
+You can also use this method to create new "dynamic" columns based on your existing columns.
+For example, you may not care about "a" or "b" but instead simply want "a + b".  This is often
+seen in the SELECT clause of an SQL query (e.g. `SELECT a+b FROM my_table`).
+
+To create dynamic columns you can pass in a Map<string, string>.  A column will be returned
+for each entry in the map.  The key provides the name of the column.  The value is
+an SQL string used to specify how the column is calculated.
+
+For example, an SQL query might state `SELECT a + b AS combined, c`.  The equivalent
+input to this method would be:
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `columns` | `string`[] \| `Record`\<`string`, `string`\> \| `Map`\<`string`, `string`\> |
+
+#### Returns
+
+[`Query`](Query.md)
+
+**`Example`**
+
+```ts
+new Map([["combined", "a + b"], ["c", "c"]])
+
+Columns will always be returned in the order given, even if that order is different than
+the order used when adding the data.
+
+Note that you can pass in a `Record<string, string>` (e.g. an object literal). This method
+uses `Object.entries` which should preserve the insertion order of the object.  However,
+object insertion order is easy to get wrong and `Map` is more foolproof.
+```
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[select](QueryBase.md#select)
+
+#### Defined in
+
+[query.ts:108](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L108)
+
+___
+
+### toArray
+
+▸ **toArray**(): `Promise`\<`unknown`[]\>
+
+Collect the results as an array of objects.
+
+#### Returns
+
+`Promise`\<`unknown`[]\>
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[toArray](QueryBase.md#toarray)
+
+#### Defined in
+
+[query.ts:169](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L169)
+
+___
+
+### toArrow
+
+▸ **toArrow**(): `Promise`\<`Table`\<`any`\>\>
+
+Collect the results as an Arrow
+
+#### Returns
+
+`Promise`\<`Table`\<`any`\>\>
+
+**`See`**
+
+ArrowTable.
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[toArrow](QueryBase.md#toarrow)
+
+#### Defined in
+
+[query.ts:160](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L160)
+
+___
+
+### where
+
+▸ **where**(`predicate`): [`Query`](Query.md)
+
+A filter statement to be applied to this query.
+
+The filter should be supplied as an SQL query string.  For example:
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `predicate` | `string` |
+
+#### Returns
+
+[`Query`](Query.md)
+
+**`Example`**
+
+```ts
+x > 10
+y > 0 AND y < 100
+x > 5 OR y = 'test'
+
+Filtering performance can often be improved by creating a scalar index
+on the filter column(s).
+```
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[where](QueryBase.md#where)
+
+#### Defined in
+
+[query.ts:73](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L73)

--- a/docs/src/js/classes/QueryBase.md
+++ b/docs/src/js/classes/QueryBase.md
@@ -1,0 +1,291 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / QueryBase
+
+# Class: QueryBase\<NativeQueryType, QueryType\>
+
+Common methods supported by all query types
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `NativeQueryType` | extends `NativeQuery` \| `NativeVectorQuery` |
+| `QueryType` | `QueryType` |
+
+## Hierarchy
+
+- **`QueryBase`**
+
+  ↳ [`Query`](Query.md)
+
+  ↳ [`VectorQuery`](VectorQuery.md)
+
+## Implements
+
+- `AsyncIterable`\<`RecordBatch`\>
+
+## Table of contents
+
+### Constructors
+
+- [constructor](QueryBase.md#constructor)
+
+### Properties
+
+- [inner](QueryBase.md#inner)
+
+### Methods
+
+- [[asyncIterator]](QueryBase.md#[asynciterator])
+- [execute](QueryBase.md#execute)
+- [limit](QueryBase.md#limit)
+- [nativeExecute](QueryBase.md#nativeexecute)
+- [select](QueryBase.md#select)
+- [toArray](QueryBase.md#toarray)
+- [toArrow](QueryBase.md#toarrow)
+- [where](QueryBase.md#where)
+
+## Constructors
+
+### constructor
+
+• **new QueryBase**\<`NativeQueryType`, `QueryType`\>(`inner`): [`QueryBase`](QueryBase.md)\<`NativeQueryType`, `QueryType`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `NativeQueryType` | extends `Query` \| `VectorQuery` |
+| `QueryType` | `QueryType` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `inner` | `NativeQueryType` |
+
+#### Returns
+
+[`QueryBase`](QueryBase.md)\<`NativeQueryType`, `QueryType`\>
+
+#### Defined in
+
+[query.ts:59](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L59)
+
+## Properties
+
+### inner
+
+• `Protected` **inner**: `NativeQueryType`
+
+#### Defined in
+
+[query.ts:59](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L59)
+
+## Methods
+
+### [asyncIterator]
+
+▸ **[asyncIterator]**(): `AsyncIterator`\<`RecordBatch`\<`any`\>, `any`, `undefined`\>
+
+#### Returns
+
+`AsyncIterator`\<`RecordBatch`\<`any`\>, `any`, `undefined`\>
+
+#### Implementation of
+
+AsyncIterable.[asyncIterator]
+
+#### Defined in
+
+[query.ts:154](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L154)
+
+___
+
+### execute
+
+▸ **execute**(): [`RecordBatchIterator`](RecordBatchIterator.md)
+
+Execute the query and return the results as an
+
+#### Returns
+
+[`RecordBatchIterator`](RecordBatchIterator.md)
+
+**`See`**
+
+ - AsyncIterator
+of
+ - RecordBatch.
+
+By default, LanceDb will use many threads to calculate results and, when
+the result set is large, multiple batches will be processed at one time.
+This readahead is limited however and backpressure will be applied if this
+stream is consumed slowly (this constrains the maximum memory used by a
+single query)
+
+#### Defined in
+
+[query.ts:149](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L149)
+
+___
+
+### limit
+
+▸ **limit**(`limit`): `QueryType`
+
+Set the maximum number of results to return.
+
+By default, a plain search has no limit.  If this method is not
+called then every valid row from the table will be returned.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `limit` | `number` |
+
+#### Returns
+
+`QueryType`
+
+#### Defined in
+
+[query.ts:129](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L129)
+
+___
+
+### nativeExecute
+
+▸ **nativeExecute**(): `Promise`\<`RecordBatchIterator`\>
+
+#### Returns
+
+`Promise`\<`RecordBatchIterator`\>
+
+#### Defined in
+
+[query.ts:134](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L134)
+
+___
+
+### select
+
+▸ **select**(`columns`): `QueryType`
+
+Return only the specified columns.
+
+By default a query will return all columns from the table.  However, this can have
+a very significant impact on latency.  LanceDb stores data in a columnar fashion.  This
+means we can finely tune our I/O to select exactly the columns we need.
+
+As a best practice you should always limit queries to the columns that you need.  If you
+pass in an array of column names then only those columns will be returned.
+
+You can also use this method to create new "dynamic" columns based on your existing columns.
+For example, you may not care about "a" or "b" but instead simply want "a + b".  This is often
+seen in the SELECT clause of an SQL query (e.g. `SELECT a+b FROM my_table`).
+
+To create dynamic columns you can pass in a Map<string, string>.  A column will be returned
+for each entry in the map.  The key provides the name of the column.  The value is
+an SQL string used to specify how the column is calculated.
+
+For example, an SQL query might state `SELECT a + b AS combined, c`.  The equivalent
+input to this method would be:
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `columns` | `string`[] \| `Record`\<`string`, `string`\> \| `Map`\<`string`, `string`\> |
+
+#### Returns
+
+`QueryType`
+
+**`Example`**
+
+```ts
+new Map([["combined", "a + b"], ["c", "c"]])
+
+Columns will always be returned in the order given, even if that order is different than
+the order used when adding the data.
+
+Note that you can pass in a `Record<string, string>` (e.g. an object literal). This method
+uses `Object.entries` which should preserve the insertion order of the object.  However,
+object insertion order is easy to get wrong and `Map` is more foolproof.
+```
+
+#### Defined in
+
+[query.ts:108](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L108)
+
+___
+
+### toArray
+
+▸ **toArray**(): `Promise`\<`unknown`[]\>
+
+Collect the results as an array of objects.
+
+#### Returns
+
+`Promise`\<`unknown`[]\>
+
+#### Defined in
+
+[query.ts:169](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L169)
+
+___
+
+### toArrow
+
+▸ **toArrow**(): `Promise`\<`Table`\<`any`\>\>
+
+Collect the results as an Arrow
+
+#### Returns
+
+`Promise`\<`Table`\<`any`\>\>
+
+**`See`**
+
+ArrowTable.
+
+#### Defined in
+
+[query.ts:160](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L160)
+
+___
+
+### where
+
+▸ **where**(`predicate`): `QueryType`
+
+A filter statement to be applied to this query.
+
+The filter should be supplied as an SQL query string.  For example:
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `predicate` | `string` |
+
+#### Returns
+
+`QueryType`
+
+**`Example`**
+
+```ts
+x > 10
+y > 0 AND y < 100
+x > 5 OR y = 'test'
+
+Filtering performance can often be improved by creating a scalar index
+on the filter column(s).
+```
+
+#### Defined in
+
+[query.ts:73](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L73)

--- a/docs/src/js/classes/RecordBatchIterator.md
+++ b/docs/src/js/classes/RecordBatchIterator.md
@@ -1,0 +1,80 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / RecordBatchIterator
+
+# Class: RecordBatchIterator
+
+## Implements
+
+- `AsyncIterator`\<`RecordBatch`\>
+
+## Table of contents
+
+### Constructors
+
+- [constructor](RecordBatchIterator.md#constructor)
+
+### Properties
+
+- [inner](RecordBatchIterator.md#inner)
+- [promisedInner](RecordBatchIterator.md#promisedinner)
+
+### Methods
+
+- [next](RecordBatchIterator.md#next)
+
+## Constructors
+
+### constructor
+
+• **new RecordBatchIterator**(`promise?`): [`RecordBatchIterator`](RecordBatchIterator.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `promise?` | `Promise`\<`RecordBatchIterator`\> |
+
+#### Returns
+
+[`RecordBatchIterator`](RecordBatchIterator.md)
+
+#### Defined in
+
+[query.ts:27](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L27)
+
+## Properties
+
+### inner
+
+• `Private` `Optional` **inner**: `RecordBatchIterator`
+
+#### Defined in
+
+[query.ts:25](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L25)
+
+___
+
+### promisedInner
+
+• `Private` `Optional` **promisedInner**: `Promise`\<`RecordBatchIterator`\>
+
+#### Defined in
+
+[query.ts:24](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L24)
+
+## Methods
+
+### next
+
+▸ **next**(): `Promise`\<`IteratorResult`\<`RecordBatch`\<`any`\>, `any`\>\>
+
+#### Returns
+
+`Promise`\<`IteratorResult`\<`RecordBatch`\<`any`\>, `any`\>\>
+
+#### Implementation of
+
+AsyncIterator.next
+
+#### Defined in
+
+[query.ts:33](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L33)

--- a/docs/src/js/classes/Table.md
+++ b/docs/src/js/classes/Table.md
@@ -1,0 +1,594 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / Table
+
+# Class: Table
+
+A Table is a collection of Records in a LanceDB Database.
+
+A Table object is expected to be long lived and reused for multiple operations.
+Table objects will cache a certain amount of index data in memory.  This cache
+will be freed when the Table is garbage collected.  To eagerly free the cache you
+can call the `close` method.  Once the Table is closed, it cannot be used for any
+further operations.
+
+Closing a table is optional.  It not closed, it will be closed when it is garbage
+collected.
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Table.md#constructor)
+
+### Properties
+
+- [inner](Table.md#inner)
+
+### Methods
+
+- [add](Table.md#add)
+- [addColumns](Table.md#addcolumns)
+- [alterColumns](Table.md#altercolumns)
+- [checkout](Table.md#checkout)
+- [checkoutLatest](Table.md#checkoutlatest)
+- [close](Table.md#close)
+- [countRows](Table.md#countrows)
+- [createIndex](Table.md#createindex)
+- [delete](Table.md#delete)
+- [display](Table.md#display)
+- [dropColumns](Table.md#dropcolumns)
+- [isOpen](Table.md#isopen)
+- [listIndices](Table.md#listindices)
+- [query](Table.md#query)
+- [restore](Table.md#restore)
+- [schema](Table.md#schema)
+- [update](Table.md#update)
+- [vectorSearch](Table.md#vectorsearch)
+- [version](Table.md#version)
+
+## Constructors
+
+### constructor
+
+• **new Table**(`inner`): [`Table`](Table.md)
+
+Construct a Table. Internal use only.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `inner` | `Table` |
+
+#### Returns
+
+[`Table`](Table.md)
+
+#### Defined in
+
+[table.ts:69](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L69)
+
+## Properties
+
+### inner
+
+• `Private` `Readonly` **inner**: `Table`
+
+#### Defined in
+
+[table.ts:66](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L66)
+
+## Methods
+
+### add
+
+▸ **add**(`data`, `options?`): `Promise`\<`void`\>
+
+Insert records into this Table.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `data` | [`Data`](../modules.md#data) | Records to be inserted into the Table |
+| `options?` | `Partial`\<[`AddDataOptions`](../interfaces/AddDataOptions.md)\> | - |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:105](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L105)
+
+___
+
+### addColumns
+
+▸ **addColumns**(`newColumnTransforms`): `Promise`\<`void`\>
+
+Add new columns with defined values.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newColumnTransforms` | [`AddColumnsSql`](../interfaces/AddColumnsSql.md)[] | pairs of column names and the SQL expression to use to calculate the value of the new column. These expressions will be evaluated for each row in the table, and can reference existing columns in the table. |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:261](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L261)
+
+___
+
+### alterColumns
+
+▸ **alterColumns**(`columnAlterations`): `Promise`\<`void`\>
+
+Alter the name or nullability of columns.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `columnAlterations` | [`ColumnAlteration`](../interfaces/ColumnAlteration.md)[] | One or more alterations to apply to columns. |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:270](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L270)
+
+___
+
+### checkout
+
+▸ **checkout**(`version`): `Promise`\<`void`\>
+
+Checks out a specific version of the Table
+
+Any read operation on the table will now access the data at the checked out version.
+As a consequence, calling this method will disable any read consistency interval
+that was previously set.
+
+This is a read-only operation that turns the table into a sort of "view"
+or "detached head".  Other table instances will not be affected.  To make the change
+permanent you can use the `[Self::restore]` method.
+
+Any operation that modifies the table will fail while the table is in a checked
+out state.
+
+To return the table to a normal state use `[Self::checkout_latest]`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `version` | `number` |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:317](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L317)
+
+___
+
+### checkoutLatest
+
+▸ **checkoutLatest**(): `Promise`\<`void`\>
+
+Ensures the table is pointing at the latest version
+
+This can be used to manually update a table when the read_consistency_interval is None
+It can also be used to undo a `[Self::checkout]` operation
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:327](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L327)
+
+___
+
+### close
+
+▸ **close**(): `void`
+
+Close the table, releasing any underlying resources.
+
+It is safe to call this method multiple times.
+
+Any attempt to use the table after it is closed will result in an error.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[table.ts:85](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L85)
+
+___
+
+### countRows
+
+▸ **countRows**(`filter?`): `Promise`\<`number`\>
+
+Count the total number of rows in the dataset.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `filter?` | `string` |
+
+#### Returns
+
+`Promise`\<`number`\>
+
+#### Defined in
+
+[table.ts:152](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L152)
+
+___
+
+### createIndex
+
+▸ **createIndex**(`column`, `options?`): `Promise`\<`void`\>
+
+Create an index to speed up queries.
+
+Indices can be created on vector columns or scalar columns.
+Indices on vector columns will speed up vector searches.
+Indices on scalar columns will speed up filtering (in both
+vector and non-vector searches)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `column` | `string` |
+| `options?` | `Partial`\<[`IndexOptions`](../interfaces/IndexOptions.md)\> |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+**`Example`**
+
+```ts
+// If the column has a vector (fixed size list) data type then
+// an IvfPq vector index will be created.
+const table = await conn.openTable("my_table");
+await table.createIndex(["vector"]);
+```
+
+**`Example`**
+
+```ts
+// For advanced control over vector index creation you can specify
+// the index type and options.
+const table = await conn.openTable("my_table");
+await table.createIndex(["vector"], I)
+  .ivf_pq({ num_partitions: 128, num_sub_vectors: 16 })
+  .build();
+```
+
+**`Example`**
+
+```ts
+// Or create a Scalar index
+await table.createIndex("my_float_col").build();
+```
+
+#### Defined in
+
+[table.ts:184](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L184)
+
+___
+
+### delete
+
+▸ **delete**(`predicate`): `Promise`\<`void`\>
+
+Delete the rows that satisfy the predicate.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `predicate` | `string` |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:157](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L157)
+
+___
+
+### display
+
+▸ **display**(): `string`
+
+Return a brief description of the table
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[table.ts:90](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L90)
+
+___
+
+### dropColumns
+
+▸ **dropColumns**(`columnNames`): `Promise`\<`void`\>
+
+Drop one or more columns from the dataset
+
+This is a metadata-only operation and does not remove the data from the
+underlying storage. In order to remove the data, you must subsequently
+call ``compact_files`` to rewrite the data without the removed columns and
+then call ``cleanup_files`` to remove the old files.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `columnNames` | `string`[] | The names of the columns to drop. These can be nested column references (e.g. "a.b.c") or top-level column names (e.g. "a"). |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:285](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L285)
+
+___
+
+### isOpen
+
+▸ **isOpen**(): `boolean`
+
+Return true if the table has not been closed
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[table.ts:74](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L74)
+
+___
+
+### listIndices
+
+▸ **listIndices**(): `Promise`\<[`IndexConfig`](../interfaces/IndexConfig.md)[]\>
+
+List all indices that have been created with Self::create_index
+
+#### Returns
+
+`Promise`\<[`IndexConfig`](../interfaces/IndexConfig.md)[]\>
+
+#### Defined in
+
+[table.ts:350](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L350)
+
+___
+
+### query
+
+▸ **query**(): [`Query`](Query.md)
+
+Create a [Query](Query.md) Builder.
+
+Queries allow you to search your existing data.  By default the query will
+return all the data in the table in no particular order.  The builder
+returned by this method can be used to control the query using filtering,
+vector similarity, sorting, and more.
+
+Note: By default, all columns are returned.  For best performance, you should
+only fetch the columns you need.  See [`Query::select_with_projection`] for
+more details.
+
+When appropriate, various indices and statistics based pruning will be used to
+accelerate the query.
+
+#### Returns
+
+[`Query`](Query.md)
+
+A builder that can be used to parameterize the query
+
+**`Example`**
+
+```ts
+// SQL-style filtering
+//
+// This query will return up to 1000 rows whose value in the `id` column
+// is greater than 5.  LanceDb supports a broad set of filtering functions.
+for await (const batch of table.query()
+                         .filter("id > 1").select(["id"]).limit(20)) {
+ console.log(batch);
+}
+```
+
+**`Example`**
+
+```ts
+// Vector Similarity Search
+//
+// This example will find the 10 rows whose value in the "vector" column are
+// closest to the query vector [1.0, 2.0, 3.0].  If an index has been created
+// on the "vector" column then this will perform an ANN search.
+//
+// The `refine_factor` and `nprobes` methods are used to control the recall /
+// latency tradeoff of the search.
+for await (const batch of table.query()
+                   .nearestTo([1, 2, 3])
+                   .refineFactor(5).nprobe(10)
+                   .limit(10)) {
+ console.log(batch);
+}
+```
+
+**`Example`**
+
+```ts
+// Scan the full dataset
+//
+// This query will return everything in the table in no particular order.
+for await (const batch of table.query()) {
+  console.log(batch);
+}
+```
+
+#### Defined in
+
+[table.ts:238](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L238)
+
+___
+
+### restore
+
+▸ **restore**(): `Promise`\<`void`\>
+
+Restore the table to the currently checked out version
+
+This operation will fail if checkout has not been called previously
+
+This operation will overwrite the latest version of the table with a
+previous version.  Any changes made since the checked out version will
+no longer be visible.
+
+Once the operation concludes the table will no longer be in a checked
+out state and the read_consistency_interval, if any, will apply.
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:343](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L343)
+
+___
+
+### schema
+
+▸ **schema**(): `Promise`\<`Schema`\<`any`\>\>
+
+Get the schema of the table.
+
+#### Returns
+
+`Promise`\<`Schema`\<`any`\>\>
+
+#### Defined in
+
+[table.ts:95](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L95)
+
+___
+
+### update
+
+▸ **update**(`updates`, `options?`): `Promise`\<`void`\>
+
+Update existing records in the Table
+
+An update operation can be used to adjust existing values.  Use the
+returned builder to specify which columns to update.  The new value
+can be a literal value (e.g. replacing nulls with some default value)
+or an expression applied to the old value (e.g. incrementing a value)
+
+An optional condition can be specified (e.g. "only update if the old
+value is 0")
+
+Note: if your condition is something like "some_id_column == 7" and
+you are updating many rows (with different ids) then you will get
+better performance with a single [`merge_insert`] call instead of
+repeatedly calilng this method.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `updates` | `Record`\<`string`, `string`\> \| `Map`\<`string`, `string`\> | the columns to update Keys in the map should specify the name of the column to update. Values in the map provide the new value of the column. These can be SQL literal strings (e.g. "7" or "'foo'") or they can be expressions based on the row being updated (e.g. "my_col + 1") |
+| `options?` | `Partial`\<[`UpdateOptions`](../interfaces/UpdateOptions.md)\> | additional options to control the update behavior |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[table.ts:137](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L137)
+
+___
+
+### vectorSearch
+
+▸ **vectorSearch**(`vector`): [`VectorQuery`](VectorQuery.md)
+
+Search the table with a given query vector.
+
+This is a convenience method for preparing a vector query and
+is the same thing as calling `nearestTo` on the builder returned
+by `query`.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `vector` | `unknown` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+**`See`**
+
+[Query#nearestTo](Query.md#nearestto) for more details.
+
+#### Defined in
+
+[table.ts:249](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L249)
+
+___
+
+### version
+
+▸ **version**(): `Promise`\<`number`\>
+
+Retrieve the version of the table
+
+LanceDb supports versioning.  Every operation that modifies the table increases
+version.  As long as a version hasn't been deleted you can `[Self::checkout]` that
+version to view the data at that point.  In addition, you can `[Self::restore]` the
+version to replace the current table with a previous version.
+
+#### Returns
+
+`Promise`\<`number`\>
+
+#### Defined in
+
+[table.ts:297](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L297)

--- a/docs/src/js/classes/VectorColumnOptions.md
+++ b/docs/src/js/classes/VectorColumnOptions.md
@@ -1,0 +1,45 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / VectorColumnOptions
+
+# Class: VectorColumnOptions
+
+## Table of contents
+
+### Constructors
+
+- [constructor](VectorColumnOptions.md#constructor)
+
+### Properties
+
+- [type](VectorColumnOptions.md#type)
+
+## Constructors
+
+### constructor
+
+• **new VectorColumnOptions**(`values?`): [`VectorColumnOptions`](VectorColumnOptions.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `values?` | `Partial`\<[`VectorColumnOptions`](VectorColumnOptions.md)\> |
+
+#### Returns
+
+[`VectorColumnOptions`](VectorColumnOptions.md)
+
+#### Defined in
+
+[arrow.ts:49](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L49)
+
+## Properties
+
+### type
+
+• **type**: `Float`\<`Floats`\>
+
+Vector column type.
+
+#### Defined in
+
+[arrow.ts:47](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L47)

--- a/docs/src/js/classes/VectorQuery.md
+++ b/docs/src/js/classes/VectorQuery.md
@@ -1,0 +1,531 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / VectorQuery
+
+# Class: VectorQuery
+
+A builder used to construct a vector search
+
+This builder can be reused to execute the query many times.
+
+## Hierarchy
+
+- [`QueryBase`](QueryBase.md)\<`NativeVectorQuery`, [`VectorQuery`](VectorQuery.md)\>
+
+  ↳ **`VectorQuery`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](VectorQuery.md#constructor)
+
+### Properties
+
+- [inner](VectorQuery.md#inner)
+
+### Methods
+
+- [[asyncIterator]](VectorQuery.md#[asynciterator])
+- [bypassVectorIndex](VectorQuery.md#bypassvectorindex)
+- [column](VectorQuery.md#column)
+- [distanceType](VectorQuery.md#distancetype)
+- [execute](VectorQuery.md#execute)
+- [limit](VectorQuery.md#limit)
+- [nativeExecute](VectorQuery.md#nativeexecute)
+- [nprobes](VectorQuery.md#nprobes)
+- [postfilter](VectorQuery.md#postfilter)
+- [refineFactor](VectorQuery.md#refinefactor)
+- [select](VectorQuery.md#select)
+- [toArray](VectorQuery.md#toarray)
+- [toArrow](VectorQuery.md#toarrow)
+- [where](VectorQuery.md#where)
+
+## Constructors
+
+### constructor
+
+• **new VectorQuery**(`inner`): [`VectorQuery`](VectorQuery.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `inner` | `VectorQuery` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+#### Overrides
+
+[QueryBase](QueryBase.md).[constructor](QueryBase.md#constructor)
+
+#### Defined in
+
+[query.ts:189](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L189)
+
+## Properties
+
+### inner
+
+• `Protected` **inner**: `VectorQuery`
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[inner](QueryBase.md#inner)
+
+#### Defined in
+
+[query.ts:59](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L59)
+
+## Methods
+
+### [asyncIterator]
+
+▸ **[asyncIterator]**(): `AsyncIterator`\<`RecordBatch`\<`any`\>, `any`, `undefined`\>
+
+#### Returns
+
+`AsyncIterator`\<`RecordBatch`\<`any`\>, `any`, `undefined`\>
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[[asyncIterator]](QueryBase.md#[asynciterator])
+
+#### Defined in
+
+[query.ts:154](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L154)
+
+___
+
+### bypassVectorIndex
+
+▸ **bypassVectorIndex**(): [`VectorQuery`](VectorQuery.md)
+
+If this is called then any vector index is skipped
+
+An exhaustive (flat) search will be performed.  The query vector will
+be compared to every vector in the table.  At high scales this can be
+expensive.  However, this is often still useful.  For example, skipping
+the vector index can give you ground truth results which you can use to
+calculate your recall to select an appropriate value for nprobes.
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+#### Defined in
+
+[query.ts:321](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L321)
+
+___
+
+### column
+
+▸ **column**(`column`): [`VectorQuery`](VectorQuery.md)
+
+Set the vector column to query
+
+This controls which column is compared to the query vector supplied in
+the call to
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `column` | `string` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+**`See`**
+
+[Query#nearestTo](Query.md#nearestto)
+
+This parameter must be specified if the table has more than one column
+whose data type is a fixed-size-list of floats.
+
+#### Defined in
+
+[query.ts:229](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L229)
+
+___
+
+### distanceType
+
+▸ **distanceType**(`distanceType`): [`VectorQuery`](VectorQuery.md)
+
+Set the distance metric to use
+
+When performing a vector search we try and find the "nearest" vectors according
+to some kind of distance metric.  This parameter controls which distance metric to
+use.  See
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `distanceType` | `string` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+**`See`**
+
+[IvfPqOptions.distanceType](../interfaces/IvfPqOptions.md#distancetype) for more details on the different
+distance metrics available.
+
+Note: if there is a vector index then the distance type used MUST match the distance
+type used to train the vector index.  If this is not done then the results will be
+invalid.
+
+By default "l2" is used.
+
+#### Defined in
+
+[query.ts:248](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L248)
+
+___
+
+### execute
+
+▸ **execute**(): [`RecordBatchIterator`](RecordBatchIterator.md)
+
+Execute the query and return the results as an
+
+#### Returns
+
+[`RecordBatchIterator`](RecordBatchIterator.md)
+
+**`See`**
+
+ - AsyncIterator
+of
+ - RecordBatch.
+
+By default, LanceDb will use many threads to calculate results and, when
+the result set is large, multiple batches will be processed at one time.
+This readahead is limited however and backpressure will be applied if this
+stream is consumed slowly (this constrains the maximum memory used by a
+single query)
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[execute](QueryBase.md#execute)
+
+#### Defined in
+
+[query.ts:149](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L149)
+
+___
+
+### limit
+
+▸ **limit**(`limit`): [`VectorQuery`](VectorQuery.md)
+
+Set the maximum number of results to return.
+
+By default, a plain search has no limit.  If this method is not
+called then every valid row from the table will be returned.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `limit` | `number` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[limit](QueryBase.md#limit)
+
+#### Defined in
+
+[query.ts:129](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L129)
+
+___
+
+### nativeExecute
+
+▸ **nativeExecute**(): `Promise`\<`RecordBatchIterator`\>
+
+#### Returns
+
+`Promise`\<`RecordBatchIterator`\>
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[nativeExecute](QueryBase.md#nativeexecute)
+
+#### Defined in
+
+[query.ts:134](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L134)
+
+___
+
+### nprobes
+
+▸ **nprobes**(`nprobes`): [`VectorQuery`](VectorQuery.md)
+
+Set the number of partitions to search (probe)
+
+This argument is only used when the vector column has an IVF PQ index.
+If there is no index then this value is ignored.
+
+The IVF stage of IVF PQ divides the input into partitions (clusters) of
+related values.
+
+The partition whose centroids are closest to the query vector will be
+exhaustiely searched to find matches.  This parameter controls how many
+partitions should be searched.
+
+Increasing this value will increase the recall of your query but will
+also increase the latency of your query.  The default value is 20.  This
+default is good for many cases but the best value to use will depend on
+your data and the recall that you need to achieve.
+
+For best results we recommend tuning this parameter with a benchmark against
+your actual data to find the smallest possible value that will still give
+you the desired recall.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `nprobes` | `number` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+#### Defined in
+
+[query.ts:215](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L215)
+
+___
+
+### postfilter
+
+▸ **postfilter**(): [`VectorQuery`](VectorQuery.md)
+
+If this is called then filtering will happen after the vector search instead of
+before.
+
+By default filtering will be performed before the vector search.  This is how
+filtering is typically understood to work.  This prefilter step does add some
+additional latency.  Creating a scalar index on the filter column(s) can
+often improve this latency.  However, sometimes a filter is too complex or scalar
+indices cannot be applied to the column.  In these cases postfiltering can be
+used instead of prefiltering to improve latency.
+
+Post filtering applies the filter to the results of the vector search.  This means
+we only run the filter on a much smaller set of data.  However, it can cause the
+query to return fewer than `limit` results (or even no results) if none of the nearest
+results match the filter.
+
+Post filtering happens during the "refine stage" (described in more detail in
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+**`See`**
+
+[VectorQuery#refineFactor](VectorQuery.md#refinefactor)).  This means that setting a higher refine
+factor can often help restore some of the results lost by post filtering.
+
+#### Defined in
+
+[query.ts:307](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L307)
+
+___
+
+### refineFactor
+
+▸ **refineFactor**(`refineFactor`): [`VectorQuery`](VectorQuery.md)
+
+A multiplier to control how many additional rows are taken during the refine step
+
+This argument is only used when the vector column has an IVF PQ index.
+If there is no index then this value is ignored.
+
+An IVF PQ index stores compressed (quantized) values.  They query vector is compared
+against these values and, since they are compressed, the comparison is inaccurate.
+
+This parameter can be used to refine the results.  It can improve both improve recall
+and correct the ordering of the nearest results.
+
+To refine results LanceDb will first perform an ANN search to find the nearest
+`limit` * `refine_factor` results.  In other words, if `refine_factor` is 3 and
+`limit` is the default (10) then the first 30 results will be selected.  LanceDb
+then fetches the full, uncompressed, values for these 30 results.  The results are
+then reordered by the true distance and only the nearest 10 are kept.
+
+Note: there is a difference between calling this method with a value of 1 and never
+calling this method at all.  Calling this method with any value will have an impact
+on your search latency.  When you call this method with a `refine_factor` of 1 then
+LanceDb still needs to fetch the full, uncompressed, values so that it can potentially
+reorder the results.
+
+Note: if this method is NOT called then the distances returned in the _distance column
+will be approximate distances based on the comparison of the quantized query vector
+and the quantized result vectors.  This can be considerably different than the true
+distance between the query vector and the actual uncompressed vector.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `refineFactor` | `number` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+#### Defined in
+
+[query.ts:282](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L282)
+
+___
+
+### select
+
+▸ **select**(`columns`): [`VectorQuery`](VectorQuery.md)
+
+Return only the specified columns.
+
+By default a query will return all columns from the table.  However, this can have
+a very significant impact on latency.  LanceDb stores data in a columnar fashion.  This
+means we can finely tune our I/O to select exactly the columns we need.
+
+As a best practice you should always limit queries to the columns that you need.  If you
+pass in an array of column names then only those columns will be returned.
+
+You can also use this method to create new "dynamic" columns based on your existing columns.
+For example, you may not care about "a" or "b" but instead simply want "a + b".  This is often
+seen in the SELECT clause of an SQL query (e.g. `SELECT a+b FROM my_table`).
+
+To create dynamic columns you can pass in a Map<string, string>.  A column will be returned
+for each entry in the map.  The key provides the name of the column.  The value is
+an SQL string used to specify how the column is calculated.
+
+For example, an SQL query might state `SELECT a + b AS combined, c`.  The equivalent
+input to this method would be:
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `columns` | `string`[] \| `Record`\<`string`, `string`\> \| `Map`\<`string`, `string`\> |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+**`Example`**
+
+```ts
+new Map([["combined", "a + b"], ["c", "c"]])
+
+Columns will always be returned in the order given, even if that order is different than
+the order used when adding the data.
+
+Note that you can pass in a `Record<string, string>` (e.g. an object literal). This method
+uses `Object.entries` which should preserve the insertion order of the object.  However,
+object insertion order is easy to get wrong and `Map` is more foolproof.
+```
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[select](QueryBase.md#select)
+
+#### Defined in
+
+[query.ts:108](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L108)
+
+___
+
+### toArray
+
+▸ **toArray**(): `Promise`\<`unknown`[]\>
+
+Collect the results as an array of objects.
+
+#### Returns
+
+`Promise`\<`unknown`[]\>
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[toArray](QueryBase.md#toarray)
+
+#### Defined in
+
+[query.ts:169](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L169)
+
+___
+
+### toArrow
+
+▸ **toArrow**(): `Promise`\<`Table`\<`any`\>\>
+
+Collect the results as an Arrow
+
+#### Returns
+
+`Promise`\<`Table`\<`any`\>\>
+
+**`See`**
+
+ArrowTable.
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[toArrow](QueryBase.md#toarrow)
+
+#### Defined in
+
+[query.ts:160](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L160)
+
+___
+
+### where
+
+▸ **where**(`predicate`): [`VectorQuery`](VectorQuery.md)
+
+A filter statement to be applied to this query.
+
+The filter should be supplied as an SQL query string.  For example:
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `predicate` | `string` |
+
+#### Returns
+
+[`VectorQuery`](VectorQuery.md)
+
+**`Example`**
+
+```ts
+x > 10
+y > 0 AND y < 100
+x > 5 OR y = 'test'
+
+Filtering performance can often be improved by creating a scalar index
+on the filter column(s).
+```
+
+#### Inherited from
+
+[QueryBase](QueryBase.md).[where](QueryBase.md#where)
+
+#### Defined in
+
+[query.ts:73](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/query.ts#L73)

--- a/docs/src/js/classes/embedding.OpenAIEmbeddingFunction.md
+++ b/docs/src/js/classes/embedding.OpenAIEmbeddingFunction.md
@@ -1,0 +1,111 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / [embedding](../modules/embedding.md) / OpenAIEmbeddingFunction
+
+# Class: OpenAIEmbeddingFunction
+
+[embedding](../modules/embedding.md).OpenAIEmbeddingFunction
+
+An embedding function that automatically creates vector representation for a given column.
+
+## Implements
+
+- [`EmbeddingFunction`](../interfaces/embedding.EmbeddingFunction.md)\<`string`\>
+
+## Table of contents
+
+### Constructors
+
+- [constructor](embedding.OpenAIEmbeddingFunction.md#constructor)
+
+### Properties
+
+- [\_modelName](embedding.OpenAIEmbeddingFunction.md#_modelname)
+- [\_openai](embedding.OpenAIEmbeddingFunction.md#_openai)
+- [sourceColumn](embedding.OpenAIEmbeddingFunction.md#sourcecolumn)
+
+### Methods
+
+- [embed](embedding.OpenAIEmbeddingFunction.md#embed)
+
+## Constructors
+
+### constructor
+
+• **new OpenAIEmbeddingFunction**(`sourceColumn`, `openAIKey`, `modelName?`): [`OpenAIEmbeddingFunction`](embedding.OpenAIEmbeddingFunction.md)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `sourceColumn` | `string` | `undefined` |
+| `openAIKey` | `string` | `undefined` |
+| `modelName` | `string` | `"text-embedding-ada-002"` |
+
+#### Returns
+
+[`OpenAIEmbeddingFunction`](embedding.OpenAIEmbeddingFunction.md)
+
+#### Defined in
+
+[embedding/openai.ts:22](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/openai.ts#L22)
+
+## Properties
+
+### \_modelName
+
+• `Private` `Readonly` **\_modelName**: `string`
+
+#### Defined in
+
+[embedding/openai.ts:20](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/openai.ts#L20)
+
+___
+
+### \_openai
+
+• `Private` `Readonly` **\_openai**: `OpenAI`
+
+#### Defined in
+
+[embedding/openai.ts:19](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/openai.ts#L19)
+
+___
+
+### sourceColumn
+
+• **sourceColumn**: `string`
+
+The name of the column that will be used as input for the Embedding Function.
+
+#### Implementation of
+
+[EmbeddingFunction](../interfaces/embedding.EmbeddingFunction.md).[sourceColumn](../interfaces/embedding.EmbeddingFunction.md#sourcecolumn)
+
+#### Defined in
+
+[embedding/openai.ts:61](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/openai.ts#L61)
+
+## Methods
+
+### embed
+
+▸ **embed**(`data`): `Promise`\<`number`[][]\>
+
+Creates a vector representation for the given values.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `string`[] |
+
+#### Returns
+
+`Promise`\<`number`[][]\>
+
+#### Implementation of
+
+[EmbeddingFunction](../interfaces/embedding.EmbeddingFunction.md).[embed](../interfaces/embedding.EmbeddingFunction.md#embed)
+
+#### Defined in
+
+[embedding/openai.ts:48](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/openai.ts#L48)

--- a/docs/src/js/enums/WriteMode.md
+++ b/docs/src/js/enums/WriteMode.md
@@ -1,0 +1,43 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / WriteMode
+
+# Enumeration: WriteMode
+
+Write mode for writing a table.
+
+## Table of contents
+
+### Enumeration Members
+
+- [Append](WriteMode.md#append)
+- [Create](WriteMode.md#create)
+- [Overwrite](WriteMode.md#overwrite)
+
+## Enumeration Members
+
+### Append
+
+• **Append** = ``"Append"``
+
+#### Defined in
+
+native.d.ts:69
+
+___
+
+### Create
+
+• **Create** = ``"Create"``
+
+#### Defined in
+
+native.d.ts:68
+
+___
+
+### Overwrite
+
+• **Overwrite** = ``"Overwrite"``
+
+#### Defined in
+
+native.d.ts:70

--- a/docs/src/js/interfaces/AddColumnsSql.md
+++ b/docs/src/js/interfaces/AddColumnsSql.md
@@ -1,0 +1,37 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / AddColumnsSql
+
+# Interface: AddColumnsSql
+
+A definition of a new column to add to a table.
+
+## Table of contents
+
+### Properties
+
+- [name](AddColumnsSql.md#name)
+- [valueSql](AddColumnsSql.md#valuesql)
+
+## Properties
+
+### name
+
+• **name**: `string`
+
+The name of the new column.
+
+#### Defined in
+
+native.d.ts:43
+
+___
+
+### valueSql
+
+• **valueSql**: `string`
+
+The values to populate the new column with, as a SQL expression.
+The expression can reference other columns in the table.
+
+#### Defined in
+
+native.d.ts:48

--- a/docs/src/js/interfaces/AddDataOptions.md
+++ b/docs/src/js/interfaces/AddDataOptions.md
@@ -1,0 +1,25 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / AddDataOptions
+
+# Interface: AddDataOptions
+
+Options for adding data to a table.
+
+## Table of contents
+
+### Properties
+
+- [mode](AddDataOptions.md#mode)
+
+## Properties
+
+### mode
+
+• **mode**: ``"append"`` \| ``"overwrite"``
+
+If "append" (the default) then the new data will be added to the table
+
+If "overwrite" then the new data will replace the existing data in the table.
+
+#### Defined in
+
+[table.ts:36](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L36)

--- a/docs/src/js/interfaces/ColumnAlteration.md
+++ b/docs/src/js/interfaces/ColumnAlteration.md
@@ -1,0 +1,56 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / ColumnAlteration
+
+# Interface: ColumnAlteration
+
+A definition of a column alteration. The alteration changes the column at
+`path` to have the new name `name`, to be nullable if `nullable` is true,
+and to have the data type `data_type`. At least one of `rename` or `nullable`
+must be provided.
+
+## Table of contents
+
+### Properties
+
+- [nullable](ColumnAlteration.md#nullable)
+- [path](ColumnAlteration.md#path)
+- [rename](ColumnAlteration.md#rename)
+
+## Properties
+
+### nullable
+
+• `Optional` **nullable**: `boolean`
+
+Set the new nullability. Note that a nullable column cannot be made non-nullable.
+
+#### Defined in
+
+native.d.ts:38
+
+___
+
+### path
+
+• **path**: `string`
+
+The path to the column to alter. This is a dot-separated path to the column.
+If it is a top-level column then it is just the name of the column. If it is
+a nested column then it is the path to the column, e.g. "a.b.c" for a column
+`c` nested inside a column `b` nested inside a column `a`.
+
+#### Defined in
+
+native.d.ts:31
+
+___
+
+### rename
+
+• `Optional` **rename**: `string`
+
+The new name of the column. If not provided then the name will not be changed.
+This must be distinct from the names of all other columns in the table.
+
+#### Defined in
+
+native.d.ts:36

--- a/docs/src/js/interfaces/ConnectionOptions.md
+++ b/docs/src/js/interfaces/ConnectionOptions.md
@@ -1,0 +1,51 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / ConnectionOptions
+
+# Interface: ConnectionOptions
+
+## Table of contents
+
+### Properties
+
+- [apiKey](ConnectionOptions.md#apikey)
+- [hostOverride](ConnectionOptions.md#hostoverride)
+- [readConsistencyInterval](ConnectionOptions.md#readconsistencyinterval)
+
+## Properties
+
+### apiKey
+
+• `Optional` **apiKey**: `string`
+
+#### Defined in
+
+native.d.ts:51
+
+___
+
+### hostOverride
+
+• `Optional` **hostOverride**: `string`
+
+#### Defined in
+
+native.d.ts:52
+
+___
+
+### readConsistencyInterval
+
+• `Optional` **readConsistencyInterval**: `number`
+
+(For LanceDB OSS only): The interval, in seconds, at which to check for
+updates to the table from other processes. If None, then consistency is not
+checked. For performance reasons, this is the default. For strong
+consistency, set this to zero seconds. Then every read will check for
+updates from other processes. As a compromise, you can set this to a
+non-zero value for eventual consistency. If more than that interval
+has passed since the last check, then the table will be checked for updates.
+Note: this consistency only applies to read operations. Write operations are
+always consistent.
+
+#### Defined in
+
+native.d.ts:64

--- a/docs/src/js/interfaces/CreateTableOptions.md
+++ b/docs/src/js/interfaces/CreateTableOptions.md
@@ -1,0 +1,41 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / CreateTableOptions
+
+# Interface: CreateTableOptions
+
+## Table of contents
+
+### Properties
+
+- [existOk](CreateTableOptions.md#existok)
+- [mode](CreateTableOptions.md#mode)
+
+## Properties
+
+### existOk
+
+• **existOk**: `boolean`
+
+If this is true and the table already exists and the mode is "create"
+then no error will be raised.
+
+#### Defined in
+
+[connection.ts:35](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L35)
+
+___
+
+### mode
+
+• **mode**: ``"overwrite"`` \| ``"create"``
+
+The mode to use when creating the table.
+
+If this is set to "create" and the table already exists then either
+an error will be thrown or, if existOk is true, then nothing will
+happen.  Any provided data will be ignored.
+
+If this is set to "overwrite" then any existing table will be replaced.
+
+#### Defined in
+
+[connection.ts:30](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L30)

--- a/docs/src/js/interfaces/ExecutableQuery.md
+++ b/docs/src/js/interfaces/ExecutableQuery.md
@@ -1,0 +1,7 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / ExecutableQuery
+
+# Interface: ExecutableQuery
+
+An interface for a query that can be executed
+
+Supported by all query types

--- a/docs/src/js/interfaces/IndexConfig.md
+++ b/docs/src/js/interfaces/IndexConfig.md
@@ -1,0 +1,39 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / IndexConfig
+
+# Interface: IndexConfig
+
+A description of an index currently configured on a column
+
+## Table of contents
+
+### Properties
+
+- [columns](IndexConfig.md#columns)
+- [indexType](IndexConfig.md#indextype)
+
+## Properties
+
+### columns
+
+• **columns**: `string`[]
+
+The columns in the index
+
+Currently this is always an array of size 1.  In the future there may
+be more columns to represent composite indices.
+
+#### Defined in
+
+native.d.ts:16
+
+___
+
+### indexType
+
+• **indexType**: `string`
+
+The type of the index
+
+#### Defined in
+
+native.d.ts:9

--- a/docs/src/js/interfaces/IndexOptions.md
+++ b/docs/src/js/interfaces/IndexOptions.md
@@ -1,0 +1,48 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / IndexOptions
+
+# Interface: IndexOptions
+
+## Table of contents
+
+### Properties
+
+- [config](IndexOptions.md#config)
+- [replace](IndexOptions.md#replace)
+
+## Properties
+
+### config
+
+• `Optional` **config**: [`Index`](../classes/Index.md)
+
+Advanced index configuration
+
+This option allows you to specify a specfic index to create and also
+allows you to pass in configuration for training the index.
+
+See the static methods on Index for details on the various index types.
+
+If this is not supplied then column data type(s) and column statistics
+will be used to determine the most useful kind of index to create.
+
+#### Defined in
+
+[indices.ts:192](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L192)
+
+___
+
+### replace
+
+• `Optional` **replace**: `boolean`
+
+Whether to replace the existing index
+
+If this is false, and another index already exists on the same columns
+and the same name, then an error will be returned.  This is true even if
+that index is out of date.
+
+The default is true
+
+#### Defined in
+
+[indices.ts:202](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L202)

--- a/docs/src/js/interfaces/IvfPqOptions.md
+++ b/docs/src/js/interfaces/IvfPqOptions.md
@@ -1,0 +1,144 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / IvfPqOptions
+
+# Interface: IvfPqOptions
+
+Options to create an `IVF_PQ` index
+
+## Table of contents
+
+### Properties
+
+- [distanceType](IvfPqOptions.md#distancetype)
+- [maxIterations](IvfPqOptions.md#maxiterations)
+- [numPartitions](IvfPqOptions.md#numpartitions)
+- [numSubVectors](IvfPqOptions.md#numsubvectors)
+- [sampleRate](IvfPqOptions.md#samplerate)
+
+## Properties
+
+### distanceType
+
+• `Optional` **distanceType**: ``"l2"`` \| ``"cosine"`` \| ``"dot"``
+
+Distance type to use to build the index.
+
+Default value is "l2".
+
+This is used when training the index to calculate the IVF partitions
+(vectors are grouped in partitions with similar vectors according to this
+distance type) and to calculate a subvector's code during quantization.
+
+The distance type used to train an index MUST match the distance type used
+to search the index.  Failure to do so will yield inaccurate results.
+
+The following distance types are available:
+
+"l2" - Euclidean distance. This is a very common distance metric that
+accounts for both magnitude and direction when determining the distance
+between vectors. L2 distance has a range of [0, ∞).
+
+"cosine" - Cosine distance.  Cosine distance is a distance metric
+calculated from the cosine similarity between two vectors. Cosine
+similarity is a measure of similarity between two non-zero vectors of an
+inner product space. It is defined to equal the cosine of the angle
+between them.  Unlike L2, the cosine distance is not affected by the
+magnitude of the vectors.  Cosine distance has a range of [0, 2].
+
+Note: the cosine distance is undefined when one (or both) of the vectors
+are all zeros (there is no direction).  These vectors are invalid and may
+never be returned from a vector search.
+
+"dot" - Dot product. Dot distance is the dot product of two vectors. Dot
+distance has a range of (-∞, ∞). If the vectors are normalized (i.e. their
+L2 norm is 1), then dot distance is equivalent to the cosine distance.
+
+#### Defined in
+
+[indices.ts:83](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L83)
+
+___
+
+### maxIterations
+
+• `Optional` **maxIterations**: `number`
+
+Max iteration to train IVF kmeans.
+
+When training an IVF PQ index we use kmeans to calculate the partitions.  This parameter
+controls how many iterations of kmeans to run.
+
+Increasing this might improve the quality of the index but in most cases these extra
+iterations have diminishing returns.
+
+The default value is 50.
+
+#### Defined in
+
+[indices.ts:96](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L96)
+
+___
+
+### numPartitions
+
+• `Optional` **numPartitions**: `number`
+
+The number of IVF partitions to create.
+
+This value should generally scale with the number of rows in the dataset.
+By default the number of partitions is the square root of the number of
+rows.
+
+If this value is too large then the first part of the search (picking the
+right partition) will be slow.  If this value is too small then the second
+part of the search (searching within a partition) will be slow.
+
+#### Defined in
+
+[indices.ts:32](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L32)
+
+___
+
+### numSubVectors
+
+• `Optional` **numSubVectors**: `number`
+
+Number of sub-vectors of PQ.
+
+This value controls how much the vector is compressed during the quantization step.
+The more sub vectors there are the less the vector is compressed.  The default is
+the dimension of the vector divided by 16.  If the dimension is not evenly divisible
+by 16 we use the dimension divded by 8.
+
+The above two cases are highly preferred.  Having 8 or 16 values per subvector allows
+us to use efficient SIMD instructions.
+
+If the dimension is not visible by 8 then we use 1 subvector.  This is not ideal and
+will likely result in poor performance.
+
+#### Defined in
+
+[indices.ts:48](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L48)
+
+___
+
+### sampleRate
+
+• `Optional` **sampleRate**: `number`
+
+The number of vectors, per partition, to sample when training IVF kmeans.
+
+When an IVF PQ index is trained, we need to calculate partitions.  These are groups
+of vectors that are similar to each other.  To do this we use an algorithm called kmeans.
+
+Running kmeans on a large dataset can be slow.  To speed this up we run kmeans on a
+random sample of the data.  This parameter controls the size of the sample.  The total
+number of vectors used to train the index is `sample_rate * num_partitions`.
+
+Increasing this value might improve the quality of the index but in most cases the
+default should be sufficient.
+
+The default value is 256.
+
+#### Defined in
+
+[indices.ts:113](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/indices.ts#L113)

--- a/docs/src/js/interfaces/TableNamesOptions.md
+++ b/docs/src/js/interfaces/TableNamesOptions.md
@@ -1,0 +1,38 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / TableNamesOptions
+
+# Interface: TableNamesOptions
+
+## Table of contents
+
+### Properties
+
+- [limit](TableNamesOptions.md#limit)
+- [startAfter](TableNamesOptions.md#startafter)
+
+## Properties
+
+### limit
+
+• `Optional` **limit**: `number`
+
+An optional limit to the number of results to return.
+
+#### Defined in
+
+[connection.ts:48](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L48)
+
+___
+
+### startAfter
+
+• `Optional` **startAfter**: `string`
+
+If present, only return names that come lexicographically after the
+supplied value.
+
+This can be combined with limit to implement pagination by setting this to
+the last table name from the previous page.
+
+#### Defined in
+
+[connection.ts:46](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/connection.ts#L46)

--- a/docs/src/js/interfaces/UpdateOptions.md
+++ b/docs/src/js/interfaces/UpdateOptions.md
@@ -1,0 +1,28 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / UpdateOptions
+
+# Interface: UpdateOptions
+
+## Table of contents
+
+### Properties
+
+- [where](UpdateOptions.md#where)
+
+## Properties
+
+### where
+
+• **where**: `string`
+
+A filter that limits the scope of the update.
+
+This should be an SQL filter expression.
+
+Only rows that satisfy the expression will be updated.
+
+For example, this could be 'my_col == 0' to replace all instances
+of 0 in a column with some other default value.
+
+#### Defined in
+
+[table.ts:50](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/table.ts#L50)

--- a/docs/src/js/interfaces/WriteOptions.md
+++ b/docs/src/js/interfaces/WriteOptions.md
@@ -1,0 +1,21 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / WriteOptions
+
+# Interface: WriteOptions
+
+Write options when creating a Table.
+
+## Table of contents
+
+### Properties
+
+- [mode](WriteOptions.md#mode)
+
+## Properties
+
+### mode
+
+• `Optional` **mode**: [`WriteMode`](../enums/WriteMode.md)
+
+#### Defined in
+
+native.d.ts:74

--- a/docs/src/js/interfaces/embedding.EmbeddingFunction.md
+++ b/docs/src/js/interfaces/embedding.EmbeddingFunction.md
@@ -1,0 +1,129 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / [embedding](../modules/embedding.md) / EmbeddingFunction
+
+# Interface: EmbeddingFunction\<T\>
+
+[embedding](../modules/embedding.md).EmbeddingFunction
+
+An embedding function that automatically creates vector representation for a given column.
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Implemented by
+
+- [`OpenAIEmbeddingFunction`](../classes/embedding.OpenAIEmbeddingFunction.md)
+
+## Table of contents
+
+### Properties
+
+- [destColumn](embedding.EmbeddingFunction.md#destcolumn)
+- [embed](embedding.EmbeddingFunction.md#embed)
+- [embeddingDataType](embedding.EmbeddingFunction.md#embeddingdatatype)
+- [embeddingDimension](embedding.EmbeddingFunction.md#embeddingdimension)
+- [excludeSource](embedding.EmbeddingFunction.md#excludesource)
+- [sourceColumn](embedding.EmbeddingFunction.md#sourcecolumn)
+
+## Properties
+
+### destColumn
+
+• `Optional` **destColumn**: `string`
+
+The name of the column that will contain the embedding
+
+By default this is "vector"
+
+#### Defined in
+
+[embedding/embedding_function.ts:49](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/embedding_function.ts#L49)
+
+___
+
+### embed
+
+• **embed**: (`data`: `T`[]) => `Promise`\<`number`[][]\>
+
+Creates a vector representation for the given values.
+
+#### Type declaration
+
+▸ (`data`): `Promise`\<`number`[][]\>
+
+Creates a vector representation for the given values.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `T`[] |
+
+##### Returns
+
+`Promise`\<`number`[][]\>
+
+#### Defined in
+
+[embedding/embedding_function.ts:62](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/embedding_function.ts#L62)
+
+___
+
+### embeddingDataType
+
+• `Optional` **embeddingDataType**: `Float`\<`Floats`\>
+
+The data type of the embedding
+
+The embedding function should return `number`.  This will be converted into
+an Arrow float array.  By default this will be Float32 but this property can
+be used to control the conversion.
+
+#### Defined in
+
+[embedding/embedding_function.ts:33](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/embedding_function.ts#L33)
+
+___
+
+### embeddingDimension
+
+• `Optional` **embeddingDimension**: `number`
+
+The dimension of the embedding
+
+This is optional, normally this can be determined by looking at the results of
+`embed`.  If this is not specified, and there is an attempt to apply the embedding
+to an empty table, then that process will fail.
+
+#### Defined in
+
+[embedding/embedding_function.ts:42](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/embedding_function.ts#L42)
+
+___
+
+### excludeSource
+
+• `Optional` **excludeSource**: `boolean`
+
+Should the source column be excluded from the resulting table
+
+By default the source column is included.  Set this to true and
+only the embedding will be stored.
+
+#### Defined in
+
+[embedding/embedding_function.ts:57](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/embedding_function.ts#L57)
+
+___
+
+### sourceColumn
+
+• **sourceColumn**: `string`
+
+The name of the column that will be used as input for the Embedding Function.
+
+#### Defined in
+
+[embedding/embedding_function.ts:24](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/embedding_function.ts#L24)

--- a/docs/src/js/modules.md
+++ b/docs/src/js/modules.md
@@ -1,0 +1,208 @@
+[@lancedb/lancedb](README.md) / Exports
+
+# @lancedb/lancedb
+
+## Table of contents
+
+### Namespaces
+
+- [embedding](modules/embedding.md)
+
+### Enumerations
+
+- [WriteMode](enums/WriteMode.md)
+
+### Classes
+
+- [Connection](classes/Connection.md)
+- [Index](classes/Index.md)
+- [MakeArrowTableOptions](classes/MakeArrowTableOptions.md)
+- [Query](classes/Query.md)
+- [QueryBase](classes/QueryBase.md)
+- [RecordBatchIterator](classes/RecordBatchIterator.md)
+- [Table](classes/Table.md)
+- [VectorColumnOptions](classes/VectorColumnOptions.md)
+- [VectorQuery](classes/VectorQuery.md)
+
+### Interfaces
+
+- [AddColumnsSql](interfaces/AddColumnsSql.md)
+- [AddDataOptions](interfaces/AddDataOptions.md)
+- [ColumnAlteration](interfaces/ColumnAlteration.md)
+- [ConnectionOptions](interfaces/ConnectionOptions.md)
+- [CreateTableOptions](interfaces/CreateTableOptions.md)
+- [ExecutableQuery](interfaces/ExecutableQuery.md)
+- [IndexConfig](interfaces/IndexConfig.md)
+- [IndexOptions](interfaces/IndexOptions.md)
+- [IvfPqOptions](interfaces/IvfPqOptions.md)
+- [TableNamesOptions](interfaces/TableNamesOptions.md)
+- [UpdateOptions](interfaces/UpdateOptions.md)
+- [WriteOptions](interfaces/WriteOptions.md)
+
+### Type Aliases
+
+- [Data](modules.md#data)
+
+### Functions
+
+- [connect](modules.md#connect)
+- [makeArrowTable](modules.md#makearrowtable)
+
+## Type Aliases
+
+### Data
+
+Ƭ **Data**: `Record`\<`string`, `unknown`\>[] \| `ArrowTable`
+
+Data type accepted by NodeJS SDK
+
+#### Defined in
+
+[arrow.ts:40](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L40)
+
+## Functions
+
+### connect
+
+▸ **connect**(`uri`, `opts?`): `Promise`\<[`Connection`](classes/Connection.md)\>
+
+Connect to a LanceDB instance at the given URI.
+
+Accpeted formats:
+
+- `/path/to/database` - local database
+- `s3://bucket/path/to/database` or `gs://bucket/path/to/database` - database on cloud storage
+- `db://host:port` - remote database (LanceDB cloud)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `uri` | `string` | The uri of the database. If the database uri starts with `db://` then it connects to a remote database. |
+| `opts?` | `Partial`\<[`ConnectionOptions`](interfaces/ConnectionOptions.md)\> | - |
+
+#### Returns
+
+`Promise`\<[`Connection`](classes/Connection.md)\>
+
+**`See`**
+
+[ConnectionOptions](interfaces/ConnectionOptions.md) for more details on the URI format.
+
+#### Defined in
+
+[index.ts:62](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/index.ts#L62)
+
+___
+
+### makeArrowTable
+
+▸ **makeArrowTable**(`data`, `options?`): `ArrowTable`
+
+An enhanced version of the makeTable function from Apache Arrow
+that supports nested fields and embeddings columns.
+
+(typically you do not need to call this function.  It will be called automatically
+when creating a table or adding data to it)
+
+This function converts an array of Record<String, any> (row-major JS objects)
+to an Arrow Table (a columnar structure)
+
+Note that it currently does not support nulls.
+
+If a schema is provided then it will be used to determine the resulting array
+types.  Fields will also be reordered to fit the order defined by the schema.
+
+If a schema is not provided then the types will be inferred and the field order
+will be controlled by the order of properties in the first record.  If a type
+is inferred it will always be nullable.
+
+If the input is empty then a schema must be provided to create an empty table.
+
+When a schema is not specified then data types will be inferred.  The inference
+rules are as follows:
+
+ - boolean => Bool
+ - number => Float64
+ - String => Utf8
+ - Buffer => Binary
+ - Record<String, any> => Struct
+ - Array<any> => List
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Record`\<`string`, `unknown`\>[] |
+| `options?` | `Partial`\<[`MakeArrowTableOptions`](classes/MakeArrowTableOptions.md)\> |
+
+#### Returns
+
+`ArrowTable`
+
+**`Example`**
+
+import { fromTableToBuffer, makeArrowTable } from "../arrow";
+import { Field, FixedSizeList, Float16, Float32, Int32, Schema } from "apache-arrow";
+
+const schema = new Schema([
+  new Field("a", new Int32()),
+  new Field("b", new Float32()),
+  new Field("c", new FixedSizeList(3, new Field("item", new Float16()))),
+ ]);
+ const table = makeArrowTable([
+   { a: 1, b: 2, c: [1, 2, 3] },
+   { a: 4, b: 5, c: [4, 5, 6] },
+   { a: 7, b: 8, c: [7, 8, 9] },
+ ], { schema });
+```
+
+By default it assumes that the column named `vector` is a vector column
+and it will be converted into a fixed size list array of type float32.
+The `vectorColumns` option can be used to support other vector column
+names and data types.
+
+```ts
+
+const schema = new Schema([
+   new Field("a", new Float64()),
+   new Field("b", new Float64()),
+   new Field(
+     "vector",
+     new FixedSizeList(3, new Field("item", new Float32()))
+   ),
+ ]);
+ const table = makeArrowTable([
+   { a: 1, b: 2, vector: [1, 2, 3] },
+   { a: 4, b: 5, vector: [4, 5, 6] },
+   { a: 7, b: 8, vector: [7, 8, 9] },
+ ]);
+ assert.deepEqual(table.schema, schema);
+```
+
+You can specify the vector column types and names using the options as well
+
+```typescript
+
+const schema = new Schema([
+   new Field('a', new Float64()),
+   new Field('b', new Float64()),
+   new Field('vec1', new FixedSizeList(3, new Field('item', new Float16()))),
+   new Field('vec2', new FixedSizeList(3, new Field('item', new Float16())))
+ ]);
+const table = makeArrowTable([
+   { a: 1, b: 2, vec1: [1, 2, 3], vec2: [2, 4, 6] },
+   { a: 4, b: 5, vec1: [4, 5, 6], vec2: [8, 10, 12] },
+   { a: 7, b: 8, vec1: [7, 8, 9], vec2: [14, 16, 18] }
+ ], {
+   vectorColumns: {
+     vec1: { type: new Float16() },
+     vec2: { type: new Float16() }
+   }
+ }
+assert.deepEqual(table.schema, schema)
+```
+
+#### Defined in
+
+[arrow.ts:197](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/arrow.ts#L197)

--- a/docs/src/js/modules/embedding.md
+++ b/docs/src/js/modules/embedding.md
@@ -1,0 +1,45 @@
+[@lancedb/lancedb](../README.md) / [Exports](../modules.md) / embedding
+
+# Namespace: embedding
+
+## Table of contents
+
+### Classes
+
+- [OpenAIEmbeddingFunction](../classes/embedding.OpenAIEmbeddingFunction.md)
+
+### Interfaces
+
+- [EmbeddingFunction](../interfaces/embedding.EmbeddingFunction.md)
+
+### Functions
+
+- [isEmbeddingFunction](embedding.md#isembeddingfunction)
+
+## Functions
+
+### isEmbeddingFunction
+
+▸ **isEmbeddingFunction**\<`T`\>(`value`): value is EmbeddingFunction\<T\>
+
+Test if the input seems to be an embedding function
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `unknown` |
+
+#### Returns
+
+value is EmbeddingFunction\<T\>
+
+#### Defined in
+
+[embedding/embedding_function.ts:66](https://github.com/lancedb/lancedb/blob/9d178c7/nodejs/lancedb/embedding/embedding_function.ts#L66)

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -59,7 +59,7 @@
     "build": "npm run build:debug && tsc -b && shx cp lancedb/native.d.ts dist/native.d.ts",
     "build-release": "npm run build:release && tsc -b && shx cp lancedb/native.d.ts dist/native.d.ts",
     "chkformat": "prettier . --check",
-    "docs": "typedoc --plugin typedoc-plugin-markdown lancedb/index.ts",
+    "docs": "typedoc --plugin typedoc-plugin-markdown --out ../docs/src/js lancedb/index.ts",
     "lint": "eslint lancedb && eslint __test__",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "npm run build && jest --verbose",

--- a/nodejs/typedoc.json
+++ b/nodejs/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "intentionallyNotExported": [
+    "lancedb/native.d.ts:Connection",
+    "lancedb/native.d.ts:Index",
+    "lancedb/native.d.ts:Query",
+    "lancedb/native.d.ts:VectorQuery",
+    "lancedb/native.d.ts:RecordBatchIterator",
+    "lancedb/native.d.ts:Table"
+  ]
+}


### PR DESCRIPTION
We aren't yet ready to switch over the examples since almost all JS examples rely on embeddings and we haven't yet ported those over.  However, this makes it possible for those that are interested to start using `@lancedb/lancedb`