### PR TITLE
feat: rust embedding registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 venv
 
 .vscode
-
+.zed
 rust/target
 rust/Cargo.lock
 

--- a/rust/lancedb/examples/embedding_registry.rs
+++ b/rust/lancedb/examples/embedding_registry.rs
@@ -1,0 +1,114 @@
+use std::{borrow::Cow, sync::Arc};
+
+use arrow::datatypes::Float32Type;
+use arrow_array::{
+    Array, FixedSizeListArray, GenericStringArray, Int32Array, RecordBatch, RecordBatchIterator,
+};
+use arrow_schema::{DataType, Field, Schema};
+use futures::StreamExt;
+use lancedb::{
+    arrow::IntoArrow,
+    connect,
+    embeddings::{EmbeddingDefinition, EmbeddingFunction},
+    query::ExecutableQuery,
+    Result,
+};
+
+#[derive(Debug)]
+struct MockEmbed {
+    source_type: DataType,
+    dest_type: DataType,
+}
+const DIM: usize = 1;
+
+impl MockEmbed {
+    pub fn new() -> Self {
+        Self {
+            source_type: DataType::Utf8,
+            dest_type: DataType::new_fixed_size_list(DataType::Float32, DIM as i32, true),
+        }
+    }
+}
+
+impl EmbeddingFunction for MockEmbed {
+    fn name(&self) -> &str {
+        "mock_embed"
+    }
+    fn source_type(&self) -> Cow<DataType> {
+        Cow::Borrowed(&self.source_type)
+    }
+    fn dest_type(&self) -> Cow<DataType> {
+        Cow::Borrowed(&self.dest_type)
+    }
+    fn embed(&self, source: Arc<dyn Array>) -> Result<Arc<dyn Array>> {
+        let len = source.len();
+        Ok(Arc::new(FixedSizeListArray::from_iter_primitive::<
+            Float32Type,
+            _,
+            _,
+        >(
+            (0..len).map(|_| Some(vec![Some(1.0); DIM])),
+            DIM as i32,
+        )))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = tempdir.path().to_str().unwrap();
+    let db = connect(tempdir).execute().await?;
+    let embed_fun = MockEmbed::new();
+    db.embedding_registry()
+        .register("embed_fun", Arc::new(embed_fun));
+    let tbl = db
+        .create_table("test", create_some_records()?)
+        .add_embedding(EmbeddingDefinition::new(
+            "text",
+            "embed_fun",
+            Some("embeddings"),
+        ))?
+        .execute()
+        .await?;
+    let mut res = tbl.query().execute().await?;
+    while let Some(batch) = res.next().await {
+        // just drain the batches
+        batch?;
+    }
+
+    // now make sure the embeddings are applied when
+    // we add new records too
+    tbl.add(create_some_records()?).execute().await?;
+    let mut res = tbl.query().execute().await?;
+    while let Some(batch) = res.next().await {
+        println!("batch = {:?}", batch);
+    }
+    Ok(())
+}
+
+fn create_some_records() -> Result<impl IntoArrow> {
+    const TOTAL: usize = 2;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("text", DataType::Utf8, true),
+    ]));
+
+    // Create a RecordBatch stream.
+    let batches = RecordBatchIterator::new(
+        vec![RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..TOTAL as i32)),
+                Arc::new(GenericStringArray::<i32>::from_iter(
+                    std::iter::repeat(Some("hello world".to_string())).take(TOTAL),
+                )),
+            ],
+        )
+        .unwrap()]
+        .into_iter()
+        .map(Ok),
+        schema.clone(),
+    );
+    Ok(Box::new(batches))
+}

--- a/rust/lancedb/examples/embedding_registry.rs
+++ b/rust/lancedb/examples/embedding_registry.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
 
 use arrow::datatypes::Float32Type;
 use arrow_array::{
@@ -9,58 +9,26 @@ use futures::StreamExt;
 use lancedb::{
     arrow::IntoArrow,
     connect,
-    embeddings::{EmbeddingDefinition, EmbeddingFunction},
+    embeddings::{EmbeddingDefinition, EmbeddingFunction, EmbeddingRegistry},
     query::ExecutableQuery,
-    Result,
+    Error, Result,
 };
-
-#[derive(Debug)]
-struct MockEmbed {
-    source_type: DataType,
-    dest_type: DataType,
-}
-const DIM: usize = 1;
-
-impl MockEmbed {
-    pub fn new() -> Self {
-        Self {
-            source_type: DataType::Utf8,
-            dest_type: DataType::new_fixed_size_list(DataType::Float32, DIM as i32, true),
-        }
-    }
-}
-
-impl EmbeddingFunction for MockEmbed {
-    fn name(&self) -> &str {
-        "mock_embed"
-    }
-    fn source_type(&self) -> Cow<DataType> {
-        Cow::Borrowed(&self.source_type)
-    }
-    fn dest_type(&self) -> Cow<DataType> {
-        Cow::Borrowed(&self.dest_type)
-    }
-    fn embed(&self, source: Arc<dyn Array>) -> Result<Arc<dyn Array>> {
-        let len = source.len();
-        Ok(Arc::new(FixedSizeListArray::from_iter_primitive::<
-            Float32Type,
-            _,
-            _,
-        >(
-            (0..len).map(|_| Some(vec![Some(1.0); DIM])),
-            DIM as i32,
-        )))
-    }
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    custom_func().await?;
+    custom_registry().await?;
+    Ok(())
+}
+
+async fn custom_func() -> Result<()> {
     let tempdir = tempfile::tempdir().unwrap();
     let tempdir = tempdir.path().to_str().unwrap();
     let db = connect(tempdir).execute().await?;
     let embed_fun = MockEmbed::new();
     db.embedding_registry()
-        .register("embed_fun", Arc::new(embed_fun));
+        .register("embed_fun", Arc::new(embed_fun))?;
+
     let tbl = db
         .create_table("test", create_some_records()?)
         .add_embedding(EmbeddingDefinition::new(
@@ -71,17 +39,83 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
     let mut res = tbl.query().execute().await?;
-    while let Some(batch) = res.next().await {
-        // just drain the batches
-        batch?;
+    while let Some(Ok(batch)) = res.next().await {
+        let embeddings = batch.column_by_name("embeddings");
+        assert!(embeddings.is_some());
+        let embeddings = embeddings.unwrap();
+        assert_eq!(
+            embeddings.data_type(),
+            MockEmbed::new().dest_type().as_ref()
+        );
     }
-
     // now make sure the embeddings are applied when
     // we add new records too
     tbl.add(create_some_records()?).execute().await?;
     let mut res = tbl.query().execute().await?;
-    while let Some(batch) = res.next().await {
-        println!("batch = {:?}", batch);
+    while let Some(Ok(batch)) = res.next().await {
+        let embeddings = batch.column_by_name("embeddings");
+        assert!(embeddings.is_some());
+        let embeddings = embeddings.unwrap();
+        assert_eq!(
+            embeddings.data_type(),
+            MockEmbed::new().dest_type().as_ref()
+        );
+    }
+    Ok(())
+}
+
+async fn custom_registry() -> Result<()> {
+    #[derive(Debug)]
+    struct MyRegistry {}
+
+    /// a mock registry that only has one function called `embed_fun`
+    impl EmbeddingRegistry for MyRegistry {
+        fn functions(&self) -> HashSet<String> {
+            std::iter::once("embed_fun".to_string()).collect()
+        }
+
+        fn register(&self, _name: &str, _function: Arc<dyn EmbeddingFunction>) -> Result<()> {
+            Err(Error::Other {
+                message: "MyRegistry is read-only".to_string(),
+                source: None,
+            })
+        }
+
+        fn get(&self, name: &str) -> Option<Arc<dyn EmbeddingFunction>> {
+            if name == "embed_fun" {
+                Some(Arc::new(MockEmbed::new()))
+            } else {
+                None
+            }
+        }
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = tempdir.path().to_str().unwrap();
+
+    let db = connect(tempdir)
+        .embedding_registry(Arc::new(MyRegistry {}))
+        .execute()
+        .await?;
+
+    let tbl = db
+        .create_table("test", create_some_records()?)
+        .add_embedding(EmbeddingDefinition::new(
+            "text",
+            "embed_fun",
+            Some("embeddings"),
+        ))?
+        .execute()
+        .await?;
+    let mut res = tbl.query().execute().await?;
+    while let Some(Ok(batch)) = res.next().await {
+        let embeddings = batch.column_by_name("embeddings");
+        assert!(embeddings.is_some());
+        let embeddings = embeddings.unwrap();
+        assert_eq!(
+            embeddings.data_type(),
+            MockEmbed::new().dest_type().as_ref()
+        );
     }
     Ok(())
 }
@@ -111,4 +145,42 @@ fn create_some_records() -> Result<impl IntoArrow> {
         schema.clone(),
     );
     Ok(Box::new(batches))
+}
+
+#[derive(Debug)]
+struct MockEmbed {
+    source_type: DataType,
+    dest_type: DataType,
+}
+const DIM: usize = 1;
+
+impl MockEmbed {
+    pub fn new() -> Self {
+        Self {
+            source_type: DataType::Utf8,
+            dest_type: DataType::new_fixed_size_list(DataType::Float32, DIM as i32, true),
+        }
+    }
+}
+impl EmbeddingFunction for MockEmbed {
+    fn name(&self) -> &str {
+        "mock_embed"
+    }
+    fn source_type(&self) -> Cow<DataType> {
+        Cow::Borrowed(&self.source_type)
+    }
+    fn dest_type(&self) -> Cow<DataType> {
+        Cow::Borrowed(&self.dest_type)
+    }
+    fn embed(&self, source: Arc<dyn Array>) -> Result<Arc<dyn Array>> {
+        let len = source.len();
+        Ok(Arc::new(FixedSizeListArray::from_iter_primitive::<
+            Float32Type,
+            _,
+            _,
+        >(
+            (0..len).map(|_| Some(vec![Some(1.0); DIM])),
+            DIM as i32,
+        )))
+    }
 }

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -114,8 +114,16 @@ pub trait IntoArrow {
     fn into_arrow(self) -> Result<Box<dyn arrow_array::RecordBatchReader + Send>>;
 }
 
+pub type BoxedRecordBatchReader = Box<dyn arrow_array::RecordBatchReader + Send>;
+
 impl<T: arrow_array::RecordBatchReader + Send + 'static> IntoArrow for T {
     fn into_arrow(self) -> Result<Box<dyn arrow_array::RecordBatchReader + Send>> {
         Ok(Box::new(self))
+    }
+}
+
+impl<S: Stream<Item = Result<arrow_array::RecordBatch>>> SimpleRecordBatchStream<S> {
+    pub fn new(stream: S, schema: Arc<arrow_schema::Schema>) -> Self {
+        Self { schema, stream }
     }
 }

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -124,11 +124,11 @@ impl<T: arrow_array::RecordBatchReader + Send + 'static> IntoArrow for T {
     }
 }
 
-
 impl<S: Stream<Item = Result<arrow_array::RecordBatch>>> SimpleRecordBatchStream<S> {
     pub fn new(stream: S, schema: Arc<arrow_schema::Schema>) -> Self {
         Self { schema, stream }
     }
+}
 #[cfg(feature = "polars")]
 /// An iterator of record batches formed from a Polars DataFrame.
 pub struct PolarsDataFrameRecordBatchReader {
@@ -294,6 +294,5 @@ mod tests {
                 ("float".to_owned(), polars::prelude::DataType::Float64)
             ]
         );
-
     }
 }

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -134,7 +134,6 @@ pub struct CreateTableBuilder<const HAS_DATA: bool, T: IntoArrow> {
     parent: Arc<dyn ConnectionInternal>,
     pub(crate) name: String,
     pub(crate) data: Option<T>,
-    // pub(crate) schema: Option<SchemaRef>,
     pub(crate) mode: CreateTableMode,
     pub(crate) write_options: WriteOptions,
     pub(crate) table_definition: Option<TableDefinition>,

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -147,7 +147,6 @@ impl<T: IntoArrow> CreateTableBuilder<true, T> {
             parent,
             name,
             data: Some(data),
-            // schema: None,
             mode: CreateTableMode::default(),
             write_options: WriteOptions::default(),
             table_definition: None,

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -227,7 +227,6 @@ impl CreateTableBuilder<false, NoData> {
             name,
             data: None,
             table_definition: Some(table_definition),
-            // schema: Some(schema),
             mode: CreateTableMode::default(),
             write_options: WriteOptions::default(),
         }

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -194,11 +194,8 @@ impl<T: IntoArrow> CreateTableBuilder<true, T> {
             .parent
             .embedding_registry()
             .get(&definition.embedding_name)
-            .ok_or_else(|| Error::InvalidInput {
-                message: format!(
-                    "There is no embedding named {} in the connection's embeddings registry",
-                    definition.embedding_name
-                ),
+            .ok_or_else(|| Error::EmbeddingFunctionNotFound {
+                name: definition.embedding_name.to_string(),
             })?;
 
         self.embeddings.push((definition, embedding_func));

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -196,6 +196,8 @@ impl<T: IntoArrow> CreateTableBuilder<true, T> {
             .get(&definition.embedding_name)
             .ok_or_else(|| Error::EmbeddingFunctionNotFound {
                 name: definition.embedding_name.to_string(),
+                reason: "No embedding function found in the connection's embedding_registry"
+                    .to_string(),
             })?;
 
         self.embeddings.push((definition, embedding_func));
@@ -477,6 +479,9 @@ impl Connection {
         self.internal.drop_db().await
     }
 
+    /// Get the in-memory embedding registry.
+    /// It's important to note that the embedding registry is not persisted across connections.
+    /// So if a table contains embeddings, you will need to make sure that you are using a connection that has the same embedding functions registered
     pub fn embedding_registry(&self) -> &dyn EmbeddingRegistry {
         self.internal.embedding_registry()
     }

--- a/rust/lancedb/src/embeddings.rs
+++ b/rust/lancedb/src/embeddings.rs
@@ -1,0 +1,264 @@
+use lance::arrow::RecordBatchExt;
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use arrow_array::{Array, RecordBatch, RecordBatchReader};
+use arrow_schema::{DataType, Field, SchemaBuilder};
+// use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::Result,
+    table::{ColumnDefinition, ColumnKind, TableDefinition},
+};
+
+/// Trait for embedding functions
+///
+/// An embedding function is a function that is applied to a column of input data
+/// to produce an "embedding" of that input.  This embedding is then stored in the
+/// database alongside (or instead of) the original input.
+///
+/// An "embedding" is often a lower-dimensional representation of the input data.
+/// For example, sentence-transformers can be used to embed sentences into a 768-dimensional
+/// vector space.  This is useful for tasks like similarity search, where we want to find
+/// similar sentences to a query sentence.
+///
+/// To use an embedding function you must first register it with the `EmbeddingsRegistry`.
+/// Then you can define it on a column in the table schema.  That embedding will then be used
+/// to embed the data in that column.
+// #[async_trait]
+pub trait EmbeddingFunction: std::fmt::Debug + Send + Sync {
+    fn name(&self) -> &str;
+    fn source_type(&self) -> Cow<DataType>;
+    fn dest_type(&self) -> Cow<DataType>;
+
+    /// TODO: This should be async
+    fn embed(&self, source: Arc<dyn Array>) -> Result<Arc<dyn Array>>;
+}
+
+/// Defines an embedding from input data into a lower-dimensional space
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingDefinition {
+    /// The name of the column in the input data
+    pub source_column: String,
+    /// The name of the embedding column, if not specified
+    /// it will be the source column with `_embedding` appended
+    pub dest_column: Option<String>,
+    /// The name of the embedding function to apply
+    pub embedding_name: String,
+}
+
+impl EmbeddingDefinition {
+    pub fn new<S: Into<String>>(source_column: S, embedding_name: S, dest: Option<S>) -> Self {
+        Self {
+            source_column: source_column.into(),
+            dest_column: dest.map(|d| d.into()),
+            embedding_name: embedding_name.into(),
+        }
+    }
+}
+
+pub trait EmbeddingRegistry: Send + Sync {
+    /// Register a new embedding function
+    // All embedding registries must provide inner mutability
+    fn register(&self, name: &str, function: Arc<dyn EmbeddingFunction>);
+    /// Get an embedding function by name
+    fn get(&self, name: &str) -> Option<Arc<dyn EmbeddingFunction>>;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MemoryRegistry {
+    functions: Arc<RwLock<HashMap<String, Arc<dyn EmbeddingFunction>>>>,
+}
+
+impl EmbeddingRegistry for MemoryRegistry {
+    fn register(&self, name: &str, function: Arc<dyn EmbeddingFunction>) {
+        self.functions
+            .write()
+            .unwrap()
+            .insert(name.to_string(), function);
+    }
+
+    fn get(&self, name: &str) -> Option<Arc<dyn EmbeddingFunction>> {
+        self.functions.read().unwrap().get(name).cloned()
+    }
+}
+
+impl MemoryRegistry {
+    /// Create a new `MemoryRegistry`
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// A record batch reader that has embeddings applied to it
+/// This is a wrapper around another record batch reader that applies an embedding function
+/// when reading from the record batch
+pub struct WithEmbeddings<R: RecordBatchReader> {
+    inner: R,
+    embedding_func: Arc<dyn EmbeddingFunction>,
+    embedding_def: EmbeddingDefinition,
+}
+
+/// A record batch that might have embeddings applied to it.
+pub enum MaybeEmbedded<R: RecordBatchReader> {
+    /// The record batch reader has embeddings applied to it
+    Yes(WithEmbeddings<R>),
+    /// The record batch reader does not have embeddings applied to it
+    No(R),
+}
+
+impl<R: RecordBatchReader> MaybeEmbedded<R> {
+    /// Create a new RecordBatchReader with embeddings applied to it if the table definition
+    /// specifies an embedding column and the registry contains an embedding function with that name
+    /// Otherwise, return the original RecordBatchReader
+    pub fn try_new(
+        inner: R,
+        table_definition: TableDefinition,
+        registry: Option<Arc<dyn EmbeddingRegistry>>,
+    ) -> Result<Self> {
+        if registry.is_none() {
+            return Ok(MaybeEmbedded::No(inner));
+        }
+
+        let embedding_def =
+            table_definition
+                .column_definitions
+                .iter()
+                .find_map(|cd| match &cd.kind {
+                    ColumnKind::Embedding(embedding_def) => Some(embedding_def.clone()),
+                    _ => None,
+                });
+
+        if let Some(embedding_def) = embedding_def {
+            let embedding_func = registry
+                .unwrap()
+                .get(&embedding_def.embedding_name)
+                .expect("Embedding function not found in registry")
+                .clone();
+
+            Ok(MaybeEmbedded::Yes(WithEmbeddings {
+                inner,
+                embedding_func,
+                embedding_def,
+            }))
+        } else {
+            Ok(MaybeEmbedded::No(inner))
+        }
+    }
+}
+
+impl<R: RecordBatchReader> WithEmbeddings<R> {
+    pub fn new(
+        inner: R,
+        embedding_func: Arc<dyn EmbeddingFunction>,
+        embedding_def: EmbeddingDefinition,
+    ) -> Self {
+        Self {
+            inner,
+            embedding_func,
+            embedding_def,
+        }
+    }
+}
+
+impl<R: RecordBatchReader> WithEmbeddings<R> {
+    fn dest_field(&self, nullable: bool) -> Field {
+        let field_name = self
+            .embedding_def
+            .dest_column
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| format!("{}_embedding", &self.embedding_def.source_column));
+
+        Field::new(
+            field_name,
+            self.embedding_func.dest_type().into_owned(),
+            nullable,
+        )
+    }
+
+    pub fn table_definition(&self) -> TableDefinition {
+        let base_schema = self.inner.schema();
+
+        let src_column = base_schema
+            .field_with_name(&self.embedding_def.source_column)
+            .unwrap();
+
+        let field = Arc::new(self.dest_field(src_column.is_nullable()));
+        let column_definitions: Vec<_> = base_schema
+            .fields()
+            .iter()
+            .map(|_| ColumnDefinition {
+                kind: ColumnKind::Physical,
+            })
+            .chain(std::iter::once(ColumnDefinition {
+                kind: ColumnKind::Embedding(self.embedding_def.clone()),
+            }))
+            .collect();
+
+        let mut sb: SchemaBuilder = base_schema.as_ref().into();
+        sb.push(field);
+        let schema = Arc::new(sb.finish());
+        TableDefinition {
+            schema,
+            column_definitions,
+        }
+    }
+}
+
+impl<R: RecordBatchReader> Iterator for MaybeEmbedded<R> {
+    type Item = std::result::Result<RecordBatch, arrow_schema::ArrowError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            MaybeEmbedded::Yes(inner) => inner.next(),
+            MaybeEmbedded::No(inner) => inner.next(),
+        }
+    }
+}
+
+impl<R: RecordBatchReader> RecordBatchReader for MaybeEmbedded<R> {
+    fn schema(&self) -> Arc<arrow_schema::Schema> {
+        match self {
+            MaybeEmbedded::Yes(inner) => inner.schema(),
+            MaybeEmbedded::No(inner) => inner.schema(),
+        }
+    }
+}
+
+impl<R: RecordBatchReader> Iterator for WithEmbeddings<R> {
+    type Item = std::result::Result<RecordBatch, arrow_schema::ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let batch = self.inner.next()?;
+        if let Ok(mut batch) = batch {
+            let schema = batch.schema();
+            let is_nullable = schema
+                .field_with_name(&self.embedding_def.source_column)
+                .unwrap()
+                .is_nullable();
+
+            let dst_field = Arc::new(self.dest_field(is_nullable));
+
+            let src_column = batch
+                .column_by_name(&self.embedding_def.source_column)
+                .unwrap();
+            let embedding = self.embedding_func.embed(src_column.clone()).unwrap();
+            batch = batch
+                .try_with_column(dst_field.as_ref().clone(), embedding)
+                .unwrap();
+            Some(Ok(batch))
+        } else {
+            Some(Err(batch.unwrap_err()))
+        }
+    }
+}
+
+impl<R: RecordBatchReader> RecordBatchReader for WithEmbeddings<R> {
+    fn schema(&self) -> Arc<arrow_schema::Schema> {
+        self.table_definition().into_rich_schema()
+    }
+}

--- a/rust/lancedb/src/embeddings.rs
+++ b/rust/lancedb/src/embeddings.rs
@@ -77,11 +77,11 @@ impl EmbeddingDefinition {
     }
 }
 
-/// A registry of embedding functions
+/// A registry of embedding
 pub trait EmbeddingRegistry: Send + Sync + std::fmt::Debug {
     /// Return the names of all registered embedding functions
     fn functions(&self) -> HashSet<String>;
-    /// Register a new [`EmbeddingFunction`]
+    /// Register a new [`EmbeddingFunction
     /// Returns an error if the function can not be registered
     fn register(&self, name: &str, function: Arc<dyn EmbeddingFunction>) -> Result<()>;
     /// Get an embedding function by name
@@ -156,6 +156,10 @@ impl<R: RecordBatchReader> MaybeEmbedded<R> {
                         None => {
                             return Err(Error::EmbeddingFunctionNotFound {
                                 name: embedding_def.embedding_name.to_string(),
+                                reason: format!(
+                                    "Table was defined with an embedding column `{}` but no embedding function was found with that name within the registry.",
+                                    embedding_def.embedding_name
+                                ),
                             });
                         }
                     }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     InvalidInput { message: String },
     #[snafu(display("Table '{name}' was not found"))]
     TableNotFound { name: String },
+    #[snafu(display("Embedding '{name}' was not found"))]
+    EmbeddingFunctionNotFound { name: String },
     #[snafu(display("Table '{name}' already exists"))]
     TableAlreadyExists { name: String },
     #[snafu(display("Unable to created lance dataset at {path}: {source}"))]

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     InvalidInput { message: String },
     #[snafu(display("Table '{name}' was not found"))]
     TableNotFound { name: String },
-    #[snafu(display("Embedding '{name}' was not found"))]
+    #[snafu(display("Embedding '{name}' was not found, Make sure you have registered the embedding function with the name '{name}' with your db/connection"))]
     EmbeddingFunctionNotFound { name: String },
     #[snafu(display("Table '{name}' already exists"))]
     TableAlreadyExists { name: String },

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -26,8 +26,9 @@ pub enum Error {
     InvalidInput { message: String },
     #[snafu(display("Table '{name}' was not found"))]
     TableNotFound { name: String },
-    #[snafu(display("Embedding '{name}' was not found, Make sure you have registered the embedding function with the name '{name}' with your db/connection"))]
-    EmbeddingFunctionNotFound { name: String },
+    #[snafu(display("Embedding function '{name}' was not found. : {reason}"))]
+    EmbeddingFunctionNotFound { name: String, reason: String },
+
     #[snafu(display("Table '{name}' already exists"))]
     TableAlreadyExists { name: String },
     #[snafu(display("Unable to created lance dataset at {path}: {source}"))]

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -194,6 +194,7 @@
 pub mod arrow;
 pub mod connection;
 pub mod data;
+pub mod embeddings;
 pub mod error;
 pub mod index;
 pub mod io;

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -23,6 +23,7 @@ use tokio::task::spawn_blocking;
 use crate::connection::{
     ConnectionInternal, CreateTableBuilder, NoData, OpenTableBuilder, TableNamesBuilder,
 };
+use crate::embeddings::EmbeddingRegistry;
 use crate::error::Result;
 use crate::Table;
 
@@ -113,6 +114,10 @@ impl ConnectionInternal for RemoteDatabase {
     }
 
     async fn drop_db(&self) -> Result<()> {
+        todo!()
+    }
+
+    fn embedding_registry(&self) -> &dyn EmbeddingRegistry {
         todo!()
     }
 }

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -10,7 +10,7 @@ use crate::{
     query::{Query, QueryExecutionOptions, VectorQuery},
     table::{
         merge::MergeInsertBuilder, AddDataBuilder, NativeTable, OptimizeAction, OptimizeStats,
-        TableInternal, UpdateBuilder,
+        TableDefinition, TableInternal, UpdateBuilder,
     },
 };
 
@@ -118,6 +118,9 @@ impl TableInternal for RemoteTable {
         todo!()
     }
     async fn list_indices(&self) -> Result<Vec<IndexConfig>> {
+        todo!()
+    }
+    async fn table_definition(&self) -> Result<TableDefinition> {
         todo!()
     }
 }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -113,7 +113,7 @@ impl TableDefinition {
                 serde_json::from_str(column_definitions).map_err(|e| Error::Runtime {
                     message: format!("Failed to deserialize column definitions: {}", e),
                 })?;
-            Ok(TableDefinition::new(schema, column_definitions))
+            Ok(Self::new(schema, column_definitions))
         } else {
             let column_definitions = schema
                 .fields()
@@ -122,7 +122,7 @@ impl TableDefinition {
                     kind: ColumnKind::Physical,
                 })
                 .collect();
-            Ok(TableDefinition::new(schema, column_definitions))
+            Ok(Self::new(schema, column_definitions))
         }
     }
 
@@ -1010,8 +1010,6 @@ impl NativeTable {
             Some(wrapper) => params.patch_with_store_wrapper(wrapper)?,
             None => params,
         };
-        let schema = batches.schema();
-        println!("schema: {:#?}", schema);
         let storage_options = params
             .store_params
             .clone()
@@ -1434,7 +1432,7 @@ impl TableInternal for NativeTable {
         let lance_schema = self.dataset.get().await?.schema().clone();
         Ok(Arc::new(Schema::from(&lance_schema)))
     }
-    
+
     async fn table_definition(&self) -> Result<TableDefinition> {
         let schema = self.schema().await?;
         TableDefinition::try_from_rich_schema(schema)

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1447,7 +1447,6 @@ impl TableInternal for NativeTable {
         add: AddDataBuilder<NoData>,
         data: Box<dyn RecordBatchReader + Send>,
     ) -> Result<()> {
-        println!("add embedding reg: {}", add.embedding_registry.is_some());
         let data =
             MaybeEmbedded::try_new(data, self.table_definition().await?, add.embedding_registry)?;
 

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1447,6 +1447,7 @@ impl TableInternal for NativeTable {
         add: AddDataBuilder<NoData>,
         data: Box<dyn RecordBatchReader + Send>,
     ) -> Result<()> {
+        println!("add embedding reg: {}", add.embedding_registry.is_some());
         let data =
             MaybeEmbedded::try_new(data, self.table_definition().await?, add.embedding_registry)?;
 

--- a/rust/lancedb/tests/embedding_registry_test.rs
+++ b/rust/lancedb/tests/embedding_registry_test.rs
@@ -90,6 +90,11 @@ async fn test_custom_registry() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_multiple_embeddings() -> Result<()> {
+    Ok(())
+}
+
 fn create_some_records() -> Result<impl IntoArrow> {
     const TOTAL: usize = 2;
 

--- a/rust/lancedb/tests/embedding_registry_test.rs
+++ b/rust/lancedb/tests/embedding_registry_test.rs
@@ -1,8 +1,14 @@
-use std::{borrow::Cow, collections::HashSet, sync::Arc};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    iter::repeat,
+    sync::Arc,
+};
 
-use arrow::datatypes::Float32Type;
+use arrow::buffer::NullBuffer;
 use arrow_array::{
-    Array, FixedSizeListArray, GenericStringArray, Int32Array, RecordBatch, RecordBatchIterator,
+    Array, FixedSizeListArray, Float32Array, Int32Array, RecordBatch, RecordBatchIterator,
+    StringArray,
 };
 use arrow_schema::{DataType, Field, Schema};
 use futures::StreamExt;
@@ -19,15 +25,15 @@ async fn test_custom_func() -> Result<()> {
     let tempdir = tempfile::tempdir().unwrap();
     let tempdir = tempdir.path().to_str().unwrap();
     let db = connect(tempdir).execute().await?;
-    let embed_fun = MockEmbed::new();
+    let embed_fun = MockEmbed::new("embed_fun".to_string(), 1);
     db.embedding_registry()
-        .register("embed_fun", Arc::new(embed_fun))?;
+        .register("embed_fun", Arc::new(embed_fun.clone()))?;
 
     let tbl = db
         .create_table("test", create_some_records()?)
         .add_embedding(EmbeddingDefinition::new(
             "text",
-            "embed_fun",
+            &embed_fun.name,
             Some("embeddings"),
         ))?
         .execute()
@@ -37,10 +43,7 @@ async fn test_custom_func() -> Result<()> {
         let embeddings = batch.column_by_name("embeddings");
         assert!(embeddings.is_some());
         let embeddings = embeddings.unwrap();
-        assert_eq!(
-            embeddings.data_type(),
-            MockEmbed::new().dest_type().as_ref()
-        );
+        assert_eq!(embeddings.data_type(), embed_fun.dest_type()?.as_ref());
     }
     // now make sure the embeddings are applied when
     // we add new records too
@@ -50,10 +53,7 @@ async fn test_custom_func() -> Result<()> {
         let embeddings = batch.column_by_name("embeddings");
         assert!(embeddings.is_some());
         let embeddings = embeddings.unwrap();
-        assert_eq!(
-            embeddings.data_type(),
-            MockEmbed::new().dest_type().as_ref()
-        );
+        assert_eq!(embeddings.data_type(), embed_fun.dest_type()?.as_ref());
     }
     Ok(())
 }
@@ -64,7 +64,7 @@ async fn test_custom_registry() -> Result<()> {
     let tempdir = tempdir.path().to_str().unwrap();
 
     let db = connect(tempdir)
-        .embedding_registry(Arc::new(MyRegistry {}))
+        .embedding_registry(Arc::new(MyRegistry::default()))
         .execute()
         .await?;
 
@@ -72,7 +72,7 @@ async fn test_custom_registry() -> Result<()> {
         .create_table("test", create_some_records()?)
         .add_embedding(EmbeddingDefinition::new(
             "text",
-            "embed_fun",
+            "func_1",
             Some("embeddings"),
         ))?
         .execute()
@@ -84,7 +84,9 @@ async fn test_custom_registry() -> Result<()> {
         let embeddings = embeddings.unwrap();
         assert_eq!(
             embeddings.data_type(),
-            MockEmbed::new().dest_type().as_ref()
+            MockEmbed::new("func_1".to_string(), 1)
+                .dest_type()?
+                .as_ref()
         );
     }
     Ok(())
@@ -92,6 +94,61 @@ async fn test_custom_registry() -> Result<()> {
 
 #[tokio::test]
 async fn test_multiple_embeddings() -> Result<()> {
+    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = tempdir.path().to_str().unwrap();
+
+    let db = connect(tempdir).execute().await?;
+    let func_1 = MockEmbed::new("func_1".to_string(), 1);
+    let func_2 = MockEmbed::new("func_2".to_string(), 10);
+    db.embedding_registry()
+        .register(&func_1.name, Arc::new(func_1.clone()))?;
+    db.embedding_registry()
+        .register(&func_2.name, Arc::new(func_2.clone()))?;
+
+    let tbl = db
+        .create_table("test", create_some_records()?)
+        .add_embedding(EmbeddingDefinition::new(
+            "text",
+            &func_1.name,
+            Some("first_embeddings"),
+        ))?
+        .add_embedding(EmbeddingDefinition::new(
+            "text",
+            &func_2.name,
+            Some("second_embeddings"),
+        ))?
+        .execute()
+        .await?;
+    let mut res = tbl.query().execute().await?;
+    while let Some(Ok(batch)) = res.next().await {
+        let embeddings = batch.column_by_name("first_embeddings");
+        assert!(embeddings.is_some());
+        let second_embeddings = batch.column_by_name("second_embeddings");
+        assert!(second_embeddings.is_some());
+
+        let embeddings = embeddings.unwrap();
+        assert_eq!(embeddings.data_type(), func_1.dest_type()?.as_ref());
+
+        let second_embeddings = second_embeddings.unwrap();
+        assert_eq!(second_embeddings.data_type(), func_2.dest_type()?.as_ref());
+    }
+
+    // now make sure the embeddings are applied when
+    // we add new records too
+    tbl.add(create_some_records()?).execute().await?;
+    let mut res = tbl.query().execute().await?;
+    while let Some(Ok(batch)) = res.next().await {
+        let embeddings = batch.column_by_name("first_embeddings");
+        assert!(embeddings.is_some());
+        let second_embeddings = batch.column_by_name("second_embeddings");
+        assert!(second_embeddings.is_some());
+
+        let embeddings = embeddings.unwrap();
+        assert_eq!(embeddings.data_type(), func_1.dest_type()?.as_ref());
+
+        let second_embeddings = second_embeddings.unwrap();
+        assert_eq!(second_embeddings.data_type(), func_2.dest_type()?.as_ref());
+    }
     Ok(())
 }
 
@@ -109,8 +166,8 @@ fn create_some_records() -> Result<impl IntoArrow> {
             schema.clone(),
             vec![
                 Arc::new(Int32Array::from_iter_values(0..TOTAL as i32)),
-                Arc::new(GenericStringArray::<i32>::from_iter(
-                    std::iter::repeat(Some("hello world".to_string())).take(TOTAL),
+                Arc::new(StringArray::from_iter(
+                    repeat(Some("hello world".to_string())).take(TOTAL),
                 )),
             ],
         )
@@ -123,12 +180,28 @@ fn create_some_records() -> Result<impl IntoArrow> {
 }
 
 #[derive(Debug)]
-struct MyRegistry {}
+struct MyRegistry {
+    functions: HashMap<String, Arc<dyn EmbeddingFunction>>,
+}
+impl Default for MyRegistry {
+    fn default() -> Self {
+        let funcs: Vec<Arc<dyn EmbeddingFunction>> = vec![
+            Arc::new(MockEmbed::new("func_1".to_string(), 1)),
+            Arc::new(MockEmbed::new("func_2".to_string(), 10)),
+        ];
+        Self {
+            functions: funcs
+                .into_iter()
+                .map(|f| (f.name().to_string(), f))
+                .collect(),
+        }
+    }
+}
 
 /// a mock registry that only has one function called `embed_fun`
 impl EmbeddingRegistry for MyRegistry {
     fn functions(&self) -> HashSet<String> {
-        std::iter::once("embed_fun".to_string()).collect()
+        self.functions.keys().cloned().collect()
     }
 
     fn register(&self, _name: &str, _function: Arc<dyn EmbeddingFunction>) -> Result<()> {
@@ -139,48 +212,52 @@ impl EmbeddingRegistry for MyRegistry {
     }
 
     fn get(&self, name: &str) -> Option<Arc<dyn EmbeddingFunction>> {
-        if name == "embed_fun" {
-            Some(Arc::new(MockEmbed::new()))
-        } else {
-            None
-        }
+        self.functions.get(name).cloned()
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct MockEmbed {
     source_type: DataType,
     dest_type: DataType,
+    name: String,
+    dim: usize,
 }
-const DIM: usize = 1;
 
 impl MockEmbed {
-    pub fn new() -> Self {
+    pub fn new(name: String, dim: usize) -> Self {
         Self {
             source_type: DataType::Utf8,
-            dest_type: DataType::new_fixed_size_list(DataType::Float32, DIM as i32, true),
+            dest_type: DataType::new_fixed_size_list(DataType::Float32, dim as _, true),
+            name,
+            dim,
         }
     }
 }
+
 impl EmbeddingFunction for MockEmbed {
     fn name(&self) -> &str {
-        "mock_embed"
+        &self.name
     }
-    fn source_type(&self) -> Cow<DataType> {
-        Cow::Borrowed(&self.source_type)
+    fn source_type(&self) -> Result<Cow<DataType>> {
+        Ok(Cow::Borrowed(&self.source_type))
     }
-    fn dest_type(&self) -> Cow<DataType> {
-        Cow::Borrowed(&self.dest_type)
+    fn dest_type(&self) -> Result<Cow<DataType>> {
+        Ok(Cow::Borrowed(&self.dest_type))
     }
     fn embed(&self, source: Arc<dyn Array>) -> Result<Arc<dyn Array>> {
+        // We can't use the FixedSizeListBuilder here because it always adds a null bitmap
+        // and we want to explicitly work with non-nullable arrays.
         let len = source.len();
-        Ok(Arc::new(FixedSizeListArray::from_iter_primitive::<
-            Float32Type,
-            _,
-            _,
-        >(
-            (0..len).map(|_| Some(vec![Some(1.0); DIM])),
-            DIM as i32,
-        )))
+        let inner = Arc::new(Float32Array::from(vec![Some(1.0); len * self.dim]));
+        let field = Field::new("item", inner.data_type().clone(), false);
+        let arr = FixedSizeListArray::new(
+            Arc::new(field),
+            self.dim as _,
+            inner,
+            Some(NullBuffer::new_valid(len)),
+        );
+
+        Ok(Arc::new(arr))
     }
 }


### PR DESCRIPTION

Todo:

- [x] add proper documentation
- [x] add unit tests
- [x] better handling of the registry**1
- [x] allow user defined registry**2

**1 The python implementation just uses a global registry so it makes things a bit easier. I attached it to the db/connection to prevent future conflicts if running multiple connections/databases. I mostly modeled the registry & pattern off of datafusion's [FunctionRegistry](https://docs.rs/datafusion/latest/datafusion/execution/trait.FunctionRegistry.html). 

**2 Ideally, the user should be able to provide it's own registry entirely, but currently it just uses an in memory registry by default (_which isn't configurable_)

`rust/lancedb/examples/embedding_registry.rs` provides a thorough example of expected usage. 

---

Some additional notes:

This does not provide any of the out of box functionality that the python registry does.

_i.e there are no built-in embedding functions._ 

You can think of this as the ground work for adding those built in functions, So while this is part of https://github.com/lancedb/lancedb/issues/994, it does not yet offer feature parity. 
