### PR TITLE
chore: bump arrow to 51

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ lance-index = { "version" = "=0.10.15" }
 lance-linalg = { "version" = "=0.10.15" }
 lance-testing = { "version" = "=0.10.15" }
 # Note that this one does not include pyarrow
-arrow = { version = "50.0", optional = false }
-arrow-array = "50.0"
-arrow-data = "50.0"
-arrow-ipc = "50.0"
-arrow-ord = "50.0"
-arrow-schema = "50.0"
-arrow-arith = "50.0"
-arrow-cast = "50.0"
+arrow = { version = "51.0", optional = false }
+arrow-array = "51.0"
+arrow-data = "51.0"
+arrow-ipc = "51.0"
+arrow-ord = "51.0"
+arrow-schema = "51.0"
+arrow-arith = "51.0"
+arrow-cast = "51.0"
 async-trait = "0"
 chrono = "0.4.35"
 half = { "version" = "=2.3.1", default-features = false, features = [


### PR DESCRIPTION
NOTE: while the released `0.10.15` depends on `arrow = 50`, we have bumped to `arrow = 51` on top of `main`.
