### PR TITLE
Implement convertors to and from Polars DataFrames in Rust SDK using polars-arrow high level convertors #1099

### DIFF
--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -35,21 +35,15 @@ impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
         match &self {
             Ok(_) => Ok(self.unwrap()),
             Err(err) => match err {
-                LanceError::InvalidInput { .. } => self.value_error(),
-                LanceError::InvalidTableName { .. } => self.value_error(),
-                LanceError::TableNotFound { .. } => self.value_error(),
-                LanceError::Schema { .. } => self.value_error(),
+                LanceError::InvalidInput { .. }
+                | LanceError::InvalidTableName { .. }
+                | LanceError::TableNotFound { .. }
+                | LanceError::Schema { .. } => self.value_error(),
                 LanceError::CreateDir { .. } => self.os_error(),
-                LanceError::TableAlreadyExists { .. } => self.runtime_error(),
                 LanceError::ObjectStore { .. } => Err(PyIOError::new_err(err.to_string())),
-                LanceError::Lance { .. } => self.runtime_error(),
-                LanceError::Runtime { .. } => self.runtime_error(),
-                LanceError::Http { .. } => self.runtime_error(),
-                LanceError::Arrow { .. } => self.runtime_error(),
                 LanceError::NotSupported { .. } => {
                     Err(PyNotImplementedError::new_err(err.to_string()))
                 }
-                LanceError::Other { .. } => self.runtime_error(),
                 _ => self.runtime_error(),
             },
         }

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -50,6 +50,7 @@ impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
                     Err(PyNotImplementedError::new_err(err.to_string()))
                 }
                 LanceError::Other { .. } => self.runtime_error(),
+                _ => self.runtime_error(),
             },
         }
     }

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -40,6 +40,8 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 # For remote feature
 reqwest = { version = "0.11.24", features = ["gzip", "json"], optional = true }
+polars-arrow = { version = "0.39.2", features=["arrow_rs"], optional = true }
+polars = { version = "0.39.2", optional = true}
 
 [dev-dependencies]
 tempfile = "3.5.0"
@@ -56,3 +58,4 @@ default = ["remote"]
 remote = ["dep:reqwest"]
 fp16kernels = ["lance-linalg/fp16kernels"]
 s3-test = []
+polars = ["dep:polars-arrow", "dep:polars"]

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -201,12 +201,12 @@ impl arrow_array::RecordBatchReader for PolarsDataFrameRecordBatchReader {
 /// chunks are not guaranteed to be contiguous.
 #[cfg(feature = "polars")]
 pub trait IntoPolars {
-    fn into_polars(&mut self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
+    fn into_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
 }
 
 #[cfg(feature = "polars")]
 impl IntoPolars for SendableRecordBatchStream {
-    async fn into_polars(&mut self) -> Result<DataFrame> {
+    async fn into_polars(mut self) -> Result<DataFrame> {
         let arrow_schema = self.schema();
         let polars_schema = convert_arrow_schema_to_polars_schema(&arrow_schema);
         let mut acc_df: DataFrame = DataFrame::from(&polars_schema);
@@ -302,7 +302,7 @@ mod tests {
     async fn from_arrow_to_polars() {
         let record_batch_reader = get_record_batch_reader_from_polars();
         let schema = record_batch_reader.schema();
-        let mut stream: SendableRecordBatchStream = Box::pin(SimpleRecordBatchStream {
+        let stream: SendableRecordBatchStream = Box::pin(SimpleRecordBatchStream {
             schema: schema.clone(),
             stream: futures::stream::iter(
                 record_batch_reader

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -17,6 +17,15 @@ use std::{pin::Pin, sync::Arc};
 pub use arrow_array;
 pub use arrow_schema;
 use futures::{Stream, StreamExt};
+use polars::frame::ArrowChunk;
+
+#[cfg(feature = "polars")]
+use {
+    futures::TryStreamExt,
+    polars::datatypes,
+    polars::prelude::{DataFrame, Field, Schema, Series},
+    polars_arrow::array,
+};
 
 use crate::error::Result;
 
@@ -117,5 +126,216 @@ pub trait IntoArrow {
 impl<T: arrow_array::RecordBatchReader + Send + 'static> IntoArrow for T {
     fn into_arrow(self) -> Result<Box<dyn arrow_array::RecordBatchReader + Send>> {
         Ok(Box::new(self))
+    }
+}
+
+#[cfg(feature = "polars")]
+/// An iterator of record batches formed from a Polars DataFrame. The iterator
+/// panics if the DataFrame's chunks are not aligned. Consider calling
+/// [`polars::prelude::DataFrame::should_rechunk`] to determine whether the DataFrame
+/// should be rechunked and calling [`polars::prelude::DataFrame::align_chunks`]
+/// if the DataFrame needs to be rechunked before using the iterator.
+pub struct PolarsDataFrameRecordBatchReader {
+    chunks: Vec<ArrowChunk>,
+    arrow_schema: Arc<arrow_schema::Schema>,
+    index: usize,
+}
+
+#[cfg(feature = "polars")]
+impl PolarsDataFrameRecordBatchReader {
+    /// Creates a new `PolarsDataFrameRecordBatchReader` from a given Polars DataFrame.
+    pub fn new(df: DataFrame) -> Self {
+        let fields: Vec<arrow_schema::Field> = df
+            .schema()
+            .into_iter()
+            .map(|(name, dtype)| {
+                arrow_schema::Field::new(
+                    name,
+                    arrow_schema::DataType::from(dtype.to_arrow(false)),
+                    true,
+                )
+            })
+            .collect();
+        // Use pl_flavor = false to use LargeBinary and LargeUtf8 Arrow types instead of
+        // BinaryView and Utf8View types because polars-arrow to arrow-rs conversion
+        // is not yet implemented for BinaryView and Utf8View.
+        // See: https://lists.apache.org/thread/w88tpz76ox8h3rxkjl4so6rg3f1rv7wt for the
+        // differences in the types.
+        PolarsDataFrameRecordBatchReader {
+            chunks: df.iter_chunks(false).collect(),
+            arrow_schema: Arc::new(arrow_schema::Schema::new(fields)),
+            index: 0,
+        }
+    }
+}
+
+#[cfg(feature = "polars")]
+impl Iterator for PolarsDataFrameRecordBatchReader {
+    type Item = std::result::Result<arrow_array::RecordBatch, arrow_schema::ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.chunks.len() {
+            let columns: Vec<arrow_array::ArrayRef> = self.chunks[self.index]
+                .arrays()
+                .iter()
+                .map(|polars_array| arrow_array::ArrayRef::from(&**polars_array))
+                .collect();
+            self.index += 1;
+            Some(arrow_array::RecordBatch::try_new(
+                self.arrow_schema.clone(),
+                columns,
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "polars")]
+impl arrow_array::RecordBatchReader for PolarsDataFrameRecordBatchReader {
+    fn schema(&self) -> Arc<arrow_schema::Schema> {
+        self.arrow_schema.clone()
+    }
+
+    fn next_batch(
+        &mut self,
+    ) -> std::prelude::v1::Result<Option<arrow_array::RecordBatch>, arrow_schema::ArrowError> {
+        self.next().transpose()
+    }
+}
+
+/// A trait for converting the result of a LanceDB query into a Polars DataFrame with aligned
+/// chunks. The resulting Polars DataFrame will have aligned chunks, but the series's
+/// chunks are not guaranteed to be contiguous.
+#[cfg(feature = "polars")]
+pub trait ToPolars {
+    fn to_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
+}
+
+#[cfg(feature = "polars")]
+impl ToPolars for SendableRecordBatchStream {
+    async fn to_polars(self) -> Result<DataFrame> {
+        let arrow_schema = self.schema();
+        let polars_schema = convert_arrow_schema_to_polars_schema(&arrow_schema);
+        let mut acc_df: DataFrame = DataFrame::from(&polars_schema);
+        let record_batches = self.try_collect::<Vec<_>>().await?;
+        for record_batch in record_batches {
+            let new_df = convert_record_batch_to_polars_df(&record_batch, &polars_schema)?;
+            acc_df = acc_df.vstack(&new_df)?;
+        }
+        return Ok(acc_df);
+    }
+}
+
+#[cfg(feature = "polars")]
+fn convert_arrow_schema_to_polars_schema(arrow_schema: &arrow_schema::Schema) -> Schema {
+    Schema::from_iter(arrow_schema.fields().iter().map(|field| {
+        Field::new(
+            field.name(),
+            datatypes::DataType::from(&datatypes::ArrowDataType::from(field.data_type().clone())),
+        )
+    }))
+}
+
+#[cfg(feature = "polars")]
+fn convert_record_batch_to_polars_df(
+    record_batch: &arrow::record_batch::RecordBatch,
+    polars_schema: &Schema,
+) -> Result<DataFrame> {
+    let mut columns: Vec<Series> = Vec::with_capacity(record_batch.num_columns());
+
+    for (i, column) in record_batch.columns().iter().enumerate() {
+        let polars_array = Box::<dyn array::Array>::from(&**column);
+        columns.push(Series::from_arrow(
+            polars_schema.try_get_at_index(i)?.0,
+            polars_array,
+        )?);
+    }
+
+    Ok(DataFrame::from_iter(columns))
+}
+
+#[cfg(all(test, feature = "polars"))]
+mod tests {
+    use super::SendableRecordBatchStream;
+    use crate::arrow::{
+        IntoArrow, PolarsDataFrameRecordBatchReader, SimpleRecordBatchStream, ToPolars,
+    };
+    use polars::df;
+
+    fn get_record_batch_reader_from_polars() -> Box<dyn arrow_array::RecordBatchReader + Send> {
+        let df1 = df!("string" => &["ab"],
+             "int" => &[1],
+             "float" => &[1.0])
+        .unwrap();
+        let df2 = df!("string" => &["bc"],
+             "int" => &[2],
+             "float" => &[2.0])
+        .unwrap();
+
+        PolarsDataFrameRecordBatchReader::new(df1.vstack(&df2).unwrap())
+            .into_arrow()
+            .unwrap()
+    }
+
+    #[test]
+    fn from_polars_to_arrow_non_empty() {
+        let record_batch_reader = get_record_batch_reader_from_polars();
+        let schema = record_batch_reader.schema();
+
+        // Test schema conversion
+        assert_eq!(
+            schema
+                .fields
+                .iter()
+                .map(|field| ((field.name().as_str(), field.data_type())))
+                .collect::<Vec<_>>(),
+            vec![
+                ("string", &arrow_schema::DataType::LargeUtf8),
+                ("int", &arrow_schema::DataType::Int32),
+                ("float", &arrow_schema::DataType::Float64)
+            ]
+        );
+        let record_batches: Vec<arrow_array::RecordBatch> =
+            record_batch_reader.map(|result| result.unwrap()).collect();
+        assert_eq!(record_batches.len(), 2);
+        assert_eq!(schema, record_batches[0].schema());
+        assert_eq!(record_batches[0].schema(), record_batches[1].schema());
+
+        // Test number of rows
+        assert_eq!(record_batches[0].num_rows(), 1);
+        assert_eq!(record_batches[1].num_rows(), 1);
+    }
+
+    #[tokio::test]
+    async fn from_arrow_to_polars_non_empty() {
+        let record_batch_reader = get_record_batch_reader_from_polars();
+        let schema = record_batch_reader.schema();
+        let stream: SendableRecordBatchStream = Box::pin(SimpleRecordBatchStream {
+            schema: schema.clone(),
+            stream: futures::stream::iter(
+                record_batch_reader
+                    .into_iter()
+                    .map(|r| r.map_err(Into::into)),
+            ),
+        });
+        let df = stream.to_polars().await.unwrap();
+
+        // Test number of chunks and rows
+        assert_eq!(df.n_chunks(), 2);
+        assert_eq!(df.height(), 2);
+
+        // Test schema conversion
+        assert_eq!(
+            df.schema()
+                .into_iter()
+                .map(|(name, datatype)| (name.to_string(), datatype))
+                .collect::<Vec<_>>(),
+            vec![
+                ("string".to_string(), polars::prelude::DataType::String),
+                ("int".to_owned(), polars::prelude::DataType::Int32),
+                ("float".to_owned(), polars::prelude::DataType::Float64)
+            ]
+        );
     }
 }

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -163,7 +163,7 @@ impl PolarsDataFrameRecordBatchReader {
                 )
             })
             .collect();
-        PolarsDataFrameRecordBatchReader {
+        Self {
             chunks: df
                 .iter_chunks(POLARS_ARROW_FLAVOR)
                 .collect::<Vec<ArrowChunk>>()
@@ -214,7 +214,7 @@ impl IntoPolars for SendableRecordBatchStream {
             let new_df = convert_record_batch_to_polars_df(&record_batch?, &polars_schema)?;
             acc_df = acc_df.vstack(&new_df)?;
         }
-        return Ok(acc_df);
+        Ok(acc_df)
     }
 }
 

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -208,13 +208,13 @@ impl arrow_array::RecordBatchReader for PolarsDataFrameRecordBatchReader {
 /// chunks. The resulting Polars DataFrame will have aligned chunks, but the series's
 /// chunks are not guaranteed to be contiguous.
 #[cfg(feature = "polars")]
-pub trait ToPolars {
-    fn to_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
+pub trait IntoPolars {
+    fn into_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
 }
 
 #[cfg(feature = "polars")]
-impl ToPolars for SendableRecordBatchStream {
-    async fn to_polars(self) -> Result<DataFrame> {
+impl IntoPolars for SendableRecordBatchStream {
+    async fn into_polars(self) -> Result<DataFrame> {
         let arrow_schema = self.schema();
         let polars_schema = convert_arrow_schema_to_polars_schema(&arrow_schema);
         let mut acc_df: DataFrame = DataFrame::from(&polars_schema);
@@ -259,7 +259,7 @@ fn convert_record_batch_to_polars_df(
 mod tests {
     use super::SendableRecordBatchStream;
     use crate::arrow::{
-        IntoArrow, PolarsDataFrameRecordBatchReader, SimpleRecordBatchStream, ToPolars,
+        IntoArrow, IntoPolars, PolarsDataFrameRecordBatchReader, SimpleRecordBatchStream,
     };
     use polars::df;
 
@@ -319,7 +319,7 @@ mod tests {
                     .map(|r| r.map_err(Into::into)),
             ),
         });
-        let df = stream.to_polars().await.unwrap();
+        let df = stream.into_polars().await.unwrap();
 
         // Test number of chunks and rows
         assert_eq!(df.n_chunks(), 2);

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -279,7 +279,7 @@ mod tests {
             schema
                 .fields
                 .iter()
-                .map(|field| ((field.name().as_str(), field.data_type())))
+                .map(|field| (field.name().as_str(), field.data_type()))
                 .collect::<Vec<_>>(),
             vec![
                 ("string", &arrow_schema::DataType::LargeUtf8),

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -17,12 +17,12 @@ use std::{pin::Pin, sync::Arc};
 pub use arrow_array;
 pub use arrow_schema;
 use futures::{Stream, StreamExt};
-use polars::frame::ArrowChunk;
 
 #[cfg(feature = "polars")]
 use {
     futures::TryStreamExt,
     polars::datatypes,
+    polars::frame::ArrowChunk,
     polars::prelude::{DataFrame, Field, Schema, Series},
     polars_arrow::array,
 };

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -117,7 +117,7 @@ impl From<url::ParseError> for Error {
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
         Self::Other {
-            message: "Error when importing or exporting Polars DataFrame into LanceDB".to_string(),
+            message: "Error in Polars DataFrame integration.".to_string(),
             source: Some(Box::new(source)),
         }
     }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -19,6 +19,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum Error {
     #[snafu(display("Invalid table name (\"{name}\"): {reason}"))]
     InvalidTableName { name: String, reason: String },
@@ -49,6 +50,9 @@ pub enum Error {
     Arrow { source: ArrowError },
     #[snafu(display("LanceDBError: not supported: {message}"))]
     NotSupported { message: String },
+    #[cfg(feature = "polars")]
+    #[snafu(display("Polars error: {source}"))]
+    Polars { source: polars::error::PolarsError },
     #[snafu(whatever, display("{message}"))]
     Other {
         message: String,
@@ -110,5 +114,12 @@ impl From<url::ParseError> for Error {
         Self::Http {
             message: e.to_string(),
         }
+    }
+}
+
+#[cfg(feature = "polars")]
+impl From<polars::prelude::PolarsError> for Error {
+    fn from(source: polars::prelude::PolarsError) -> Self {
+        Self::Polars { source }
     }
 }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -52,6 +52,7 @@ pub enum Error {
     NotSupported { message: String },
     #[cfg(feature = "polars")]
     #[snafu(display("Polars error: {source}"))]
+    #[cfg(feature = "polars")]
     Polars { source: polars::error::PolarsError },
     #[snafu(whatever, display("{message}"))]
     Other {

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -50,10 +50,10 @@ pub enum Error {
     Arrow { source: ArrowError },
     #[snafu(display("LanceDBError: not supported: {message}"))]
     NotSupported { message: String },
-    #[cfg(feature = "polars")]
-    #[snafu(display("Polars error: {source}"))]
-    #[cfg(feature = "polars")]
-    Polars { source: polars::error::PolarsError },
+    #[snafu(display("External error: {source}"))]
+    External {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     #[snafu(whatever, display("{message}"))]
     Other {
         message: String,
@@ -121,6 +121,8 @@ impl From<url::ParseError> for Error {
 #[cfg(feature = "polars")]
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
-        Self::Polars { source }
+        Self::External {
+            source: Box::new(source),
+        }
     }
 }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -117,7 +117,7 @@ impl From<url::ParseError> for Error {
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
         Self::Other {
-            message: "Error when importing Polars DataFrame into LanceDB".to_string(),
+            message: "Error when importing or exporting Polars DataFrame into LanceDB".to_string(),
             source: Some(Box::new(source)),
         }
     }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -19,7 +19,6 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
-#[non_exhaustive]
 pub enum Error {
     #[snafu(display("Invalid table name (\"{name}\"): {reason}"))]
     InvalidTableName { name: String, reason: String },
@@ -50,10 +49,6 @@ pub enum Error {
     Arrow { source: ArrowError },
     #[snafu(display("LanceDBError: not supported: {message}"))]
     NotSupported { message: String },
-    #[snafu(display("External error: {source}"))]
-    External {
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
     #[snafu(whatever, display("{message}"))]
     Other {
         message: String,
@@ -121,8 +116,9 @@ impl From<url::ParseError> for Error {
 #[cfg(feature = "polars")]
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
-        Self::External {
-            source: Box::new(source),
+        Self::Other {
+            message: "Error when importing Polars DataFrame into LanceDB".to_string(),
+            source: Some(Box::new(source)),
         }
     }
 }


### PR DESCRIPTION
Took a stab at #1099, but I have a few questions/concerns:
1. Because of the [blanket implementation](https://github.com/lancedb/lancedb/blob/431f94e5644936e67298e81285c76d8fd1858d29/rust/lancedb/src/arrow.rs#L117) of IntoArrow for any type that implements RecordBatchReader, it is not possible to implement IntoArrow directly for Polar's DataFrame struct. Because of this, I had to create a new type (`PolarsDataFrameRecordBatchReader`) that consumed the DataFrame and implement the trait for this type. This does not seem ideal as users will not be able to directly called `into_arrow()` directly on their Polars DataFrame. Please advise on the best way to address this. If we remove the blanket implementation, we will have to explicitly box things that are already record batch readers, which also isn't too ergonomic.

2. My implementation of `into_polars `requires calling `try_collect()` on `arrow::SendableRecordBatchStream`. `Into_polars` is fallible due to any potential errors that occur in the LanceDB query OR due to any errors that occur in the conversion process. I wasn't sure the best way to surface that union to the user (creating a new Error enum specifically for this function didn't seem right), so I decided to extend the existing LanceDB error enum with a variant for Polars Errors behind a feature flag. This seems like bad practice too as it requires me to mark the enum as non-exhaustive, which is a breaking change. This is to handle cases where crate A depends on LanceDB, but does not enable the polars feature but crate B, which depends on crate A and LanceDB, does enable the polars feature, preventing crate A from compiling. 

3. What is the purpose of SimpleRecordBatchReader and RecordBatchReader defined [here](https://github.com/lancedb/lancedb/blob/main/rust/lancedb/src/arrow.rs#L24-L52)? I don't see it referenced. When would we have a RecordBatchReader that uses the LanceDB error type and not the arrow error type?

Thanks!