### PR TITLE
feat: add the optimize function to nodejs and async python

### DIFF
--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -442,7 +442,7 @@ describe("when optimizing a dataset", () => {
   });
 
   it("cleanups old versions", async () => {
-    const stats = await table.optimize({ cleanupOlderThanMs: 0 });
+    const stats = await table.optimize({ cleanupOlderThan: new Date() });
     expect(stats.prune.bytesRemoved).toBeGreaterThan(0);
     expect(stats.prune.oldVersionsRemoved).toBe(3);
   });

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -42,7 +42,7 @@ describe("Given a table", () => {
 
   it("be displayable", async () => {
     expect(table.display()).toMatch(
-      /NativeTable\(some_table, uri=.*, read_consistency_interval=None\)/
+      /NativeTable\(some_table, uri=.*, read_consistency_interval=None\)/,
     );
     table.close();
     expect(table.display()).toBe("ClosedTable(some_table)");
@@ -108,7 +108,7 @@ describe("When creating an index", () => {
         })),
       {
         schema,
-      }
+      },
     );
     queryVec = data.toArray()[5].vec.toJSON();
     tbl = await db.createTable("test", data);
@@ -167,7 +167,7 @@ describe("When creating an index", () => {
     // Default is replace=true
     await tbl.createIndex("id");
     await expect(tbl.createIndex("id", { replace: false })).rejects.toThrow(
-      "already exists"
+      "already exists",
     );
     await tbl.createIndex("id", { replace: true });
   });
@@ -191,7 +191,7 @@ describe("When creating an index", () => {
       new Field("vec", new FixedSizeList(32, new Field("item", new Float32()))),
       new Field(
         "vec2",
-        new FixedSizeList(64, new Field("item", new Float32()))
+        new FixedSizeList(64, new Field("item", new Float32())),
       ),
     ]);
     const tbl = await db.createTable(
@@ -208,8 +208,8 @@ describe("When creating an index", () => {
               .fill(1)
               .map(() => Math.random()),
           })),
-        { schema }
-      )
+        { schema },
+      ),
     );
 
     // Only build index over v1
@@ -223,7 +223,7 @@ describe("When creating an index", () => {
       .nearestTo(
         Array(32)
           .fill(1)
-          .map(() => Math.random())
+          .map(() => Math.random()),
       )
       .toArrow();
     expect(rst.numRows).toBe(2);
@@ -236,10 +236,10 @@ describe("When creating an index", () => {
         .nearestTo(
           Array(64)
             .fill(1)
-            .map(() => Math.random())
+            .map(() => Math.random()),
         )
         .column("vec")
-        .toArrow()
+        .toArrow(),
     ).rejects.toThrow(/.* query dim=64, expected vector dim=32.*/);
 
     const query64 = Array(64)
@@ -319,7 +319,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float32(), true)),
-        true
+        true,
       ),
       new Field("price", new Float32(), false),
     ]);
@@ -333,7 +333,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float32(), true)),
-        true
+        true,
       ),
       new Field("price", new Float64(), false),
     ]);
@@ -356,7 +356,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float32(), true)),
-        true
+        true,
       ),
       new Field("price", new Float64(), true),
     ]);
@@ -398,7 +398,7 @@ describe("when dealing with versioning", () => {
     expect(await table.countRows()).toBe(1);
     // Can't add data in time travel mode
     await expect(table.add([{ id: 3n, vector: [0.1, 0.2] }])).rejects.toThrow(
-      "table cannot be modified when a specific version is checked out"
+      "table cannot be modified when a specific version is checked out",
     );
     // Can go back to normal mode
     await table.checkoutLatest();
@@ -415,7 +415,7 @@ describe("when dealing with versioning", () => {
     expect(await table.countRows()).toBe(2);
     // Can't use restore if not checked out
     await expect(table.restore()).rejects.toThrow(
-      "checkout before running restore"
+      "checkout before running restore",
     );
   });
 });

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -154,7 +154,7 @@ export class Table {
    */
   async update(
     updates: Map<string, string> | Record<string, string>,
-    options?: Partial<UpdateOptions>
+    options?: Partial<UpdateOptions>,
   ) {
     const onlyIf = options?.where;
     let columns: [string, string][];

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -55,7 +55,6 @@ export interface OptimizeOptions {
   /**
    * If set then all versions older than the given date
    * be removed.  The current version will never be removed.
-   *
    * The default is 7 days
    *
    * @example
@@ -379,9 +378,9 @@ export class Table {
    *
    *  Optimization covers three operations:
    *
-   *   * Compaction: Merges small files into larger ones
-   *   * Prune: Removes old versions of the dataset
-   *   * Index: Optimizes the indices, adding new data to existing indices
+   *  - Compaction: Merges small files into larger ones
+   *  - Prune: Removes old versions of the dataset
+   *  - Index: Optimizes the indices, adding new data to existing indices
    *
    *
    *  Experimental API

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -53,12 +53,19 @@ export interface UpdateOptions {
 
 export interface OptimizeOptions {
   /**
-   * If set then all versions older than this number of milliseconds will
-   * be removed.
+   * If set then all versions older than the given date
+   * be removed.  The current version will never be removed.
    *
    * The default is 7 days
    *
-   * Set this value to 0 to delete all but the current version.
+   * @example
+   * // Delete all versions older than 1 day
+   * const olderThan = new Date();
+   * olderThan.setDate(olderThan.getDate() - 1));
+   * tbl.cleanupOlderVersions(olderThan);
+   *
+   * // Delete all versions except the current version
+   * tbl.cleanupOlderVersions(new Date());
    */
   cleanupOlderThan: Date;
 }
@@ -396,7 +403,15 @@ export class Table {
    *  modification operations.
    */
   async optimize(options?: Partial<OptimizeOptions>): Promise<OptimizeStats> {
-    return await this.inner.optimize(options?.cleanupOlderThanMs);
+    let cleanupOlderThanMs;
+    if (
+      options?.cleanupOlderThan !== undefined &&
+      options?.cleanupOlderThan !== null
+    ) {
+      cleanupOlderThanMs =
+        new Date().getTime() - options.cleanupOlderThan.getTime();
+    }
+    return await this.inner.optimize(cleanupOlderThanMs);
   }
 
   /** List all indices that have been created with {@link Table.createIndex} */

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -56,7 +56,6 @@ export interface OptimizeOptions {
    * If set then all versions older than the given date
    * be removed.  The current version will never be removed.
    * The default is 7 days
-   *
    * @example
    * // Delete all versions older than 1 day
    * const olderThan = new Date();

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -276,7 +276,7 @@ impl Table {
             .default_error()?
             .compaction
             .unwrap();
-        let older_than = older_than_ms.map(|since| Duration::milliseconds(since as i64));
+        let older_than = older_than_ms.map(Duration::milliseconds);
         let prune_stats = inner
             .optimize(OptimizeAction::Prune {
                 older_than,

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -15,8 +15,8 @@
 use arrow_ipc::writer::FileWriter;
 use lancedb::ipc::ipc_file_to_batches;
 use lancedb::table::{
-    AddDataMode, ColumnAlteration as LanceColumnAlteration, NewColumnTransform,
-    Table as LanceDbTable,
+    AddDataMode, ColumnAlteration as LanceColumnAlteration, Duration, NewColumnTransform,
+    OptimizeAction, OptimizeOptions, Table as LanceDbTable,
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -264,6 +264,49 @@ impl Table {
     }
 
     #[napi]
+    pub async fn optimize(&self, older_than_ms: Option<i64>) -> napi::Result<OptimizeStats> {
+        let inner = self.inner_ref()?;
+
+        let compaction_stats = inner
+            .optimize(OptimizeAction::Compact {
+                options: lancedb::table::CompactionOptions::default(),
+                remap_options: None,
+            })
+            .await
+            .default_error()?
+            .compaction
+            .unwrap();
+        let older_than = older_than_ms.map(|since| Duration::milliseconds(since as i64));
+        let prune_stats = inner
+            .optimize(OptimizeAction::Prune {
+                older_than,
+                delete_unverified: None,
+            })
+            .await
+            .default_error()?
+            .prune
+            .unwrap();
+        inner
+            .optimize(lancedb::table::OptimizeAction::Index(
+                OptimizeOptions::default(),
+            ))
+            .await
+            .default_error()?;
+        Ok(OptimizeStats {
+            compaction: CompactionStats {
+                files_added: compaction_stats.files_added as i64,
+                files_removed: compaction_stats.files_removed as i64,
+                fragments_added: compaction_stats.fragments_added as i64,
+                fragments_removed: compaction_stats.fragments_removed as i64,
+            },
+            prune: RemovalStats {
+                bytes_removed: prune_stats.bytes_removed as i64,
+                old_versions_removed: prune_stats.old_versions as i64,
+            },
+        })
+    }
+
+    #[napi]
     pub async fn list_indices(&self) -> napi::Result<Vec<IndexConfig>> {
         Ok(self
             .inner_ref()?
@@ -296,6 +339,40 @@ impl From<lancedb::index::IndexConfig> for IndexConfig {
             columns: value.columns,
         }
     }
+}
+
+/// Statistics about a compaction operation.
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct CompactionStats {
+    /// The number of fragments removed
+    pub fragments_removed: i64,
+    /// The number of new, compacted fragments added
+    pub fragments_added: i64,
+    /// The number of data files removed
+    pub files_removed: i64,
+    /// The number of new, compacted data files added
+    pub files_added: i64,
+}
+
+/// Statistics about a cleanup operation
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct RemovalStats {
+    /// The number of bytes removed
+    pub bytes_removed: i64,
+    /// The number of old versions removed
+    pub old_versions_removed: i64,
+}
+
+/// Statistics about an optimize operation
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct OptimizeStats {
+    /// Statistics about the compaction operation
+    pub compaction: CompactionStats,
+    /// Statistics about the removal operation
+    pub prune: RemovalStats,
 }
 
 ///  A definition of a column alteration. The alteration changes the column at

--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -86,3 +86,17 @@ class VectorQuery:
     def refine_factor(self, refine_factor: int): ...
     def nprobes(self, nprobes: int): ...
     def bypass_vector_index(self): ...
+
+class CompactionStats:
+    fragments_removed: int
+    fragments_added: int
+    files_removed: int
+    files_added: int
+
+class RemovalStats:
+    bytes_removed: int
+    old_versions_removed: int
+
+class OptimizeStats:
+    compaction: CompactionStats
+    prune: RemovalStats

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2395,7 +2395,8 @@ class AsyncTable:
         ----------
         cleanup_older_than: timedelta, optional default 7 days
             All files belonging to versions older than this will be removed.  Set
-            to 0 days to remove all versions except the latest.
+            to 0 days to remove all versions except the latest.  The latest version
+            is never removed.
 
         Experimental API
         ----------------

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     import PIL
     from lance.dataset import CleanupStats, ReaderLike
 
-    from ._lancedb import Table as LanceDBTable
+    from ._lancedb import Table as LanceDBTable, OptimizeStats
     from .db import LanceDBConnection
     from .index import BTree, IndexConfig, IvfPq
 
@@ -2376,6 +2376,48 @@ class AsyncTable:
         out state and the read_consistency_interval, if any, will apply.
         """
         await self._inner.restore()
+
+    async def optimize(
+        self, *, cleanup_older_than: Optional[timedelta] = None
+    ) -> OptimizeStats:
+        """
+        Optimize the on-disk data and indices for better performance.
+
+        Modeled after ``VACUUM`` in PostgreSQL.
+
+        Optimization covers three operations:
+
+         * Compaction: Merges small files into larger ones
+         * Prune: Removes old versions of the dataset
+         * Index: Optimizes the indices, adding new data to existing indices
+
+        Parameters
+        ----------
+        cleanup_older_than: timedelta, optional default 7 days
+            All files belonging to versions older than this will be removed.  Set
+            to 0 days to remove all versions except the latest.
+
+        Experimental API
+        ----------------
+
+        The optimization process is undergoing active development and may change.
+        Our goal with these changes is to improve the performance of optimization and
+        reduce the complexity.
+
+        That being said, it is essential today to run optimize if you want the best
+        performance.  It should be stable and safe to use in production, but it our
+        hope that the API may be simplified (or not even need to be called) in the
+        future.
+
+        The frequency an application shoudl call optimize is based on the frequency of
+        data modifications.  If data is frequently added, deleted, or updated then
+        optimize should be run frequently.  A good rule of thumb is to run optimize if
+        you have added or modified 100,000 or more records or run more than 20 data
+        modification operations.
+        """
+        if cleanup_older_than is not None:
+            cleanup_older_than = round(cleanup_older_than.total_seconds() * 1000)
+        return await self._inner.optimize(cleanup_older_than)
 
     async def list_indices(self) -> IndexConfig:
         """

--- a/python/src/table.rs
+++ b/python/src/table.rs
@@ -2,7 +2,9 @@ use arrow::{
     ffi_stream::ArrowArrayStreamReader,
     pyarrow::{FromPyArrow, ToPyArrow},
 };
-use lancedb::table::{AddDataMode, Table as LanceDbTable};
+use lancedb::table::{
+    AddDataMode, Duration, OptimizeAction, OptimizeOptions, Table as LanceDbTable,
+};
 use pyo3::{
     exceptions::{PyRuntimeError, PyValueError},
     pyclass, pymethods,
@@ -16,6 +18,40 @@ use crate::{
     index::{Index, IndexConfig},
     query::Query,
 };
+
+/// Statistics about a compaction operation.
+#[pyclass(get_all)]
+#[derive(Clone, Debug)]
+pub struct CompactionStats {
+    /// The number of fragments removed
+    pub fragments_removed: u64,
+    /// The number of new, compacted fragments added
+    pub fragments_added: u64,
+    /// The number of data files removed
+    pub files_removed: u64,
+    /// The number of new, compacted data files added
+    pub files_added: u64,
+}
+
+/// Statistics about a cleanup operation
+#[pyclass(get_all)]
+#[derive(Clone, Debug)]
+pub struct RemovalStats {
+    /// The number of bytes removed
+    pub bytes_removed: u64,
+    /// The number of old versions removed
+    pub old_versions_removed: u64,
+}
+
+/// Statistics about an optimize operation
+#[pyclass(get_all)]
+#[derive(Clone, Debug)]
+pub struct OptimizeStats {
+    /// Statistics about the compaction operation
+    pub compaction: CompactionStats,
+    /// Statistics about the removal operation
+    pub prune: RemovalStats,
+}
 
 #[pyclass]
 pub struct Table {
@@ -190,5 +226,48 @@ impl Table {
 
     pub fn query(&self) -> Query {
         Query::new(self.inner_ref().unwrap().query())
+    }
+
+    pub fn optimize(self_: PyRef<'_, Self>, cleanup_since_ms: Option<u64>) -> PyResult<&PyAny> {
+        let inner = self_.inner_ref()?.clone();
+        future_into_py(self_.py(), async move {
+            let compaction_stats = inner
+                .optimize(OptimizeAction::Compact {
+                    options: lancedb::table::CompactionOptions::default(),
+                    remap_options: None,
+                })
+                .await
+                .infer_error()?
+                .compaction
+                .unwrap();
+            let older_than = cleanup_since_ms.map(|since| Duration::milliseconds(since as i64));
+            let prune_stats = inner
+                .optimize(OptimizeAction::Prune {
+                    older_than,
+                    delete_unverified: None,
+                })
+                .await
+                .infer_error()?
+                .prune
+                .unwrap();
+            inner
+                .optimize(lancedb::table::OptimizeAction::Index(
+                    OptimizeOptions::default(),
+                ))
+                .await
+                .infer_error()?;
+            Ok(OptimizeStats {
+                compaction: CompactionStats {
+                    files_added: compaction_stats.files_added as u64,
+                    files_removed: compaction_stats.files_removed as u64,
+                    fragments_added: compaction_stats.fragments_added as u64,
+                    fragments_removed: compaction_stats.fragments_removed as u64,
+                },
+                prune: RemovalStats {
+                    bytes_removed: prune_stats.bytes_removed,
+                    old_versions_removed: prune_stats.old_versions,
+                },
+            })
+        })
     }
 }

--- a/rust/ffi/node/src/table.rs
+++ b/rust/ffi/node/src/table.rs
@@ -324,7 +324,7 @@ impl JsTable {
         rt.spawn(async move {
             let stats = table
                 .optimize(OptimizeAction::Prune {
-                    older_than,
+                    older_than: Some(older_than),
                     delete_unverified,
                 })
                 .await;


### PR DESCRIPTION
The optimize function is pretty crucial for getting good performance when building a large scale dataset but it was only exposed in rust (many sync python users are probably doing this via to_lance today)

This PR adds the optimize function to nodejs and to python.

I left the function marked experimental because I think there will likely be changes to optimization (e.g. if we add features like "optimize on write").  I also only exposed the `cleanup_older_than` configuration parameter since this one is very commonly used and the rest have sensible defaults and we don't really know why we would recommend different values for these defaults anyways.