### PR TITLE
SQL Documentation includes DataFusion functions

### DIFF
--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -66,6 +66,7 @@ Currently, Lance supports a growing list of SQL expressions.
 - `LIKE`, `NOT LIKE`
 - `CAST`
 - `regexp_match(column, pattern)`
+- [DataFusion Functions](https://arrow.apache.org/datafusion/user-guide/sql/scalar_functions.html)
 
 For example, the following filter string is acceptable:
 


### PR DESCRIPTION
Show that it is possible to use the DataFusion functions in the `WHERE` clause. 