### PR TITLE
feat: expose storage options in LanceDB

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -107,6 +107,7 @@ jobs:
       AWS_ENDPOINT: http://localhost:4566
       # this one is for dynamodb
       DYNAMODB_ENDPOINT: http://localhost:4566
+      ALLOW_HTTP: true
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -85,7 +85,13 @@ jobs:
       run: |
         npm ci
         npm run build
+    - name: Setup localstack
+      working-directory: .
+      run: |
+        docker-compose up --detach --wait
     - name: Test
+      env:
+        INTEGRATION_TEST: "1"
       run: npm run test
   macos:
     timeout-minutes: 30

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -87,8 +87,7 @@ jobs:
         npm run build
     - name: Setup localstack
       working-directory: .
-      run: |
-        docker-compose up --detach --wait
+      run: docker compose up --detach --wait
     - name: Test
       env:
         INTEGRATION_TEST: "1"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -90,7 +90,7 @@ jobs:
       run: docker compose up --detach --wait
     - name: Test
       env:
-        INTEGRATION_TEST: "1"
+        S3_TEST: "1"
       run: npm run test
   macos:
     timeout-minutes: 30

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -192,4 +192,4 @@ jobs:
           pip install -e .[tests]
           pip install tantivy
       - name: Run tests
-        run: pytest -m "not slow" -x -v --durations=30 python/tests
+        run: pytest -m "not slow and not integration" -x -v --durations=30 python/tests

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -97,10 +97,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: python
-      - uses: ./.github/workflows/build_linux_wheel
+      - uses: ./.github/workflows/build_linux_wheel      
+      - uses: ./.github/workflows/run_tests
         with:
           integration: true
-      - uses: ./.github/workflows/run_tests
       # Make sure wheels are not included in the Rust cache
       - name: Delete wheels
         run: rm -rf target/wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -192,4 +192,4 @@ jobs:
           pip install -e .[tests]
           pip install tantivy
       - name: Run tests
-        run: pytest -m "not slow and not integration" -x -v --durations=30 python/tests
+        run: pytest -m "not slow and not s3_test" -x -v --durations=30 python/tests

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: python
-      - uses: ./.github/workflows/build_linux_wheel      
+      - uses: ./.github/workflows/build_linux_wheel
       - uses: ./.github/workflows/run_tests
         with:
           integration: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -98,6 +98,8 @@ jobs:
         with:
           workspaces: python
       - uses: ./.github/workflows/build_linux_wheel
+        with:
+          integration: true
       - uses: ./.github/workflows/run_tests
       # Make sure wheels are not included in the Rust cache
       - name: Delete wheels

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -28,4 +28,4 @@ runs:
     - name: pytest (no integration tests)
       shell: bash
       if: ${{ inputs.integration != 'true' }}
-      run: pytest -m "not slow and not integration" -x -v --durations=30 python/python/tests
+      run: pytest -m "not slow and not s3_test" -x -v --durations=30 python/python/tests

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -5,6 +5,10 @@ inputs:
   python-minor-version:
     required: true
     description: "8 9 10 11 12"
+  integration:
+    required: false
+    description: "Run integration tests"
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -12,6 +16,13 @@ runs:
       shell: bash
       run: |
         pip3 install $(ls target/wheels/lancedb-*.whl)[tests,dev]
+    - name: Setup localstack for integration tests
+      if: ${{ inputs.integration == 'true' }}
+      shell: bash
+      working-directory: .
+      run: |
+        docker-compose compose up --detach
+        sleep 10
     - name: pytest
       shell: bash
       run: pytest -m "not slow" -x -v --durations=30 python/python/tests

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -20,9 +20,7 @@ runs:
       if: ${{ inputs.integration == 'true' }}
       shell: bash
       working-directory: .
-      run: |
-        docker-compose compose up --detach
-        sleep 10
+      run: docker compose up --detach --wait
     - name: pytest
       shell: bash
       run: pytest -m "not slow" -x -v --durations=30 python/python/tests

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -21,6 +21,11 @@ runs:
       shell: bash
       working-directory: .
       run: docker compose up --detach --wait
-    - name: pytest
+    - name: pytest (with integration)
       shell: bash
+      if: ${{ inputs.integration == 'true' }}
       run: pytest -m "not slow" -x -v --durations=30 python/python/tests
+    - name: pytest (no integration tests)
+      shell: bash
+      if: ${{ inputs.integration != 'true' }}
+      run: pytest -m "not slow and not integration" -x -v --durations=30 python/python/tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,6 +76,9 @@ jobs:
           sudo apt install -y protobuf-compiler libssl-dev
     - name: Build
       run: cargo build --all-features
+    - name: Start integration test environment
+      working-directory: .
+      run: docker compose up
     - name: Run tests
       run: cargo test --all-features
     - name: Run examples
@@ -104,6 +107,9 @@ jobs:
         run: brew install protobuf
       - name: Build
         run: cargo build --all-features
+      - name: Start integration test environment
+        working-directory: .
+        run: docker compose up
       - name: Run tests
         run: cargo test --all-features
   windows:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,7 @@ jobs:
       run: cargo build --all-features
     - name: Start integration test environment
       working-directory: .
-      run: docker compose up
+      run: docker compose up --detach && sleep 10
     - name: Run tests
       run: cargo test --all-features
     - name: Run examples
@@ -109,7 +109,7 @@ jobs:
         run: cargo build --all-features
       - name: Start integration test environment
         working-directory: .
-        run: docker compose up
+        run: docker compose up --detach && sleep 10
       - name: Run tests
         run: cargo test --all-features
   windows:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,7 @@ jobs:
       run: cargo build --all-features
     - name: Start integration test environment
       working-directory: .
-      run: docker compose up --detach && sleep 10
+      run: docker compose up --detach --wait
     - name: Run tests
       run: cargo test --all-features
     - name: Run examples
@@ -107,11 +107,9 @@ jobs:
         run: brew install protobuf
       - name: Build
         run: cargo build --all-features
-      - name: Start integration test environment
-        working-directory: .
-        run: docker compose up --detach && sleep 10
       - name: Run tests
-        run: cargo test --all-features
+        # Run with everything except the integration tests.
+        run: cargo test --features remote,fp16kernels
   windows:
     runs-on: windows-2022
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,7 +76,7 @@ jobs:
           sudo apt install -y protobuf-compiler libssl-dev
     - name: Build
       run: cargo build --all-features
-    - name: Start integration test environment
+    - name: Start S3 integration test environment
       working-directory: .
       run: docker compose up --detach --wait
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,14 @@ keywords = ["lancedb", "lance", "database", "vector", "search"]
 categories = ["database-implementations"]
 
 [workspace.dependencies]
-lance = { "version" = "=0.10.9", "features" = ["dynamodb"] }
-lance-index = { "version" = "=0.10.9" }
-lance-linalg = { "version" = "=0.10.9" }
-lance-testing = { "version" = "=0.10.9" }
+# lance = { "version" = "=0.10.9", "features" = ["dynamodb"] }
+# lance-index = { "version" = "=0.10.9" }
+# lance-linalg = { "version" = "=0.10.9" }
+# lance-testing = { "version" = "=0.10.9" }
+lance = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main", "features" = ["dynamodb"] }
+lance-index = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main" }
+lance-linalg = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main" }
+lance-testing = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main" }
 # Note that this one does not include pyarrow
 arrow = { version = "50.0", optional = false }
 arrow-array = "50.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,10 @@ keywords = ["lancedb", "lance", "database", "vector", "search"]
 categories = ["database-implementations"]
 
 [workspace.dependencies]
-# lance = { "version" = "=0.10.9", "features" = ["dynamodb"] }
-# lance-index = { "version" = "=0.10.9" }
-# lance-linalg = { "version" = "=0.10.9" }
-# lance-testing = { "version" = "=0.10.9" }
-lance = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main", "features" = ["dynamodb"] }
-lance-index = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main" }
-lance-linalg = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main" }
-lance-testing = { "git" = "https://github.com/lancedb/lance.git", "branch" = "main" }
+lance = { "version" = "=0.10.10", "features" = ["dynamodb"] }
+lance-index = { "version" = "=0.10.10" }
+lance-linalg = { "version" = "=0.10.10" }
+lance-testing = { "version" = "=0.10.10" }
 # Note that this one does not include pyarrow
 arrow = { version = "50.0", optional = false }
 arrow-array = "50.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - AWS_ACCESS_KEY_ID=ACCESSKEY
       - AWS_SECRET_ACCESS_KEY=SECRETKEY
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:4566/health" ]
+      test: [ "CMD", "curl", "-s", "http://localhost:4566/_localstack/health" ]
       interval: 5s
       retries: 3
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.9"
 services:
   localstack:
-    image: localstack/localstack:0.14
+    image: localstack/localstack:3.3
     ports:
       - 4566:4566
     environment:
-      - SERVICES=s3,dynamodb
+      - SERVICES=s3,dynamodb,kms
       - DEBUG=1
       - LS_LOG=trace
       - DOCKER_HOST=unix:///var/run/docker.sock

--- a/docs/src/guides/storage.md
+++ b/docs/src/guides/storage.md
@@ -340,6 +340,7 @@ GCS credentials are configured by setting the `GOOGLE_SERVICE_ACCOUNT` environme
 
 === "Python"
 
+    <!-- skip-test -->
     ```python
     import lancedb
     db = await lancedb.connect_async(
@@ -386,6 +387,7 @@ Azure Blob Storage credentials can be configured by setting the `AZURE_STORAGE_A
 
 === "Python"
 
+    <!-- skip-test -->
     ```python
     import lancedb
     db = await lancedb.connect_async(

--- a/docs/src/guides/storage.md
+++ b/docs/src/guides/storage.md
@@ -66,7 +66,7 @@ export TIMEOUT=60s
     The `storage_options` parameter is only available in Python *async* API and JavaScript API.
     It is not yet supported in the Python synchronous API.
 
-If you only want this to apply to one particular connection, you can pass the `storage_options` object to the `connect` function:
+If you only want this to apply to one particular connection, you can pass the `storage_options` argument when opening the connection:
 
 === "Python"
 
@@ -138,7 +138,7 @@ There are several options that can be set for all object stores, mostly related 
 
 ### AWS S3
 
-To configure credentials for AWS S3, you can use the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` keys.
+To configure credentials for AWS S3, you can use the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` keys. Region can also be set, but it is not mandatory when using AWS.
 These can be set as environment variables or passed in the `storage_options` parameter:
 
 === "Python"
@@ -376,7 +376,7 @@ The following keys can be used as both environment variables or keys in the `sto
 
 | Key                                   | Description                                  |
 |---------------------------------------|----------------------------------------------|
-| ``google_service_account``            | Path to the service account JSON file.       |
+| ``google_service_account`` / `service_account` | Path to the service account JSON file.       |
 | ``google_service_account_key``        | The serialized service account key.          |
 | ``google_application_credentials``    | Path to the application credentials.         |
 

--- a/docs/src/guides/storage.md
+++ b/docs/src/guides/storage.md
@@ -90,6 +90,7 @@ Getting even more specific, you can set the `timeout` for only a particular tabl
 
 === "Python"
 
+    <!-- skip-test -->
     ```python
     import lancedb
     db = await lancedb.connect_async("s3://bucket/path")
@@ -102,6 +103,7 @@ Getting even more specific, you can set the `timeout` for only a particular tabl
 
 === "JavaScript"
 
+    <!-- skip-test -->
     ```javascript
     const lancedb = require("lancedb");
     const db = await lancedb.connect("s3://bucket/path");

--- a/docs/src/guides/storage.md
+++ b/docs/src/guides/storage.md
@@ -64,7 +64,7 @@ export TIMEOUT=60s
 !!! note "`storage_options` availability"
 
     The `storage_options` parameter is only available in Python *async* API and JavaScript API.
-    It it not yet supported in Python synchronous API.
+    It is not yet supported in the Python synchronous API.
 
 If you only want this to apply to one particular connection, you can pass the `storage_options` object to the `connect` function:
 
@@ -83,7 +83,7 @@ If you only want this to apply to one particular connection, you can pass the `s
     ```javascript
     const lancedb = require("lancedb");
     const db = await lancedb.connect("s3://bucket/path",
-                                     {timeout: "60s"});
+                                     {storageOptions: {timeout: "60s"}});
     ```
 
 Getting even more specific, you can set the `timeout` for only a particular table:
@@ -93,7 +93,11 @@ Getting even more specific, you can set the `timeout` for only a particular tabl
     ```python
     import lancedb
     db = await lancedb.connect_async("s3://bucket/path")
-    table = await db.open_table("table", storage_options={"connect_timeout": "60s"})
+    table = await db.create_table(
+        "table",
+        [{"a": 1, "b": 2}],
+        storage_options={"timeout": "60s"}
+    )
     ```
 
 === "JavaScript"
@@ -101,8 +105,16 @@ Getting even more specific, you can set the `timeout` for only a particular tabl
     ```javascript
     const lancedb = require("lancedb");
     const db = await lancedb.connect("s3://bucket/path");
-    const table = db.openTable("table", {timeout: "60s"});
+    const table = db.createTable(
+        "table",
+        [{ a: 1, b: 2}],
+        {storageOptions: {timeout: "60s"}}
+    );
     ```
+
+!!! info "Storage option casing"
+
+    The storage option keys are case-insensitive. So `connect_timeout` and `CONNECT_TIMEOUT` are the same setting. Usually lowercase is used in the `storage_options` argument and uppercase is used for environment variables. In the `lancedb` Node package, the keys can also be provided in `camelCase` capitalization. For example, `connectTimeout` is equivalent to `connect_timeout`.
 
 ### General configuration
 
@@ -148,9 +160,11 @@ These can be set as environment variables or passed in the `storage_options` par
     const db = await lancedb.connect(
         "s3://bucket/path",
         {
-            aws_access_key_id: "my-access-key",
-            aws_secret_access_key: "my-secret-key",
-            aws_session_token: "my-session-token",
+            storageOptions: {
+                awsAccessKeyId: "my-access-key",
+                awsSecretAccessKey: "my-secret-key",
+                awsSessionToken: "my-session-token",
+            }
         }
     );
     ```
@@ -273,8 +287,10 @@ LanceDB can also connect to S3-compatible stores, such as MinIO. To do so, you m
     const db = await lancedb.connect(
         "s3://bucket/path",
         {
-            region: "us-east-1",
-            endpoint: "http://minio:9000",
+            storageOptions: {
+                region: "us-east-1",
+                endpoint: "http://minio:9000",
+            }
         }
     );
     ```
@@ -307,8 +323,10 @@ To configure LanceDB to use an S3 Express endpoint, you must set the storage opt
     const db = await lancedb.connect(
         "s3://my-bucket--use1-az4--x-s3/path",
         {
-            region: "us-east-1",
-            s3_express: "true",
+            storageOptions: {
+                region: "us-east-1",
+                s3Express: "true",
+            }
         }
     );
     ```
@@ -337,7 +355,9 @@ GCS credentials are configured by setting the `GOOGLE_SERVICE_ACCOUNT` environme
     const db = await lancedb.connect(
         "gs://my-bucket/my-database",
         {
-            service_account: "path/to/service-account.json",
+            storageOptions: {
+                serviceAccount: "path/to/service-account.json",
+            }
         }
     );
     ```
@@ -382,8 +402,10 @@ Azure Blob Storage credentials can be configured by setting the `AZURE_STORAGE_A
     const db = await lancedb.connect(
         "az://my-container/my-database",
         {
-            account_name: "some-account",
-            account_key: "some-key",
+            storageOptions: {
+                accountName: "some-account",
+                accountKey: "some-key",
+            }
         }
     );
     ```

--- a/docs/src/guides/storage.md
+++ b/docs/src/guides/storage.md
@@ -61,14 +61,21 @@ In most cases, when running in the respective cloud and permissions are set up c
 export TIMEOUT=60s
 ```
 
+!!! note "`storage_options` availability"
+
+    The `storage_options` parameter is only available in Python *async* API and JavaScript API.
+    It it not yet supported in Python synchronous API.
+
 If you only want this to apply to one particular connection, you can pass the `storage_options` object to the `connect` function:
 
 === "Python"
 
     ```python
     import lancedb
-    db = lancedb.connect("s3://bucket/path",
-                         storage_options={"timeout": "60s"})
+    db = await lancedb.connect_async(
+        "s3://bucket/path",
+        storage_options={"timeout": "60s"}
+    )
     ```
 
 === "JavaScript"
@@ -85,8 +92,8 @@ Getting even more specific, you can set the `timeout` for only a particular tabl
 
     ```python
     import lancedb
-    db = lancedb.connect("s3://bucket/path")
-    table = db.open_table("table", storage_options={"connect_timeout": "60s"})
+    db = await lancedb.connect_async("s3://bucket/path")
+    table = await db.open_table("table", storage_options={"connect_timeout": "60s"})
     ```
 
 === "JavaScript"
@@ -124,7 +131,7 @@ These can be set as environment variables or passed in the `storage_options` par
 
     ```python
     import lancedb
-    db = lancedb.connect(
+    db = await lancedb.connect_async(
         "s3://bucket/path",
         storage_options={
             "aws_access_key_id": "my-access-key",
@@ -250,7 +257,7 @@ LanceDB can also connect to S3-compatible stores, such as MinIO. To do so, you m
 
     ```python
     import lancedb
-    db = lancedb.connect(
+    db = await lancedb.connect_async(
         "s3://bucket/path",
         storage_options={
             "region": "us-east-1",
@@ -284,7 +291,7 @@ To configure LanceDB to use an S3 Express endpoint, you must set the storage opt
 
     ```python
     import lancedb
-    db = lancedb.connect(
+    db = await lancedb.connect_async(
         "s3://my-bucket--use1-az4--x-s3/path",
         storage_options={
             "region": "us-east-1",
@@ -315,7 +322,7 @@ GCS credentials are configured by setting the `GOOGLE_SERVICE_ACCOUNT` environme
 
     ```python
     import lancedb
-    db = lancedb.connect(
+    db = await lancedb.connect_async(
         "gs://my-bucket/my-database",
         storage_options={
             "service_account": "path/to/service-account.json",
@@ -359,7 +366,7 @@ Azure Blob Storage credentials can be configured by setting the `AZURE_STORAGE_A
 
     ```python
     import lancedb
-    db = lancedb.connect(
+    db = await lancedb.connect_async(
         "az://my-container/my-database",
         storage_options={
             account_name: "some-account",

--- a/docs/test/md_testing.py
+++ b/docs/test/md_testing.py
@@ -1,5 +1,5 @@
 import glob
-from typing import Iterator
+from typing import Iterator, List
 from pathlib import Path
 
 glob_string = "../src/**/*.md"
@@ -50,11 +50,24 @@ def yield_lines(lines: Iterator[str], prefix: str, suffix: str):
                 yield line[strip_length:]
 
 
+def wrap_async(lines: List[str]) -> List[str]:
+    # Indent all the lines
+    lines = ["    " + line for line in lines]
+    # Put all lines in `async def main():`
+    lines = ["async def main():\n"] + lines
+    # Put `import asyncio\n asyncio.run(main())` at the end
+    lines = lines + ["\n", "import asyncio\n", "asyncio.run(main())\n"]
+    return lines
+
+
 for file in filter(lambda file: file not in excluded_files, files):
     with open(file, "r") as f:
         lines = list(yield_lines(iter(f), "```", "```"))
 
     if len(lines) > 0:
+        if any("await" in line for line in lines):
+            lines = wrap_async(lines)
+
         print(lines)
         out_path = (
             Path(python_folder)

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -78,11 +78,24 @@ export interface ConnectionOptions {
   /** User provided AWS crednetials.
    *
    * If not provided, LanceDB will use the default credentials provider chain.
+   *
+   * @deprecated Pass `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token`
+   * through `storageOptions` instead.
    */
   awsCredentials?: AwsCredentials
 
-  /** AWS region to connect to. Default is {@link defaultAwsRegion}. */
+  /** AWS region to connect to. Default is {@link defaultAwsRegion}
+   *
+   * @deprecated Pass `region` through `storageOptions` instead.
+   */
   awsRegion?: string
+
+  /**
+   * User provided options for object storage. For example, S3 credentials or request timeouts.
+   *
+   * The various options are described at https://lancedb.github.io/lancedb/guides/storage/
+   */
+  storageOptions?: Record<string, string>
 
   /**
    * API key for the remote connections
@@ -176,7 +189,6 @@ export async function connect (
   if (typeof arg === 'string') {
     opts = { uri: arg }
   } else {
-    // opts = { uri: arg.uri, awsCredentials = arg.awsCredentials }
     const keys = Object.keys(arg)
     if (keys.length === 1 && keys[0] === 'uri' && typeof arg.uri === 'string') {
       opts = { uri: arg.uri }
@@ -198,12 +210,26 @@ export async function connect (
     // Remote connection
     return new RemoteConnection(opts)
   }
+
+  const storageOptions = opts.storageOptions ?? {};
+  if (opts.awsCredentials?.accessKeyId !== undefined) {
+    storageOptions.aws_access_key_id = opts.awsCredentials.accessKeyId
+  }
+  if (opts.awsCredentials?.secretKey !== undefined) {
+    storageOptions.aws_secret_access_key = opts.awsCredentials.secretKey
+  }
+  if (opts.awsCredentials?.sessionToken !== undefined) {
+    storageOptions.aws_session_token = opts.awsCredentials.sessionToken
+  }
+  if (opts.awsRegion !== undefined) {
+    storageOptions.region = opts.awsRegion
+  }
+  // It's a pain to pass a record to Rust, so we convert it to an array of key-value pairs
+  const storageOptionsArr = Object.entries(storageOptions);
+
   const db = await databaseNew(
     opts.uri,
-    opts.awsCredentials?.accessKeyId,
-    opts.awsCredentials?.secretKey,
-    opts.awsCredentials?.sessionToken,
-    opts.awsRegion,
+    storageOptionsArr,
     opts.readConsistencyInterval
   )
   return new LocalConnection(db, opts)
@@ -720,7 +746,6 @@ export class LocalConnection implements Connection {
     const tbl = await databaseOpenTable.call(
       this._db,
       name,
-      ...getAwsArgs(this._options())
     )
     if (embeddings !== undefined) {
       return new LocalTable(tbl, name, this._options(), embeddings)

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -74,6 +74,19 @@ describe('LanceDB client', function () {
       assert.equal(con.uri, uri)
     })
 
+    it('should accept custom storage options', async function () {
+      const uri = await createTestDB()
+      const storageOptions = {
+        region: 'us-west-2',
+        timeout: '30s'
+      };
+      const con = await lancedb.connect({
+        uri,
+        storageOptions
+      })
+      assert.equal(con.uri, uri)
+    })
+
     it('should return the existing table names', async function () {
       const uri = await createTestDB()
       const con = await lancedb.connect(uri)

--- a/nodejs/__test__/s3_integration.test.ts
+++ b/nodejs/__test__/s3_integration.test.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { connect } from "../dist";
 import {
   CreateBucketCommand,

--- a/nodejs/__test__/s3_integration.test.ts
+++ b/nodejs/__test__/s3_integration.test.ts
@@ -29,8 +29,8 @@ import {
   KMSClient,
 } from "@aws-sdk/client-kms";
 
-// Skip these tests unless the INTEGRATION_TESTS environment variable is set
-const maybeDescribe = process.env.INTEGRATION_TEST ? describe : describe.skip;
+// Skip these tests unless the S3_TEST environment variable is set
+const maybeDescribe = process.env.S3_TEST ? describe : describe.skip;
 
 // These are all keys that are accepted by storage_options
 const CONFIG = {

--- a/nodejs/__test__/s3_integration.test.ts
+++ b/nodejs/__test__/s3_integration.test.ts
@@ -1,0 +1,202 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { connect } from "../dist";
+import {
+    CreateBucketCommand,
+    DeleteBucketCommand,
+    DeleteObjectCommand,
+    HeadObjectCommand,
+    ListObjectsV2Command,
+    S3Client
+} from "@aws-sdk/client-s3";
+import {
+    CreateKeyCommand,
+    ScheduleKeyDeletionCommand,
+    KMSClient
+} from "@aws-sdk/client-kms";
+
+// These are all keys that are accepted by storage_options
+const CONFIG = {
+    allow_http: "true",
+    aws_access_key_id: "ACCESSKEY",
+    aws_secret_access_key: "SECRETKEY",
+    aws_endpoint: "http://127.0.0.1:4566",
+    aws_region: "us-east-1",
+}
+
+class S3Bucket {
+    name: string;
+    constructor(name: string) {
+        this.name = name;
+    }
+
+    static s3Client() {
+        return new S3Client({
+            region: CONFIG.aws_region,
+            credentials: {
+                accessKeyId: CONFIG.aws_access_key_id,
+                secretAccessKey: CONFIG.aws_secret_access_key
+            },
+            endpoint: CONFIG.aws_endpoint
+        });
+    }
+
+    public static async create(name: string): Promise<S3Bucket> {
+        const client = this.s3Client();
+        // Delete the bucket if it already exists
+        try {
+            await this.deleteBucket(client, name);
+        } catch (e) {
+            // It's fine if the bucket doesn't exist
+        }
+        await client.send(new CreateBucketCommand({ Bucket: name }));
+        return new S3Bucket(name);
+    }
+
+    public async delete() {
+        const client = S3Bucket.s3Client();
+        await S3Bucket.deleteBucket(client, this.name);
+    }
+
+    static async deleteBucket(client: S3Client, name: string) {
+        // Must delete all objects before we can delete the bucket
+        const objects = await client.send(new ListObjectsV2Command({ Bucket: name }));
+        if (objects.Contents) {
+            for (const object of objects.Contents) {
+                await client.send(new DeleteObjectCommand({ Bucket: name, Key: object.Key }));
+            }
+        }
+
+        await client.send(new DeleteBucketCommand({ Bucket: name }));
+    }
+
+    public async assertAllEncrypted(path: string, keyId: string) {
+        const client = S3Bucket.s3Client();
+        const objects = await client.send(new ListObjectsV2Command({ Bucket: this.name, Prefix: path }));
+        if (objects.Contents) {
+            for (const object of objects.Contents) {
+                const metadata = await client.send(new HeadObjectCommand({ Bucket: this.name, Key: object.Key }));
+                expect(metadata.ServerSideEncryption).toBe("aws:kms");
+                expect(metadata.SSEKMSKeyId).toContain(keyId);
+            }
+        }
+    }
+}
+
+class KmsKey {
+    keyId: string;
+    constructor(keyId: string) {
+        this.keyId = keyId;
+    }
+
+    static kmsClient() {
+        return new KMSClient({
+            region: CONFIG.aws_region,
+            credentials: {
+                accessKeyId: CONFIG.aws_access_key_id,
+                secretAccessKey: CONFIG.aws_secret_access_key
+            },
+            endpoint: CONFIG.aws_endpoint
+        });
+    }
+
+    public static async create(): Promise<KmsKey> {
+        const client = this.kmsClient();
+        const key = await client.send(new CreateKeyCommand({}));
+        const keyId = key?.KeyMetadata?.KeyId;
+        if (!keyId) {
+            throw new Error("Failed to create KMS key");
+        }
+        return new KmsKey(keyId);
+    }
+
+    public async delete() {
+        const client = KmsKey.kmsClient();
+        await client.send(new ScheduleKeyDeletionCommand({ KeyId: this.keyId }));
+    }
+}
+
+describe("storage_options", () => {
+    let bucket: S3Bucket;
+    let kmsKey: KmsKey;
+    beforeAll(async () => {
+        bucket = await S3Bucket.create("lancedb");
+        kmsKey = await KmsKey.create();
+    });
+    afterAll(async () => {
+        await kmsKey.delete();
+        await bucket.delete();
+    });
+
+    it("can be used to configure auth and endpoints", async () => {
+        const uri = `s3://${bucket.name}/test`;
+        const db = await connect(uri, { storageOptions: CONFIG });
+
+        let table = await db.createTable("test", [{ a: 1, b: 2 }]);
+
+        let rowCount = await table.countRows();
+        expect(rowCount).toBe(1);
+
+        let table_names = await db.tableNames();
+        expect(table_names).toEqual(["test"]);
+
+        table = await db.openTable("test");
+        rowCount = await table.countRows();
+        expect(rowCount).toBe(1);
+
+        await table.add([
+            { a: 2, b: 3 },
+            { a: 3, b: 4 }
+        ]);
+        rowCount = await table.countRows();
+        expect(rowCount).toBe(3);
+
+        await db.dropTable("test");
+
+        table_names = await db.tableNames();
+        expect(table_names).toEqual([]);
+    });
+
+    it("can configure encryption at connection and table level", async () => {
+        const uri = `s3://${bucket.name}/test`;
+        let db = await connect(uri, { storageOptions: CONFIG });
+
+        let table = await db.createTable("table1", [{ a: 1, b: 2 }], { storageOptions: {
+            aws_server_side_encryption: "aws:kms",
+            aws_sse_kms_key_id: kmsKey.keyId,
+        }});
+
+        let rowCount = await table.countRows();
+        expect(rowCount).toBe(1);
+
+        await table.add([{ a: 2, b: 3 }])
+
+        await bucket.assertAllEncrypted("test/table1.lance", kmsKey.keyId);
+
+        // Now with encryption settings at connection level        
+        db = await connect(uri, { storageOptions: {
+            ...CONFIG,
+            aws_server_side_encryption: "aws:kms",
+            aws_sse_kms_key_id: kmsKey.keyId,
+        }});
+        table = await db.createTable("table2", [{ a: 1, b: 2 }]);
+        rowCount = await table.countRows();
+        expect(rowCount).toBe(1);
+
+        await table.add([{ a: 2, b: 3 }])
+
+        await bucket.assertAllEncrypted("test/table2.lance", kmsKey.keyId);
+    });
+});

--- a/nodejs/eslint.config.js
+++ b/nodejs/eslint.config.js
@@ -13,39 +13,7 @@ module.exports = tseslint.config(
   ...tseslint.configs.recommended,
   {
     rules: {
-      "@typescript-eslint/naming-convention": [
-        "error",
-        // Make exceptions for AWS SDK properties
-        {
-          selector: "property",
-          format: null,
-          filter: {
-            regex: "(Bucket|Key|KeyId|Prefix)",
-            match: true,
-          },
-        },
-        // Defaults from https://typescript-eslint.io/rules/naming-convention/#options
-        {
-          selector: "default",
-          format: ["camelCase"],
-          leadingUnderscore: "allow",
-          trailingUnderscore: "allow",
-        },
-        {
-          selector: "import",
-          format: ["camelCase", "PascalCase"],
-        },
-        {
-          selector: "variable",
-          format: ["camelCase", "UPPER_CASE"],
-          leadingUnderscore: "allow",
-          trailingUnderscore: "allow",
-        },
-        {
-          selector: "typeLike",
-          format: ["PascalCase"],
-        },
-      ],
+      "@typescript-eslint/naming-convention": "error",
       "jsdoc/require-returns": "off",
       "jsdoc/require-param": "off",
       "jsdoc/require-jsdoc": [

--- a/nodejs/eslint.config.js
+++ b/nodejs/eslint.config.js
@@ -13,7 +13,39 @@ module.exports = tseslint.config(
   ...tseslint.configs.recommended,
   {
     rules: {
-      "@typescript-eslint/naming-convention": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        // Make exceptions for AWS SDK properties
+        {
+          selector: "property",
+          format: null,
+          filter: {
+            regex: "(Bucket|Key|KeyId|Prefix)",
+            match: true,
+          },
+        },
+        // Defaults from https://typescript-eslint.io/rules/naming-convention/#options
+        {
+          selector: "default",
+          format: ["camelCase"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allow",
+        },
+        {
+          selector: "import",
+          format: ["camelCase", "PascalCase"],
+        },
+        {
+          selector: "variable",
+          format: ["camelCase", "UPPER_CASE"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allow",
+        },
+        {
+          selector: "typeLike",
+          format: ["PascalCase"],
+        },
+      ],
       "jsdoc/require-returns": "off",
       "jsdoc/require-param": "off",
       "jsdoc/require-jsdoc": [

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -13,9 +13,31 @@
 // limitations under the License.
 
 import { fromTableToBuffer, makeArrowTable, makeEmptyTable } from "./arrow";
-import { Connection as LanceDbConnection } from "./native";
+import { ConnectionOptions, Connection as LanceDbConnection } from "./native";
 import { Table } from "./table";
 import { Table as ArrowTable, Schema } from "apache-arrow";
+
+/**
+ * Connect to a LanceDB instance at the given URI.
+ *
+ * Accpeted formats:
+ *
+ * - `/path/to/database` - local database
+ * - `s3://bucket/path/to/database` or `gs://bucket/path/to/database` - database on cloud storage
+ * - `db://host:port` - remote database (LanceDB cloud)
+ * @param {string} uri - The uri of the database. If the database uri starts
+ * with `db://` then it connects to a remote database.
+ * @see {@link ConnectionOptions} for more details on the URI format.
+ */
+export async function connect(
+  uri: string,
+  opts?: Partial<ConnectionOptions>,
+): Promise<Connection> {
+  opts = opts ?? {};
+  opts.storageOptions = cleanseStorageOptions(opts.storageOptions);
+  const nativeConn = await LanceDbConnection.new(uri, opts);
+  return new Connection(nativeConn);
+}
 
 export interface CreateTableOptions {
   /**
@@ -36,10 +58,10 @@ export interface CreateTableOptions {
 
   /**
    * Configuration for object storage.
-   * 
+   *
    * Options already set on the connection will be inherited by the table,
    * but can be overridden here.
-   * 
+   *
    * The available options are described at https://lancedb.github.io/lancedb/guides/storage/
    */
   storageOptions?: Record<string, string>;
@@ -48,7 +70,7 @@ export interface CreateTableOptions {
 export interface OpenTableOptions {
   /**
    * Configuration for object storage.
-   * 
+   *
    * Options already set on the connection will be inherited by the table,
    * but can be overridden here.
    *
@@ -137,7 +159,7 @@ export class Connection {
   ): Promise<Table> {
     const innerTable = await this.inner.openTable(
       name,
-      options?.storageOptions,
+      cleanseStorageOptions(options?.storageOptions),
     );
     return new Table(innerTable);
   }
@@ -171,7 +193,7 @@ export class Connection {
       name,
       buf,
       mode,
-      options?.storageOptions,
+      cleanseStorageOptions(options?.storageOptions),
     );
     return new Table(innerTable);
   }
@@ -199,7 +221,7 @@ export class Connection {
       name,
       buf,
       mode,
-      options?.storageOptions,
+      cleanseStorageOptions(options?.storageOptions),
     );
     return new Table(innerTable);
   }
@@ -211,4 +233,44 @@ export class Connection {
   async dropTable(name: string): Promise<void> {
     return this.inner.dropTable(name);
   }
+}
+
+/**
+ * Takes storage options and makes all the keys snake case.
+ */
+function cleanseStorageOptions(
+  options?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (options === undefined) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined) {
+      const newKey = camelToSnakeCase(key);
+      result[newKey] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Convert a string to snake case. It might already be snake case, in which case it is
+ * returned unchanged.
+ */
+function camelToSnakeCase(camel: string): string {
+  if (camel.includes("_")) {
+    // Assume if there is at least one underscore, it is already snake case
+    return camel;
+  }
+  if (camel.toLocaleUpperCase() === camel) {
+    // Assume if the string is all uppercase, it is already snake case
+    return camel;
+  }
+
+  let result = camel.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+  if (result.startsWith("_")) {
+    result = result.slice(1);
+  }
+  return result;
 }

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -33,6 +33,28 @@ export interface CreateTableOptions {
    * then no error will be raised.
    */
   existOk: boolean;
+
+  /**
+   * Configuration for object storage.
+   * 
+   * Options already set on the connection will be inherited by the table,
+   * but can be overridden here.
+   * 
+   * The available options are described at https://lancedb.github.io/lancedb/guides/storage/
+   */
+  storageOptions?: Record<string, string>;
+}
+
+export interface OpenTableOptions {
+  /**
+   * Configuration for object storage.
+   * 
+   * Options already set on the connection will be inherited by the table,
+   * but can be overridden here.
+   *
+   * The available options are described at https://lancedb.github.io/lancedb/guides/storage/
+   */
+  storageOptions?: Record<string, string>;
 }
 
 export interface TableNamesOptions {
@@ -109,8 +131,14 @@ export class Connection {
    * Open a table in the database.
    * @param {string} name - The name of the table
    */
-  async openTable(name: string): Promise<Table> {
-    const innerTable = await this.inner.openTable(name);
+  async openTable(
+    name: string,
+    options?: Partial<OpenTableOptions>,
+  ): Promise<Table> {
+    const innerTable = await this.inner.openTable(
+      name,
+      options?.storageOptions,
+    );
     return new Table(innerTable);
   }
 
@@ -139,7 +167,12 @@ export class Connection {
       table = makeArrowTable(data);
     }
     const buf = await fromTableToBuffer(table);
-    const innerTable = await this.inner.createTable(name, buf, mode);
+    const innerTable = await this.inner.createTable(
+      name,
+      buf,
+      mode,
+      options?.storageOptions,
+    );
     return new Table(innerTable);
   }
 
@@ -162,7 +195,12 @@ export class Connection {
 
     const table = makeEmptyTable(schema);
     const buf = await fromTableToBuffer(table);
-    const innerTable = await this.inner.createEmptyTable(name, buf, mode);
+    const innerTable = await this.inner.createEmptyTable(
+      name,
+      buf,
+      mode,
+      options?.storageOptions,
+    );
     return new Table(innerTable);
   }
 

--- a/nodejs/lancedb/index.ts
+++ b/nodejs/lancedb/index.ts
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Connection } from "./connection";
-import {
-  Connection as LanceDbConnection,
-  ConnectionOptions,
-} from "./native.js";
-
 export {
   WriteOptions,
   WriteMode,
@@ -32,6 +26,7 @@ export {
   VectorColumnOptions,
 } from "./arrow";
 export {
+  connect,
   Connection,
   CreateTableOptions,
   TableNamesOptions,
@@ -46,24 +41,3 @@ export {
 export { Index, IndexOptions, IvfPqOptions } from "./indices";
 export { Table, AddDataOptions, IndexConfig, UpdateOptions } from "./table";
 export * as embedding from "./embedding";
-
-/**
- * Connect to a LanceDB instance at the given URI.
- *
- * Accpeted formats:
- *
- * - `/path/to/database` - local database
- * - `s3://bucket/path/to/database` or `gs://bucket/path/to/database` - database on cloud storage
- * - `db://host:port` - remote database (LanceDB cloud)
- * @param {string} uri - The uri of the database. If the database uri starts
- * with `db://` then it connects to a remote database.
- * @see {@link ConnectionOptions} for more details on the URI format.
- */
-export async function connect(
-  uri: string,
-  opts?: Partial<ConnectionOptions>,
-): Promise<Connection> {
-  opts = opts ?? {};
-  const nativeConn = await LanceDbConnection.new(uri, opts);
-  return new Connection(nativeConn);
-}

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -22,6 +22,8 @@
         "openai": "^4.29.2"
       },
       "devDependencies": {
+        "@aws-sdk/client-kms": "^3.33.0",
+        "@aws-sdk/client-s3": "^3.33.0",
         "@napi-rs/cli": "^2.18.0",
         "@types/jest": "^29.1.2",
         "@types/tmp": "^0.2.6",
@@ -92,6 +94,906 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.549.0.tgz",
+      "integrity": "sha512-sbeG8ss4bL2sz0/ZBsvAw4o3rGI1z7RY9+rTn+8z7dKFjMPPZ+4DDr9GBtToCRktGla9sCNxcdhDeXZkdKBR9g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/credential-provider-node": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.550.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.550.0.tgz",
+      "integrity": "sha512-45jjDQI0Q37PIteWhywhlExxYaiUeOsTsbE62b+U/FOjYV8tirC8uBY9eHeHaP4IPVGHeQWvEYrFJHNU+qsQLQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "3.0.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/credential-provider-node": "3.549.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.535.0",
+        "@aws-sdk/middleware-expect-continue": "3.535.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-location-constraint": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/middleware-signing": "3.535.0",
+        "@aws-sdk/middleware-ssec": "3.537.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/signature-v4-multi-region": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@aws-sdk/xml-builder": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/eventstream-serde-browser": "^2.2.0",
+        "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+        "@smithy/eventstream-serde-node": "^2.2.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-blob-browser": "^2.2.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/hash-stream-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/md5-js": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-stream": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "@smithy/util-waiter": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.549.0.tgz",
+      "integrity": "sha512-lz+yflOAj5Q263FlCsKpNqttaCb2NPh8jC76gVCqCt7TPxRDBYVaqg0OZYluDaETIDNJi4DwN2Azcck7ilwuPw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.549.0.tgz",
+      "integrity": "sha512-FbB4A78ILAb8sM4TfBd+3CrQcfZIhe0gtVZNbaxpq5cJZh1K7oZ8vPfKw4do9JWkDUXPLsD9Bwz12f8/JpAb6Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.549.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.549.0.tgz",
+      "integrity": "sha512-63IreJ598Dzvpb+6sy81KfIX5iQxnrWSEtlyeCdC2GO6gmSQVwJzc9kr5pAC83lHmlZcm/Q3KZr3XBhRQqP0og==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.549.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.549.0.tgz",
+      "integrity": "sha512-jC61OxJn72r/BbuDRCcluiw05Xw9eVLG0CwxQpF3RocxfxyZqlrGYaGecZ8Wy+7g/3sqGRC/Ar5eUhU1YcLx7w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/core": "^1.4.1",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
+      "integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.535.0.tgz",
+      "integrity": "sha512-kdj1wCmOMZ29jSlUskRqN04S6fJ4dvt0Nq9Z32SA6wO7UG8ht6Ot9h/au/eTWJM3E1somZ7D771oK7dQt9b8yw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.549.0.tgz",
+      "integrity": "sha512-k6IIrluZjQpzui5Din8fW3bFFhHaJ64XrsfYx0Ks1mb7xan84dJxmYP3tdDDmLzUeJv5h95ag88taHfjY9rakA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.549.0",
+        "@aws-sdk/credential-provider-web-identity": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.549.0.tgz",
+      "integrity": "sha512-f3YgalsMuywEAVX4AUm9tojqrBdfpAac0+D320ePzas0Ntbp7ItYu9ceKIhgfzXO3No7P3QK0rCrOxL+ABTn8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-http": "3.535.0",
+        "@aws-sdk/credential-provider-ini": "3.549.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.549.0",
+        "@aws-sdk/credential-provider-web-identity": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.535.0.tgz",
+      "integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.549.0.tgz",
+      "integrity": "sha512-BGopRKHs7W8zkoH8qmSHrjudj263kXbhVkAUPxVUz0I28+CZNBgJC/RfVCbOpzmysIQEpwSqvOv1y0k+DQzIJQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.549.0",
+        "@aws-sdk/token-providers": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.549.0.tgz",
+      "integrity": "sha512-QzclVXPxuwSI7515l34sdvliVq5leroO8P7RQFKRgfyQKO45o1psghierwG3PgV6jlMiv78FIAGJBr/n4qZ7YA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.535.0.tgz",
+      "integrity": "sha512-7sijlfQsc4UO9Fsl11mU26Y5f9E7g6UoNg/iJUBpC5pgvvmdBRO5UEhbB/gnqvOEPsBXyhmfzbstebq23Qdz7A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.535.0.tgz",
+      "integrity": "sha512-hFKyqUBky0NWCVku8iZ9+PACehx0p6vuMw5YnZf8FVgHP0fode0b/NwQY6UY7oor/GftvRsAlRUAWGNFEGUpwA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.535.0.tgz",
+      "integrity": "sha512-rBIzldY9jjRATxICDX7t77aW6ctqmVDgnuAOgbVT5xgHftt4o7PGWKoMvl/45hYqoQgxVFnCBof9bxkqSBebVA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-crypto/crc32c": "3.0.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz",
+      "integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.535.0.tgz",
+      "integrity": "sha512-SxfS9wfidUZZ+WnlKRTCRn3h+XTsymXRXPJj8VV6hNRNeOwzNweoG3YhQbTowuuNfXf89m9v6meYkBBtkdacKw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.535.0.tgz",
+      "integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.535.0.tgz",
+      "integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.535.0.tgz",
+      "integrity": "sha512-/dLG/E3af6ohxkQ5GBHT8tZfuPIg6eItKxCXuulvYj0Tqgf3Mb+xTsvSkxQsJF06RS4sH7Qsg/PnB8ZfrJrXpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.535.0.tgz",
+      "integrity": "sha512-Rb4sfus1Gc5paRl9JJgymJGsb/i3gJKK/rTuFZICdd1PBBE5osIOHP5CpzWYBtc5LlyZE1a2QoxPMCyG+QUGPw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.537.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.537.0.tgz",
+      "integrity": "sha512-2QWMrbwd5eBy5KCYn9a15JEWBgrK2qFEKQN2lqb/6z0bhtevIOxIRfC99tzvRuPt6nixFQ+ynKuBjcfT4ZFrdQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.540.0.tgz",
+      "integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.535.0.tgz",
+      "integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.535.0.tgz",
+      "integrity": "sha512-tqCsEsEj8icW0SAh3NvyhRUq54Gz2pu4NM2tOSrFp7SO55heUUaRLSzYteNZCTOupH//AAaZvbN/UUTO/DrOog==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.549.0.tgz",
+      "integrity": "sha512-rJyeXkXknLukRFGuMQOgKnPBa+kLODJtOqEBf929SpQ96f1I6ytdndmWbB5B/OQN5Fu5DOOQUQqJypDQVl5ibQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.535.0.tgz",
+      "integrity": "sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.540.0.tgz",
+      "integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.535.0.tgz",
+      "integrity": "sha512-PHJ3SL6d2jpcgbqdgiPxkXpu7Drc2PYViwxSIqvvMKhDwzSB1W3mMvtpzwKM4IE7zLFodZo0GKjJ9AsoXndXhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.535.0.tgz",
+      "integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.535.0.tgz",
+      "integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.535.0.tgz",
+      "integrity": "sha512-VXAq/Jz8KIrU84+HqsOJhIKZqG0PNTdi6n6PFQ4xJf44ZQHD/5C7ouH4qCFX5XgZXcgbRIcMVVYGC6Jye0dRng==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1469,6 +2371,693 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.2.0.tgz",
+      "integrity": "sha512-3GJNvRwXBGdkDZZOGiziVYzDpn4j6zfyULHMDKAGIUo72yHALpE9CbhfQp/XcLNVoc1byfMpn6uW5H2BqPjgaQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.2.0.tgz",
+      "integrity": "sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+      "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+      "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+      "integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+      "integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.2.0.tgz",
+      "integrity": "sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^2.2.0",
+        "@smithy/chunked-blob-reader-native": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+      "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.2.0.tgz",
+      "integrity": "sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+      "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.2.0.tgz",
+      "integrity": "sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+      "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+      "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+      "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.2.1.tgz",
+      "integrity": "sha512-j5fHgL1iqKTsKJ1mTcw88p0RUcidDu95AWSeZTgiYJb+QcfwWU/UpBnaqiB59FNH5MiAZuSbOBnZlwzeeY2tIw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+      "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+      "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+      "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+      "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.2.0.tgz",
+      "integrity": "sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
@@ -2200,6 +3789,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2988,6 +4583,28 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.16.0",
@@ -5417,6 +7034,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5990,6 +7613,19 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -65,6 +65,7 @@
     "lint": "eslint lancedb && eslint __test__",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "npm run build && jest --verbose",
+    "integration": "INTEGRATION_TEST=1 npm run test",
     "universal": "napi universal",
     "version": "napi version"
   },

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -18,6 +18,8 @@
   },
   "license": "Apache 2.0",
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.33.0",
+    "@aws-sdk/client-kms": "^3.33.0",
     "@napi-rs/cli": "^2.18.0",
     "@types/jest": "^29.1.2",
     "@types/tmp": "^0.2.6",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -65,7 +65,7 @@
     "lint": "eslint lancedb && eslint __test__",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "npm run build && jest --verbose",
-    "integration": "INTEGRATION_TEST=1 npm run test",
+    "integration": "S3_TEST=1 npm run test",
     "universal": "napi universal",
     "version": "napi version"
   },

--- a/nodejs/src/connection.rs
+++ b/nodejs/src/connection.rs
@@ -66,6 +66,11 @@ impl Connection {
             builder =
                 builder.read_consistency_interval(std::time::Duration::from_secs_f64(interval));
         }
+        if let Some(storage_options) = options.storage_options {
+            for (key, value) in storage_options {
+                builder = builder.storage_option(key, value);
+            }
+        }
         Ok(Self::inner_new(
             builder
                 .execute()

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 
-use connection::Connection;
 use napi_derive::*;
 
 mod connection;
@@ -63,9 +62,4 @@ pub struct WriteOptions {
 #[napi(object)]
 pub struct OpenTableOptions {
     pub storage_options: Option<HashMap<String, String>>,
-}
-
-#[napi]
-pub async fn connect(uri: String, options: ConnectionOptions) -> napi::Result<Connection> {
-    Connection::new(uri, options).await
 }

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use connection::Connection;
 use napi_derive::*;
 
@@ -38,6 +40,10 @@ pub struct ConnectionOptions {
     /// Note: this consistency only applies to read operations. Write operations are
     /// always consistent.
     pub read_consistency_interval: Option<f64>,
+    /// (For LanceDB OSS only): configuration for object storage.
+    ///
+    /// The available options are described at https://lancedb.github.io/lancedb/guides/storage/
+    pub storage_options: Option<HashMap<String, String>>,
 }
 
 /// Write mode for writing a table.
@@ -52,6 +58,11 @@ pub enum WriteMode {
 #[napi(object)]
 pub struct WriteOptions {
     pub mode: Option<WriteMode>,
+}
+
+#[napi(object)]
+pub struct OpenTableOptions {
+    pub storage_options: Option<HashMap<String, String>>,
 }
 
 #[napi]

--- a/python/README.md
+++ b/python/README.md
@@ -41,7 +41,7 @@ To build the python package you can use maturin:
 ```bash
 # This will build the rust bindings and place them in the appropriate place
 # in your venv or conda environment
-matruin develop
+maturin develop
 ```
 
 To run the unit tests:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -48,6 +48,7 @@ repository = "https://github.com/lancedb/lancedb"
 [project.optional-dependencies]
 tests = [
     "aiohttp",
+    "boto3",
     "pandas>=1.4",
     "pytest",
     "pytest-mock",
@@ -97,4 +98,5 @@ addopts = "--strict-markers --ignore-glob=lancedb/embeddings/*.py"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "asyncio",
+    "integration"
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "lancedb"
 version = "0.6.7"
 dependencies = [
     "deprecation",
-    "pylance==0.10.9",
+    "pylance==0.10.10",
     "ratelimiter~=1.0",
     "retry>=0.9.2",
     "tqdm>=4.27.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -98,5 +98,5 @@ addopts = "--strict-markers --ignore-glob=lancedb/embeddings/*.py"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "asyncio",
-    "integration"
+    "s3_test"
 ]

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -15,7 +15,7 @@ import importlib.metadata
 import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 __version__ = importlib.metadata.version("lancedb")
 
@@ -118,6 +118,7 @@ async def connect_async(
     host_override: Optional[str] = None,
     read_consistency_interval: Optional[timedelta] = None,
     request_thread_pool: Optional[Union[int, ThreadPoolExecutor]] = None,
+    storage_options: Optional[Dict[str, str]] = None,
 ) -> AsyncConnection:
     """Connect to a LanceDB database.
 
@@ -144,6 +145,9 @@ async def connect_async(
         the last check, then the table will be checked for updates. Note: this
         consistency only applies to read operations. Write operations are
         always consistent.
+    storage_options: dict, optional
+        Additional options for the storage backend. See available options at
+        https://lancedb.github.io/lancedb/guides/storage/
 
     Examples
     --------
@@ -172,6 +176,7 @@ async def connect_async(
             region,
             host_override,
             read_consistency_interval_secs,
+            storage_options,
         )
     )
 

--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -19,10 +19,18 @@ class Connection(object):
         self, start_after: Optional[str], limit: Optional[int]
     ) -> list[str]: ...
     async def create_table(
-        self, name: str, mode: str, data: pa.RecordBatchReader
+        self,
+        name: str,
+        mode: str,
+        data: pa.RecordBatchReader,
+        storage_options: Optional[Dict[str, str]] = None,
     ) -> Table: ...
     async def create_empty_table(
-        self, name: str, mode: str, schema: pa.Schema
+        self,
+        name: str,
+        mode: str,
+        schema: pa.Schema,
+        storage_options: Optional[Dict[str, str]] = None,
     ) -> Table: ...
 
 class Table:

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -572,7 +572,9 @@ class AsyncConnection(object):
         fill_value: float
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         storage_options: dict, optional
-            Additional options for the storage backend. See available options at
+            Additional options for the storage backend. Options already set on the
+            connection will be inherited by the table, but can be overridden here.
+            See available options at
             https://lancedb.github.io/lancedb/guides/storage/
 
 
@@ -758,7 +760,9 @@ class AsyncConnection(object):
         name: str
             The name of the table.
         storage_options: dict, optional
-            Additional options for the storage backend. See available options at
+            Additional options for the storage backend. Options already set on the
+            connection will be inherited by the table, but can be overridden here.
+            See available options at
             https://lancedb.github.io/lancedb/guides/storage/
 
         Returns

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -18,7 +18,7 @@ import inspect
 import os
 from abc import abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Union
 
 import pyarrow as pa
 from overrides import EnforceOverrides, override
@@ -533,6 +533,7 @@ class AsyncConnection(object):
         exist_ok: Optional[bool] = None,
         on_bad_vectors: Optional[str] = None,
         fill_value: Optional[float] = None,
+        storage_options: Optional[Dict[str, str]] = None,
     ) -> AsyncTable:
         """Create an [AsyncTable][lancedb.table.AsyncTable] in the database.
 
@@ -570,6 +571,10 @@ class AsyncConnection(object):
             One of "error", "drop", "fill".
         fill_value: float
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
+        storage_options: dict, optional
+            Additional options for the storage backend. See available options at
+            https://lancedb.github.io/lancedb/guides/storage/
+
 
         Returns
         -------
@@ -729,30 +734,38 @@ class AsyncConnection(object):
             mode = "exist_ok"
 
         if data is None:
-            new_table = await self._inner.create_empty_table(name, mode, schema)
+            new_table = await self._inner.create_empty_table(
+                name, mode, schema, storage_options=storage_options
+            )
         else:
             data = data_to_reader(data, schema)
             new_table = await self._inner.create_table(
                 name,
                 mode,
                 data,
+                storage_options=storage_options,
             )
 
         return AsyncTable(new_table)
 
-    async def open_table(self, name: str) -> Table:
+    async def open_table(
+        self, name: str, storage_options: Optional[Dict[str, str]] = None
+    ) -> Table:
         """Open a Lance Table in the database.
 
         Parameters
         ----------
         name: str
             The name of the table.
+        storage_options: dict, optional
+            Additional options for the storage backend. See available options at
+            https://lancedb.github.io/lancedb/guides/storage/
 
         Returns
         -------
         A LanceTable object representing the table.
         """
-        table = await self._inner.open_table(name)
+        table = await self._inner.open_table(name, storage_options)
         return AsyncTable(table)
 
     async def drop_table(self, name: str):

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -1424,7 +1424,6 @@ class LanceTable(Table):
         on_bad_vectors: str = "error",
         fill_value: float = 0.0,
         embedding_functions: List[EmbeddingFunctionConfig] = None,
-        storage_options=None,
     ):
         """
         Create a new table.
@@ -1516,13 +1515,7 @@ class LanceTable(Table):
 
         empty = pa.Table.from_pylist([], schema=schema)
         try:
-            lance.write_dataset(
-                empty,
-                tbl._dataset_uri,
-                schema=schema,
-                mode=mode,
-                storage_options=storage_options,
-            )
+            lance.write_dataset(empty, tbl._dataset_uri, schema=schema, mode=mode)
         except OSError as err:
             if "Dataset already exists" in str(err) and exist_ok:
                 if tbl.schema != schema:

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -1424,6 +1424,7 @@ class LanceTable(Table):
         on_bad_vectors: str = "error",
         fill_value: float = 0.0,
         embedding_functions: List[EmbeddingFunctionConfig] = None,
+        storage_options=None,
     ):
         """
         Create a new table.
@@ -1515,7 +1516,13 @@ class LanceTable(Table):
 
         empty = pa.Table.from_pylist([], schema=schema)
         try:
-            lance.write_dataset(empty, tbl._dataset_uri, schema=schema, mode=mode)
+            lance.write_dataset(
+                empty,
+                tbl._dataset_uri,
+                schema=schema,
+                mode=mode,
+                storage_options=storage_options,
+            )
         except OSError as err:
             if "Dataset already exists" in str(err) and exist_ok:
                 if tbl.schema != schema:

--- a/python/python/tests/test_s3.py
+++ b/python/python/tests/test_s3.py
@@ -63,7 +63,7 @@ def delete_bucket(s3, bucket_name):
     s3.delete_bucket(Bucket=bucket_name)
 
 
-@pytest.mark.integration
+@pytest.mark.s3_test
 def test_s3_lifecycle(s3_bucket: str):
     storage_options = copy.copy(CONFIG)
 
@@ -113,7 +113,7 @@ def validate_objects_encrypted(bucket: str, path: str, kms_key: str):
         )
 
 
-@pytest.mark.integration
+@pytest.mark.s3_test
 def test_s3_sse(s3_bucket: str, kms_key: str):
     storage_options = copy.copy(CONFIG)
 

--- a/python/python/tests/test_s3.py
+++ b/python/python/tests/test_s3.py
@@ -1,0 +1,158 @@
+#  Copyright 2024 Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import asyncio
+import copy
+
+import pytest
+import pyarrow as pa
+import lancedb
+
+
+# These are all keys that are accepted by storage_options
+CONFIG = {
+    "allow_http": "true",
+    "aws_access_key_id": "ACCESSKEY",
+    "aws_secret_access_key": "SECRETKEY",
+    "aws_endpoint": "http://localhost:4566",
+    "aws_region": "us-east-1",
+}
+
+
+def get_boto3_client(*args, **kwargs):
+    import boto3
+
+    return boto3.client(
+        *args,
+        region_name=CONFIG["aws_region"],
+        aws_access_key_id=CONFIG["aws_access_key_id"],
+        aws_secret_access_key=CONFIG["aws_secret_access_key"],
+        **kwargs,
+    )
+
+
+@pytest.fixture(scope="module")
+def s3_bucket():
+    s3 = get_boto3_client("s3", endpoint_url=CONFIG["aws_endpoint"])
+    bucket_name = "lance-integtest"
+    # if bucket exists, delete it
+    try:
+        delete_bucket(s3, bucket_name)
+    except s3.exceptions.NoSuchBucket:
+        pass
+    s3.create_bucket(Bucket=bucket_name)
+    yield bucket_name
+
+    delete_bucket(s3, bucket_name)
+
+
+def delete_bucket(s3, bucket_name):
+    # Delete all objects first
+    for obj in s3.list_objects(Bucket=bucket_name).get("Contents", []):
+        s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
+    s3.delete_bucket(Bucket=bucket_name)
+
+
+@pytest.mark.integration
+def test_s3_lifecycle(s3_bucket: str):
+    storage_options = copy.copy(CONFIG)
+
+    uri = f"s3://{s3_bucket}/test_lifecycle"
+    data = pa.table({"x": [1, 2, 3]})
+
+    async def test():
+        db = await lancedb.connect_async(uri, storage_options=storage_options)
+
+        table = await db.create_table("test", schema=data.schema)
+        assert await table.count_rows() == 0
+
+        table = await db.create_table("test", data, mode="overwrite")
+        assert await table.count_rows() == 3
+
+        await table.add(data, mode="append")
+        assert await table.count_rows() == 6
+
+        table = await db.open_table("test")
+        assert await table.count_rows() == 6
+
+        await db.drop_table("test")
+
+        await db.drop_database()
+
+    asyncio.run(test())
+
+
+@pytest.fixture()
+def kms_key():
+    kms = get_boto3_client("kms", endpoint_url=CONFIG["aws_endpoint"])
+    key_id = kms.create_key()["KeyMetadata"]["KeyId"]
+    yield key_id
+    kms.schedule_key_deletion(KeyId=key_id, PendingWindowInDays=7)
+
+
+def validate_objects_encrypted(bucket: str, path: str, kms_key: str):
+    s3 = get_boto3_client("s3", endpoint_url=CONFIG["aws_endpoint"])
+    objects = s3.list_objects_v2(Bucket=bucket, Prefix=path)["Contents"]
+    for obj in objects:
+        info = s3.head_object(Bucket=bucket, Key=obj["Key"])
+        assert info["ServerSideEncryption"] == "aws:kms", (
+            "object %s not encrypted" % obj["Key"]
+        )
+        assert info["SSEKMSKeyId"].endswith(kms_key), (
+            "object %s not encrypted with correct key" % obj["Key"]
+        )
+
+
+@pytest.mark.integration
+def test_s3_sse(s3_bucket: str, kms_key: str):
+    storage_options = copy.copy(CONFIG)
+
+    uri = f"s3://{s3_bucket}/test_lifecycle"
+    data = pa.table({"x": [1, 2, 3]})
+
+    async def test():
+        # Create a table with SSE
+        db = await lancedb.connect_async(uri, storage_options=storage_options)
+
+        table = await db.create_table(
+            "table1",
+            schema=data.schema,
+            storage_options={
+                "aws_server_side_encryption": "aws:kms",
+                "aws_sse_kms_key_id": kms_key,
+            },
+        )
+        await table.add(data)
+        await table.update({"x": "1"})
+
+        path = "test_lifecycle/table1.lance"
+        validate_objects_encrypted(s3_bucket, path, kms_key)
+
+        # Test we can set encryption at connection level too.
+        db = await lancedb.connect_async(
+            uri,
+            storage_options=dict(
+                aws_server_side_encryption="aws:kms",
+                aws_sse_kms_key_id=kms_key,
+                **storage_options,
+            ),
+        )
+
+        table = await db.create_table("table2", schema=data.schema)
+        await table.add(data)
+        await table.update({"x": "1"})
+
+        path = "test_lifecycle/table2.lance"
+        validate_objects_encrypted(s3_bucket, path, kms_key)
+
+    asyncio.run(test())

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -85,7 +85,6 @@ impl Connection {
         future_into_py(self_.py(), async move { op.execute().await.infer_error() })
     }
 
-    #[pyo3(signature = (name, mode, data, storage_options = None))]
     pub fn create_table<'a>(
         self_: PyRef<'a, Self>,
         name: String,
@@ -110,7 +109,6 @@ impl Connection {
         })
     }
 
-    #[pyo3(signature = (name, mode, schema, storage_options = None))]
     pub fn create_empty_table<'a>(
         self_: PyRef<'a, Self>,
         name: String,

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use arrow::{datatypes::Schema, ffi_stream::ArrowArrayStreamReader, pyarrow::FromPyArrow};
 use lancedb::connection::{Connection as LanceConnection, CreateTableMode};
@@ -85,33 +85,38 @@ impl Connection {
         future_into_py(self_.py(), async move { op.execute().await.infer_error() })
     }
 
+    #[pyo3(signature = (name, mode, data, storage_options = None))]
     pub fn create_table<'a>(
         self_: PyRef<'a, Self>,
         name: String,
         mode: &str,
         data: &PyAny,
+        storage_options: Option<HashMap<String, String>>,
     ) -> PyResult<&'a PyAny> {
         let inner = self_.get_inner()?.clone();
 
         let mode = Self::parse_create_mode_str(mode)?;
 
         let batches = ArrowArrayStreamReader::from_pyarrow(data)?;
+        let mut builder = inner.create_table(name, batches).mode(mode);
+
+        if let Some(storage_options) = storage_options {
+            builder = builder.storage_options(storage_options);
+        }
+
         future_into_py(self_.py(), async move {
-            let table = inner
-                .create_table(name, batches)
-                .mode(mode)
-                .execute()
-                .await
-                .infer_error()?;
+            let table = builder.execute().await.infer_error()?;
             Ok(Table::new(table))
         })
     }
 
+    #[pyo3(signature = (name, mode, schema, storage_options = None))]
     pub fn create_empty_table<'a>(
         self_: PyRef<'a, Self>,
         name: String,
         mode: &str,
         schema: &PyAny,
+        storage_options: Option<HashMap<String, String>>,
     ) -> PyResult<&'a PyAny> {
         let inner = self_.get_inner()?.clone();
 
@@ -119,21 +124,31 @@ impl Connection {
 
         let schema = Schema::from_pyarrow(schema)?;
 
+        let mut builder = inner.create_empty_table(name, Arc::new(schema)).mode(mode);
+
+        if let Some(storage_options) = storage_options {
+            builder = builder.storage_options(storage_options);
+        }
+
         future_into_py(self_.py(), async move {
-            let table = inner
-                .create_empty_table(name, Arc::new(schema))
-                .mode(mode)
-                .execute()
-                .await
-                .infer_error()?;
+            let table = builder.execute().await.infer_error()?;
             Ok(Table::new(table))
         })
     }
 
-    pub fn open_table(self_: PyRef<'_, Self>, name: String) -> PyResult<&PyAny> {
+    #[pyo3(signature = (name, storage_options = None))]
+    pub fn open_table(
+        self_: PyRef<'_, Self>,
+        name: String,
+        storage_options: Option<HashMap<String, String>>,
+    ) -> PyResult<&PyAny> {
         let inner = self_.get_inner()?.clone();
+        let mut builder = inner.open_table(name);
+        if let Some(storage_options) = storage_options {
+            builder = builder.storage_options(storage_options);
+        }
         future_into_py(self_.py(), async move {
-            let table = inner.open_table(&name).execute().await.infer_error()?;
+            let table = builder.execute().await.infer_error()?;
             Ok(Table::new(table))
         })
     }
@@ -162,6 +177,7 @@ pub fn connect(
     region: Option<String>,
     host_override: Option<String>,
     read_consistency_interval: Option<f64>,
+    storage_options: Option<HashMap<String, String>>,
 ) -> PyResult<&PyAny> {
     future_into_py(py, async move {
         let mut builder = lancedb::connect(&uri);
@@ -177,6 +193,9 @@ pub fn connect(
         if let Some(read_consistency_interval) = read_consistency_interval {
             let read_consistency_interval = Duration::from_secs_f64(read_consistency_interval);
             builder = builder.read_consistency_interval(read_consistency_interval);
+        }
+        if let Some(storage_options) = storage_options {
+            builder = builder.storage_options(storage_options);
         }
         Ok(Connection::new(builder.execute().await.infer_error()?))
     })

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3.5.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 walkdir = "2"
-# For integration tests (dev deps aren't allowed to be optional atm)
+# For s3 integration tests (dev deps aren't allowed to be optional atm)
 aws-sdk-s3 = { version = "1.0" }
 aws-sdk-kms = { version = "1.0" }
 aws-config = { version = "1.0" }
@@ -55,4 +55,4 @@ aws-config = { version = "1.0" }
 default = ["remote"]
 remote = ["dep:reqwest"]
 fp16kernels = ["lance-linalg/fp16kernels"]
-integration-test = []
+s3-test = []

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -46,8 +46,13 @@ tempfile = "3.5.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 walkdir = "2"
+# For integration tests (dev deps aren't allowed to be optional atm)
+aws-sdk-s3 = { version = "1.0" }
+aws-sdk-kms = { version = "1.0" }
+aws-config = { version = "1.0" }
 
 [features]
 default = ["remote"]
 remote = ["dep:reqwest"]
 fp16kernels = ["lance-linalg/fp16kernels"]
+integration-test = []

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -22,9 +22,7 @@ use arrow_array::{RecordBatchIterator, RecordBatchReader};
 use arrow_schema::SchemaRef;
 use lance::dataset::{ReadParams, WriteMode};
 use lance::io::{ObjectStore, ObjectStoreParams, WrappingObjectStore};
-use object_store::{
-    aws::AwsCredential, local::LocalFileSystem, CredentialProvider, StaticCredentialProvider,
-};
+use object_store::{aws::AwsCredential, local::LocalFileSystem};
 use snafu::prelude::*;
 
 use crate::arrow::IntoArrow;
@@ -522,6 +520,9 @@ struct Database {
     pub(crate) store_wrapper: Option<Arc<dyn WrappingObjectStore>>,
 
     read_consistency_interval: Option<std::time::Duration>,
+
+    // Storage options to be inherited by tables created from this connection
+    storage_options: HashMap<String, String>,
 }
 
 impl std::fmt::Display for Database {
@@ -604,20 +605,20 @@ impl Database {
                 };
 
                 let plain_uri = url.to_string();
-                let os_params: ObjectStoreParams = if let Some(aws_creds) = &options.aws_creds {
-                    let credential_provider: Arc<
-                        dyn CredentialProvider<Credential = AwsCredential>,
-                    > = Arc::new(StaticCredentialProvider::new(AwsCredential {
-                        key_id: aws_creds.key_id.clone(),
-                        secret_key: aws_creds.secret_key.clone(),
-                        token: aws_creds.token.clone(),
-                    }));
-                    ObjectStoreParams::with_aws_credentials(
-                        Some(credential_provider),
-                        options.region.clone(),
-                    )
-                } else {
-                    ObjectStoreParams::default()
+
+                let mut storage_options = options.storage_options.clone();
+                // TODO: remove this when we remove aws_creds from the builder
+                if let Some(aws_creds) = &options.aws_creds {
+                    storage_options.insert("aws_access_key_id".into(), aws_creds.key_id.clone());
+                    storage_options
+                        .insert("aws_secret_access_key".into(), aws_creds.secret_key.clone());
+                    if let Some(token) = &aws_creds.token {
+                        storage_options.insert("aws_session_token".into(), token.clone());
+                    }
+                }
+                let os_params = ObjectStoreParams {
+                    storage_options: Some(storage_options.clone()),
+                    ..Default::default()
                 };
                 let (object_store, base_path) =
                     ObjectStore::from_uri_and_params(&plain_uri, &os_params).await?;
@@ -641,6 +642,7 @@ impl Database {
                     object_store,
                     store_wrapper: write_store_wrapper,
                     read_consistency_interval: options.read_consistency_interval,
+                    storage_options,
                 })
             }
             Err(_) => Self::open_path(uri, options.read_consistency_interval).await,
@@ -662,6 +664,7 @@ impl Database {
             object_store,
             store_wrapper: None,
             read_consistency_interval,
+            storage_options: HashMap::new(),
         })
     }
 
@@ -734,10 +737,25 @@ impl ConnectionInternal for Database {
 
     async fn do_create_table(
         &self,
-        options: CreateTableBuilder<false, NoData>,
+        mut options: CreateTableBuilder<false, NoData>,
         data: Box<dyn RecordBatchReader + Send>,
     ) -> Result<Table> {
         let table_uri = self.table_uri(&options.name)?;
+
+        // Inherit storage options from the connection
+        let storage_options = options
+            .write_options
+            .lance_write_params
+            .get_or_insert_with(Default::default)
+            .store_params
+            .get_or_insert_with(Default::default)
+            .storage_options
+            .get_or_insert_with(Default::default);
+        for (key, value) in self.storage_options.iter() {
+            if !storage_options.contains_key(key) {
+                storage_options.insert(key.clone(), value.clone());
+            }
+        }
 
         let mut write_params = options.write_options.lance_write_params.unwrap_or_default();
         if matches!(&options.mode, CreateTableMode::Overwrite) {

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -154,6 +154,12 @@ impl<T: IntoArrow> CreateTableBuilder<true, T> {
         self
     }
 
+    /// Set an option for the storage layer.
+    /// 
+    /// Options already set on the connection will be inherited by the table,
+    /// but can be overridden here.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let store_options = self
             .write_options
@@ -167,6 +173,12 @@ impl<T: IntoArrow> CreateTableBuilder<true, T> {
         self
     }
 
+    /// Set multiple options for the storage layer.
+    /// 
+    /// Options already set on the connection will be inherited by the table,
+    /// but can be overridden here.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
@@ -231,6 +243,12 @@ impl CreateTableBuilder<false, NoData> {
         self
     }
 
+    /// Set an option for the storage layer.
+    /// 
+    /// Options already set on the connection will be inherited by the table,
+    /// but can be overridden here.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let store_options = self
             .write_options
@@ -244,6 +262,12 @@ impl CreateTableBuilder<false, NoData> {
         self
     }
 
+    /// Set multiple options for the storage layer.
+    /// 
+    /// Options already set on the connection will be inherited by the table,
+    /// but can be overridden here.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
@@ -321,6 +345,12 @@ impl OpenTableBuilder {
         self
     }
 
+    /// Set an option for the storage layer.
+    /// 
+    /// Options already set on the connection will be inherited by the table,
+    /// but can be overridden here.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let storage_options = self
             .lance_read_params
@@ -333,6 +363,12 @@ impl OpenTableBuilder {
         self
     }
 
+    /// Set multiple options for the storage layer.
+    /// 
+    /// Options already set on the connection will be inherited by the table,
+    /// but can be overridden here.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
@@ -541,14 +577,17 @@ impl ConnectBuilder {
         self
     }
 
-    /// Set a storage option for object storage.
-    // TODO: provide a link to available keys
+    /// Set an option for the storage layer.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.storage_options.insert(key.into(), value.into());
         self
     }
 
-    /// Set multiple storage options
+    /// Set multiple options for the storage layer.
+    /// 
+    /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -990,7 +990,8 @@ impl ConnectionInternal for Database {
     }
 
     async fn drop_db(&self) -> Result<()> {
-        todo!()
+        self.object_store.remove_dir_all(self.base_path.clone()).await?;
+        Ok(())
     }
 }
 

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -155,10 +155,10 @@ impl<T: IntoArrow> CreateTableBuilder<true, T> {
     }
 
     /// Set an option for the storage layer.
-    /// 
+    ///
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let store_options = self
@@ -174,10 +174,10 @@ impl<T: IntoArrow> CreateTableBuilder<true, T> {
     }
 
     /// Set multiple options for the storage layer.
-    /// 
+    ///
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,
@@ -244,10 +244,10 @@ impl CreateTableBuilder<false, NoData> {
     }
 
     /// Set an option for the storage layer.
-    /// 
+    ///
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let store_options = self
@@ -263,10 +263,10 @@ impl CreateTableBuilder<false, NoData> {
     }
 
     /// Set multiple options for the storage layer.
-    /// 
+    ///
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,
@@ -346,10 +346,10 @@ impl OpenTableBuilder {
     }
 
     /// Set an option for the storage layer.
-    /// 
+    ///
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let storage_options = self
@@ -364,10 +364,10 @@ impl OpenTableBuilder {
     }
 
     /// Set multiple options for the storage layer.
-    /// 
+    ///
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,
@@ -578,7 +578,7 @@ impl ConnectBuilder {
     }
 
     /// Set an option for the storage layer.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.storage_options.insert(key.into(), value.into());
@@ -586,7 +586,7 @@ impl ConnectBuilder {
     }
 
     /// Set multiple options for the storage layer.
-    /// 
+    ///
     /// See available options at <https://lancedb.github.io/lancedb/guides/storage/>
     pub fn storage_options(
         mut self,

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -990,7 +990,9 @@ impl ConnectionInternal for Database {
     }
 
     async fn drop_db(&self) -> Result<()> {
-        self.object_store.remove_dir_all(self.base_path.clone()).await?;
+        self.object_store
+            .remove_dir_all(self.base_path.clone())
+            .await?;
         Ok(())
     }
 }

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -564,7 +564,7 @@ impl ConnectBuilder {
     }
 
     /// [`AwsCredential`] to use when connecting to S3.
-    #[deprecated(note = "Pass through storage params instead")]
+    #[deprecated(note = "Pass through storage_options instead")]
     pub fn aws_creds(mut self, aws_creds: AwsCredential) -> Self {
         self.storage_options
             .insert("aws_access_key_id".into(), aws_creds.key_id.clone());

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -14,6 +14,7 @@
 
 //! LanceDB Table APIs
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -757,6 +758,8 @@ pub struct NativeTable {
     // the object store wrapper to use on write path
     store_wrapper: Option<Arc<dyn WrappingObjectStore>>,
 
+    storage_options: HashMap<String, String>,
+
     // This comes from the connection options. We store here so we can pass down
     // to the dataset when we recreate it (for example, in checkout_latest).
     read_consistency_interval: Option<std::time::Duration>,
@@ -822,6 +825,13 @@ impl NativeTable {
             None => params,
         };
 
+        let storage_options = params
+            .store_options
+            .clone()
+            .unwrap_or_default()
+            .storage_options
+            .unwrap_or_default();
+
         let dataset = DatasetBuilder::from_uri(uri)
             .with_read_params(params)
             .load()
@@ -840,6 +850,7 @@ impl NativeTable {
             uri: uri.to_string(),
             dataset,
             store_wrapper: write_store_wrapper,
+            storage_options: storage_options,
             read_consistency_interval,
         })
     }
@@ -908,6 +919,13 @@ impl NativeTable {
             None => params,
         };
 
+        let storage_options = params
+            .store_params
+            .clone()
+            .unwrap_or_default()
+            .storage_options
+            .unwrap_or_default();
+
         let dataset = Dataset::write(batches, uri, Some(params))
             .await
             .map_err(|e| match e {
@@ -921,6 +939,7 @@ impl NativeTable {
             uri: uri.to_string(),
             dataset: DatasetConsistencyWrapper::new_latest(dataset, read_consistency_interval),
             store_wrapper: write_store_wrapper,
+            storage_options,
             read_consistency_interval,
         })
     }
@@ -1312,13 +1331,25 @@ impl TableInternal for NativeTable {
         add: AddDataBuilder<NoData>,
         data: Box<dyn RecordBatchReader + Send>,
     ) -> Result<()> {
-        let lance_params = add.write_options.lance_write_params.unwrap_or(WriteParams {
+        let mut lance_params = add.write_options.lance_write_params.unwrap_or(WriteParams {
             mode: match add.mode {
                 AddDataMode::Append => WriteMode::Append,
                 AddDataMode::Overwrite => WriteMode::Overwrite,
             },
             ..Default::default()
         });
+
+        // Bring storage options from table
+        let storage_options = lance_params
+            .store_params
+            .get_or_insert(Default::default())
+            .storage_options
+            .get_or_insert(Default::default());
+        for (key, value) in self.storage_options.iter() {
+            if !storage_options.contains_key(key) {
+                storage_options.insert(key.clone(), value.clone());
+            }
+        }
 
         // patch the params if we have a write store wrapper
         let lance_params = match self.store_wrapper.clone() {

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -850,7 +850,7 @@ impl NativeTable {
             uri: uri.to_string(),
             dataset,
             store_wrapper: write_store_wrapper,
-            storage_options: storage_options,
+            storage_options,
             read_consistency_interval,
         })
     }

--- a/rust/lancedb/tests/object_store_test.rs
+++ b/rust/lancedb/tests/object_store_test.rs
@@ -1,0 +1,285 @@
+// Copyright 2023 LanceDB Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![cfg(feature = "integration-test")]
+use std::sync::Arc;
+
+use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+
+use aws_config::{BehaviorVersion, ConfigLoader, Region, SdkConfig};
+use aws_sdk_s3::{config::Credentials, types::ServerSideEncryption, Client as S3Client};
+use lancedb::Result;
+
+const CONFIG: &[(&str, &str)] = &[
+    ("access_key_id", "ACCESS_KEY"),
+    ("secret_access_key", "SECRET_KEY"),
+    ("endpoint", "http://127.0.0.1:4566"),
+    ("allow_http", "true"),
+];
+
+async fn aws_config() -> SdkConfig {
+    let credentials = Credentials::new(CONFIG[0].1, CONFIG[1].1, None, None, "static");
+    let config = ConfigLoader::default()
+        .credentials_provider(credentials)
+        .endpoint_url(CONFIG[2].1)
+        .behavior_version(BehaviorVersion::latest())
+        .region(Region::new("us-east-1"))
+        .load()
+        .await;
+
+    config
+}
+
+struct S3Bucket(String);
+
+impl S3Bucket {
+    async fn new(bucket: &str) -> Self {
+        let config = aws_config().await;
+        let client = S3Client::new(&config);
+
+        // In case it wasn't deleted earlier
+        Self::delete_bucket(client.clone(), bucket).await;
+
+        client.create_bucket().bucket(bucket).send().await.unwrap();
+
+        Self(bucket.to_string())
+    }
+
+    async fn delete_bucket(client: S3Client, bucket: &str) {
+        // Before we delete the bucket, we need to delete all objects in it
+        let res = client
+            .list_objects_v2()
+            .bucket(bucket)
+            .send()
+            .await
+            .map_err(|err| err.into_service_error());
+        match res {
+            Err(e) if e.is_no_such_bucket() => return,
+            Err(e) => panic!("Failed to list objects in bucket: {}", e),
+            _ => {}
+        }
+        let objects = res.unwrap().contents.unwrap_or_default();
+        for object in objects {
+            client
+                .delete_object()
+                .bucket(bucket)
+                .key(object.key.unwrap())
+                .send()
+                .await
+                .unwrap();
+        }
+        client.delete_bucket().bucket(bucket).send().await.unwrap();
+    }
+}
+
+impl Drop for S3Bucket {
+    fn drop(&mut self) {
+        let bucket_name = self.0.clone();
+        tokio::task::spawn(async move {
+            let config = aws_config().await;
+            let client = S3Client::new(&config);
+            Self::delete_bucket(client, &bucket_name).await;
+        });
+    }
+}
+
+fn test_data() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, false),
+    ]));
+    RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        ],
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_minio_lifecycle() -> Result<()> {
+    // test create, update, drop, list on localstack minio
+    let bucket = S3Bucket::new("test-bucket").await;
+    let uri = format!("s3://{}", bucket.0);
+
+    let db = lancedb::connect(&uri)
+        .storage_options(CONFIG.iter().cloned())
+        .execute()
+        .await?;
+
+    let data = test_data();
+    let data = RecordBatchIterator::new(vec![Ok(data.clone())], data.schema());
+
+    let table = db.create_table("test_table", data).execute().await?;
+
+    let row_count = table.count_rows(None).await?;
+    assert_eq!(row_count, 3);
+
+    let table_names = db.table_names().execute().await?;
+    assert_eq!(table_names, vec!["test_table"]);
+
+    db.drop_table("test_table").await?;
+
+    Ok(())
+}
+
+struct KMSKey(String);
+
+impl KMSKey {
+    async fn new() -> Self {
+        let config = aws_config().await;
+        let client = aws_sdk_kms::Client::new(&config);
+        let key = client
+            .create_key()
+            .description("test key")
+            .send()
+            .await
+            .unwrap()
+            .key_metadata
+            .unwrap()
+            .key_id;
+        Self(key)
+    }
+}
+
+impl Drop for KMSKey {
+    fn drop(&mut self) {
+        let key_id = self.0.clone();
+        tokio::task::spawn(async move {
+            let config = aws_config().await;
+            let client = aws_sdk_kms::Client::new(&config);
+            client
+                .schedule_key_deletion()
+                .key_id(&key_id)
+                .send()
+                .await
+                .unwrap();
+        });
+    }
+}
+
+async fn validate_objects_encrypted(bucket: &str, path: &str, kms_key_id: &str) {
+    // Get S3 client
+    let config = aws_config().await;
+    let client = S3Client::new(&config);
+
+    // list the objects are the path
+    let objects = client
+        .list_objects_v2()
+        .bucket(bucket)
+        .prefix(path)
+        .send()
+        .await
+        .unwrap()
+        .contents
+        .unwrap();
+
+    let mut errors = vec![];
+    let mut correctly_encrypted = vec![];
+
+    // For each object, call head
+    for object in &objects {
+        let head = client
+            .head_object()
+            .bucket(bucket)
+            .key(object.key().unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        // Verify the object is encrypted
+        if !(head.server_side_encryption() == Some(&ServerSideEncryption::AwsKms)) {
+            errors.push(format!("Object {} is not encrypted", object.key().unwrap()));
+            continue;
+        }
+        if !(head
+            .ssekms_key_id()
+            .map(|arn| arn.ends_with(kms_key_id))
+            .unwrap_or(false))
+        {
+            errors.push(format!(
+                "Object {} has wrong key id: {:?}, vs expected: {}",
+                object.key().unwrap(),
+                head.ssekms_key_id(),
+                kms_key_id
+            ));
+            continue;
+        }
+        correctly_encrypted.push(object.key().unwrap().to_string());
+    }
+
+    if !errors.is_empty() {
+        panic!(
+            "{} of {} correctly encrypted: {:?}\n{} of {} not correct: {:?}",
+            correctly_encrypted.len(),
+            objects.len(),
+            correctly_encrypted,
+            errors.len(),
+            objects.len(),
+            errors
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_encryption() -> Result<()> {
+    // test encryption on localstack minio
+    let bucket = S3Bucket::new("test-encryption").await;
+    let key = KMSKey::new().await;
+
+    let uri = format!("s3://{}", bucket.0);
+    let db = lancedb::connect(&uri)
+        .storage_options(CONFIG.iter().cloned())
+        .execute()
+        .await?;
+
+    // Create a table with encryption
+    let data = test_data();
+    let data = RecordBatchIterator::new(vec![Ok(data.clone())], data.schema());
+
+    let mut builder = db.create_table("test_table", data);
+    for (key, value) in CONFIG {
+        builder = builder.storage_option(*key, *value);
+    }
+    let table = builder
+        .storage_option("aws_server_side_encryption", "aws:kms")
+        .storage_option("aws_sse_kms_key_id", &key.0)
+        .execute()
+        .await?;
+    validate_objects_encrypted(&bucket.0, "test_table", &key.0).await;
+
+    table.delete("a = 1").await?;
+    validate_objects_encrypted(&bucket.0, "test_table", &key.0).await;
+
+    // Create a connection with encryption
+    let db = lancedb::connect(&uri)
+        .storage_options(CONFIG.iter().cloned())
+        .storage_option("aws_server_side_encryption", "aws:kms")
+        .storage_option("aws_sse_kms_key_id", &key.0)
+        .execute()
+        .await?;
+
+    // open the table
+    let table = db.open_table("test_table").execute().await?;
+
+    // Append to it
+    let data = test_data();
+    let data = RecordBatchIterator::new(vec![Ok(data.clone())], data.schema());
+    table.add(data).execute().await?;
+    validate_objects_encrypted(&bucket.0, "test_table", &key.0).await;
+
+    Ok(())
+}

--- a/rust/lancedb/tests/object_store_test.rs
+++ b/rust/lancedb/tests/object_store_test.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![cfg(feature = "integration-test")]
+#![cfg(feature = "s3-test")]
 use std::sync::Arc;
 
 use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};

--- a/rust/lancedb/tests/object_store_test.rs
+++ b/rust/lancedb/tests/object_store_test.rs
@@ -30,15 +30,13 @@ const CONFIG: &[(&str, &str)] = &[
 
 async fn aws_config() -> SdkConfig {
     let credentials = Credentials::new(CONFIG[0].1, CONFIG[1].1, None, None, "static");
-    let config = ConfigLoader::default()
+    ConfigLoader::default()
         .credentials_provider(credentials)
         .endpoint_url(CONFIG[2].1)
         .behavior_version(BehaviorVersion::latest())
         .region(Region::new("us-east-1"))
         .load()
-        .await;
-
-    config
+        .await
 }
 
 struct S3Bucket(String);
@@ -210,7 +208,7 @@ async fn validate_objects_encrypted(bucket: &str, path: &str, kms_key_id: &str) 
             .unwrap();
 
         // Verify the object is encrypted
-        if !(head.server_side_encryption() == Some(&ServerSideEncryption::AwsKms)) {
+        if head.server_side_encryption() != Some(&ServerSideEncryption::AwsKms) {
             errors.push(format!("Object {} is not encrypted", object.key().unwrap()));
             continue;
         }


### PR DESCRIPTION
Exposes `storage_options` in LanceDB. This is provided for Python async, Node `lancedb`, and Node `vectordb` (and Rust of course). Python synchronous is omitted because it's not compatible with the PyArrow filesystems we use there currently. In the future, we will move the sync API to wrap the async one, and then it will get support for `storage_options`.

1. Fixes #1168
2. Closes #1165
3. Closes #1082
4. Closes #439
5. Closes #897
6. Closes #642
7. Closes #281
8. Closes #114
9. Closes #990
10. Deprecating `awsCredentials` and `awsRegion`. Users are encouraged to use `storageOptions` instead.
