### PR TITLE
BREAKING CHANGE: Check if remote table exists when opening (with caching)

### DIFF
--- a/node/src/remote/client.ts
+++ b/node/src/remote/client.ts
@@ -115,7 +115,7 @@ async function decodeErrorData(
       return JSON.stringify(errorData)
     }
 
-      return errorData
+    return errorData
   }
 }
 

--- a/node/src/remote/client.ts
+++ b/node/src/remote/client.ts
@@ -111,6 +111,10 @@ async function decodeErrorData(
   if (responseType === 'arraybuffer') {
       return new TextDecoder().decode(errorData)
   } else {
+    if (typeof errorData === 'object') {
+      return JSON.stringify(errorData)
+    }
+
       return errorData
   }
 }

--- a/node/src/test/test.ts
+++ b/node/src/test/test.ts
@@ -42,6 +42,7 @@ import {
   Float16,
   Int64
 } from 'apache-arrow'
+import type { RemoteRequest, RemoteResponse } from '../middleware'
 
 const expect = chai.expect
 const assert = chai.assert
@@ -913,7 +914,22 @@ describe('Remote LanceDB client', function () {
       }
 
       // Search
-      const table = await con.openTable('vectors')
+      const table = await con.withMiddleware(new (class {
+        async onRemoteRequest(req: RemoteRequest, next: (req: RemoteRequest) => Promise<RemoteResponse>) {
+          // intercept call to check if the table exists and make the call succeed
+          if (req.uri.endsWith('/describe/')) {
+            return {
+              status: 200,
+              statusText: 'OK',
+              headers: new Map(),
+              body: async () => ({})
+            }
+          }
+
+          return await next(req)
+        }
+      })()).openTable('vectors')
+
       try {
         await table.search([0.1, 0.3]).execute()
       } catch (err) {

--- a/node/src/util.ts
+++ b/node/src/util.ts
@@ -42,3 +42,36 @@ export function toSQL (value: Literal): string {
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   throw new Error(`Unsupported value type: ${typeof value} value: (${value})`)
 }
+
+export class TTLCache {
+  private readonly cache: Map<string, { value: any, expires: number }>
+
+  /**
+   * @param ttl Time to live in milliseconds
+   */
+  constructor (private readonly ttl: number) {
+    this.cache = new Map()
+  }
+
+  get (key: string): any | undefined {
+    const entry = this.cache.get(key)
+    if (entry === undefined) {
+      return undefined
+    }
+
+    if (entry.expires < Date.now()) {
+      this.cache.delete(key)
+      return undefined
+    }
+
+    return entry.value
+  }
+
+  set (key: string, value: any): void {
+    this.cache.set(key, { value, expires: Date.now() + this.ttl })
+  }
+
+  delete (key: string): void {
+    this.cache.delete(key)
+  }
+}

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -18,6 +18,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Iterable, List, Optional, Union
 from urllib.parse import urlparse
 
+from cachetools import TTLCache
 import pyarrow as pa
 from overrides import override
 
@@ -30,6 +31,7 @@ from ..util import validate_table_name
 from .arrow import to_ipc_binary
 from .client import ARROW_STREAM_CONTENT_TYPE, RestfulLanceDBClient
 from .errors import LanceDBClientError
+
 
 
 class RemoteDBConnection(DBConnection):
@@ -60,6 +62,7 @@ class RemoteDBConnection(DBConnection):
             read_timeout=read_timeout,
         )
         self._request_thread_pool = request_thread_pool
+        self._table_cache = TTLCache(maxsize=10000, ttl=300)
 
     def __repr__(self) -> str:
         return f"RemoteConnect(name={self.db_name})"
@@ -89,7 +92,17 @@ class RemoteDBConnection(DBConnection):
             else:
                 break
             for item in result:
+                self._table_cache[item] = True
                 yield item
+
+    def _table_exists(self, name: str) -> bool:
+        # try:
+        
+        return True
+        # except LanceDBClientError as err:
+        #     if str(err).startswith("Not found"):
+        #         return False
+        #     raise err
 
     @override
     def open_table(self, name: str) -> Table:
@@ -109,18 +122,11 @@ class RemoteDBConnection(DBConnection):
         self._client.mount_retry_adapter_for_table(name)
 
         # check if table exists
-        try:
+        if self._table_cache.get(name) is None:
+            print("checking if table exists!!!!!!")
             self._client.post(f"/v1/table/{name}/describe/")
-        except LanceDBClientError as err:
-            if str(err).startswith("Not found"):
-                logging.error(
-                    "Table %s does not exist. Please first call "
-                    "db.create_table(%s, data).",
-                    name,
-                    name,
-                )
-                raise err
-                
+            self._table_cache[name] = True
+            
         return RemoteTable(self, name)
 
     @override
@@ -269,6 +275,7 @@ class RemoteDBConnection(DBConnection):
             content_type=ARROW_STREAM_CONTENT_TYPE,
         )
 
+        self._table_cache[name] = True
         return RemoteTable(self, name)
 
     @override
@@ -284,6 +291,7 @@ class RemoteDBConnection(DBConnection):
         self._client.post(
             f"/v1/table/{name}/drop/",
         )
+        self._table_cache.pop(name)
 
     async def close(self):
         """Close the connection to the database."""

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -30,7 +30,6 @@ from ..table import Table, _sanitize_data
 from ..util import validate_table_name
 from .arrow import to_ipc_binary
 from .client import ARROW_STREAM_CONTENT_TYPE, RestfulLanceDBClient
-from .errors import LanceDBClientError
 
 
 class RemoteDBConnection(DBConnection):
@@ -115,7 +114,7 @@ class RemoteDBConnection(DBConnection):
         if self._table_cache.get(name) is None:
             self._client.post(f"/v1/table/{name}/describe/")
             self._table_cache[name] = True
-            
+
         return RemoteTable(self, name)
 
     @override

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -119,6 +119,8 @@ class RemoteDBConnection(DBConnection):
                     name,
                     name,
                 )
+                raise err
+                
         return RemoteTable(self, name)
 
     @override

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -33,7 +33,6 @@ from .client import ARROW_STREAM_CONTENT_TYPE, RestfulLanceDBClient
 from .errors import LanceDBClientError
 
 
-
 class RemoteDBConnection(DBConnection):
     """A connection to a remote LanceDB database."""
 
@@ -95,15 +94,6 @@ class RemoteDBConnection(DBConnection):
                 self._table_cache[item] = True
                 yield item
 
-    def _table_exists(self, name: str) -> bool:
-        # try:
-        
-        return True
-        # except LanceDBClientError as err:
-        #     if str(err).startswith("Not found"):
-        #         return False
-        #     raise err
-
     @override
     def open_table(self, name: str) -> Table:
         """Open a Lance Table in the database.
@@ -123,7 +113,6 @@ class RemoteDBConnection(DBConnection):
 
         # check if table exists
         if self._table_cache.get(name) is None:
-            print("checking if table exists!!!!!!")
             self._client.post(f"/v1/table/{name}/describe/")
             self._table_cache[name] = True
             


### PR DESCRIPTION
- make open table behaviour consistent:
  - remote tables will check if the table exists by calling /describe and throwing an error if the call doesn't succeed
  - this is similar to the behaviour for local tables where we will raise an exception when opening the table if the local dataset doesn't exist
- The table names are cached in the client with a TTL
- Also fixes a small bug where if the remote error response was deserialized from JSON as an object, we'd print it resulting in the unhelpful error message: `Error: Server Error, status: 404, message: Not Found: [object Object]`