### PR TITLE
add a default value for search.limit to be consistent with python sdk

### DIFF
--- a/node/src/query.ts
+++ b/node/src/query.ts
@@ -38,7 +38,7 @@ export class Query<T = number[]> {
   constructor (query?: T, tbl?: any, embeddings?: EmbeddingFunction<T>) {
     this._tbl = tbl
     this._query = query
-    this._limit = undefined
+    this._limit = 10
     this._nprobes = 20
     this._refineFactor = undefined
     this._select = undefined

--- a/node/src/query.ts
+++ b/node/src/query.ts
@@ -50,6 +50,7 @@ export class Query<T = number[]> {
 
   /***
      * Sets the number of results that will be returned
+     * default value is 10
      * @param value number of results
      */
   limit (value: number): Query<T> {

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -124,9 +124,9 @@ describe('LanceDB client', function () {
       const uri = await createTestDB(2, 100)
       const con = await lancedb.connect(uri)
       const table = (await con.openTable('vectors')) as LocalTable
-      let results = await table.filter('id % 2 = 0').execute()
+      let results = await table.filter('id % 2 = 0').limit(100).execute()
       assertResults(results)
-      results = await table.where('id % 2 = 0').execute()
+      results = await table.where('id % 2 = 0').limit(100).execute()
       assertResults(results)
 
       // Should reject a bad filter


### PR DESCRIPTION
Changed the default value for search.limit to be 10