### PR TITLE
feat: upgrade lance to 0.10.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["lancedb", "lance", "database", "vector", "search"]
 categories = ["database-implementations"]
 
 [workspace.dependencies]
-lance = { "version" = "=0.10.13", "features" = ["dynamodb"] }
-lance-index = { "version" = "=0.10.13" }
-lance-linalg = { "version" = "=0.10.13" }
-lance-testing = { "version" = "=0.10.13" }
+lance = { "version" = "=0.10.14", "features" = ["dynamodb"] }
+lance-index = { "version" = "=0.10.14" }
+lance-linalg = { "version" = "=0.10.14" }
+lance-testing = { "version" = "=0.10.14" }
 # Note that this one does not include pyarrow
 arrow = { version = "50.0", optional = false }
 arrow-array = "50.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["lancedb", "lance", "database", "vector", "search"]
 categories = ["database-implementations"]
 
 [workspace.dependencies]
-lance = { "version" = "=0.10.14", "features" = ["dynamodb"] }
-lance-index = { "version" = "=0.10.14" }
-lance-linalg = { "version" = "=0.10.14" }
-lance-testing = { "version" = "=0.10.14" }
+lance = { "version" = "=0.10.15", "features" = ["dynamodb"] }
+lance-index = { "version" = "=0.10.15" }
+lance-linalg = { "version" = "=0.10.15" }
+lance-testing = { "version" = "=0.10.15" }
 # Note that this one does not include pyarrow
 arrow = { version = "50.0", optional = false }
 arrow-array = "50.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "lancedb"
 version = "0.6.9"
 dependencies = [
     "deprecation",
-    "pylance==0.10.12",
+    "pylance==0.10.14",
     "ratelimiter~=1.0",
     "requests>=2.31.0",
     "retry>=0.9.2",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "lancedb"
 version = "0.6.9"
 dependencies = [
     "deprecation",
-    "pylance==0.10.14",
+    "pylance==0.10.15",
     "ratelimiter~=1.0",
     "requests>=2.31.0",
     "retry>=0.9.2",


### PR DESCRIPTION
This includes some fixes for writing to datasets that have had schema evolution applied.

Full changes at https://github.com/lancedb/lance/releases/tag/v0.10.14