### PR TITLE
fix: passing data to createTable as option

### DIFF
--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -140,6 +140,9 @@ export class RemoteConnection implements Connection {
       schema = nameOrOpts.schema
       embeddings = nameOrOpts.embeddingFunction
       tableName = nameOrOpts.name
+      if (data === undefined) {
+        data = nameOrOpts.data
+      }
     }
 
     let buffer: Buffer


### PR DESCRIPTION
Fixes issue where we would throw `Either data or schema needs to defined` when passing `data` to `createTable` as a property of the first argument (an object).

```ts
await db.createTable({
  name: 'table1',
  data,
  schema
})
```