### PR TITLE
Implement convertors to and from Polars DataFrames in Rust SDK using convertors based on C FFI #1099

### DIFF
--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -35,21 +35,15 @@ impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
         match &self {
             Ok(_) => Ok(self.unwrap()),
             Err(err) => match err {
-                LanceError::InvalidInput { .. } => self.value_error(),
-                LanceError::InvalidTableName { .. } => self.value_error(),
-                LanceError::TableNotFound { .. } => self.value_error(),
-                LanceError::Schema { .. } => self.value_error(),
+                LanceError::InvalidInput { .. }
+                | LanceError::InvalidTableName { .. }
+                | LanceError::TableNotFound { .. }
+                | LanceError::Schema { .. } => self.value_error(),
                 LanceError::CreateDir { .. } => self.os_error(),
-                LanceError::TableAlreadyExists { .. } => self.runtime_error(),
                 LanceError::ObjectStore { .. } => Err(PyIOError::new_err(err.to_string())),
-                LanceError::Lance { .. } => self.runtime_error(),
-                LanceError::Runtime { .. } => self.runtime_error(),
-                LanceError::Http { .. } => self.runtime_error(),
-                LanceError::Arrow { .. } => self.runtime_error(),
                 LanceError::NotSupported { .. } => {
                     Err(PyNotImplementedError::new_err(err.to_string()))
                 }
-                LanceError::Other { .. } => self.runtime_error(),
                 _ => self.runtime_error(),
             },
         }

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -50,6 +50,7 @@ impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
                     Err(PyNotImplementedError::new_err(err.to_string()))
                 }
                 LanceError::Other { .. } => self.runtime_error(),
+                _ => self.runtime_error(),
             },
         }
     }

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -40,8 +40,8 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 # For remote feature
 reqwest = { version = "0.11.24", features = ["gzip", "json"], optional = true }
-polars-arrow = { version = "0.39.2", optional = true }
-polars = { version = "0.39.2", optional = true}
+polars-arrow = { version = ">=0.38", optional = true }
+polars = { version = ">=0.38", optional = true}
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -40,6 +40,8 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 # For remote feature
 reqwest = { version = "0.11.24", features = ["gzip", "json"], optional = true }
+polars-arrow = { version = "0.39.2", features=["arrow_rs"], optional = true }
+polars = { version = "0.39.2", optional = true}
 
 [dev-dependencies]
 tempfile = "3.5.0"
@@ -56,3 +58,4 @@ default = ["remote"]
 remote = ["dep:reqwest"]
 fp16kernels = ["lance-linalg/fp16kernels"]
 s3-test = []
+polars = ["dep:polars-arrow", "dep:polars"]

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 # For remote feature
 reqwest = { version = "0.11.24", features = ["gzip", "json"], optional = true }
-polars-arrow = { version = "0.39.2", features=["arrow_rs"], optional = true }
+polars-arrow = { version = "0.39.2", optional = true }
 polars = { version = "0.39.2", optional = true}
 
 [dev-dependencies]

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -40,8 +40,8 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 # For remote feature
 reqwest = { version = "0.11.24", features = ["gzip", "json"], optional = true }
-polars-arrow = { version = ">=0.38", optional = true }
-polars = { version = ">=0.38", optional = true}
+polars-arrow = { version = ">=0.37", optional = true }
+polars = { version = ">=0.37", optional = true}
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -201,12 +201,12 @@ impl arrow_array::RecordBatchReader for PolarsDataFrameRecordBatchReader {
 /// chunks are not guaranteed to be contiguous.
 #[cfg(feature = "polars")]
 pub trait IntoPolars {
-    fn into_polars(&mut self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
+    fn into_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
 }
 
 #[cfg(feature = "polars")]
 impl IntoPolars for SendableRecordBatchStream {
-    async fn into_polars(&mut self) -> Result<DataFrame> {
+    async fn into_polars(mut self) -> Result<DataFrame> {
         let arrow_schema = self.schema();
         let polars_schema = convert_arrow_schema_to_polars_schema(&arrow_schema);
         let mut acc_df: DataFrame = DataFrame::from(&polars_schema);
@@ -302,7 +302,7 @@ mod tests {
     async fn from_arrow_to_polars() {
         let record_batch_reader = get_record_batch_reader_from_polars();
         let schema = record_batch_reader.schema();
-        let mut stream: SendableRecordBatchStream = Box::pin(SimpleRecordBatchStream {
+        let stream: SendableRecordBatchStream = Box::pin(SimpleRecordBatchStream {
             schema: schema.clone(),
             stream: futures::stream::iter(
                 record_batch_reader

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -17,6 +17,15 @@ use std::{pin::Pin, sync::Arc};
 pub use arrow_array;
 pub use arrow_schema;
 use futures::{Stream, StreamExt};
+use polars::frame::ArrowChunk;
+
+#[cfg(feature = "polars")]
+use {
+    futures::TryStreamExt,
+    polars::datatypes,
+    polars::prelude::{DataFrame, Field, Schema, Series},
+    polars_arrow::array,
+};
 
 use crate::error::Result;
 
@@ -117,5 +126,216 @@ pub trait IntoArrow {
 impl<T: arrow_array::RecordBatchReader + Send + 'static> IntoArrow for T {
     fn into_arrow(self) -> Result<Box<dyn arrow_array::RecordBatchReader + Send>> {
         Ok(Box::new(self))
+    }
+}
+
+#[cfg(feature = "polars")]
+/// An iterator of record batches formed from a Polars DataFrame. The iterator
+/// panics if the DataFrame's chunks are not aligned. Consider calling
+/// [`polars::prelude::DataFrame::should_rechunk`] to determine whether the DataFrame
+/// should be rechunked and calling [`polars::prelude::DataFrame::align_chunks`]
+/// if the DataFrame needs to be rechunked before using the iterator.
+pub struct PolarsDataFrameRecordBatchReader {
+    chunks: Vec<ArrowChunk>,
+    arrow_schema: Arc<arrow_schema::Schema>,
+    index: usize,
+}
+
+#[cfg(feature = "polars")]
+impl PolarsDataFrameRecordBatchReader {
+    /// Creates a new `PolarsDataFrameRecordBatchReader` from a given Polars DataFrame.
+    pub fn new(df: DataFrame) -> Self {
+        let fields: Vec<arrow_schema::Field> = df
+            .schema()
+            .into_iter()
+            .map(|(name, dtype)| {
+                arrow_schema::Field::new(
+                    name,
+                    arrow_schema::DataType::from(dtype.to_arrow(false)),
+                    true,
+                )
+            })
+            .collect();
+        // Use pl_flavor = false to use LargeBinary and LargeUtf8 Arrow types instead of
+        // BinaryView and Utf8View types because polars-arrow to arrow-rs conversion
+        // is not yet implemented for BinaryView and Utf8View.
+        // See: https://lists.apache.org/thread/w88tpz76ox8h3rxkjl4so6rg3f1rv7wt for the
+        // differences in the types.
+        PolarsDataFrameRecordBatchReader {
+            chunks: df.iter_chunks(false).collect(),
+            arrow_schema: Arc::new(arrow_schema::Schema::new(fields)),
+            index: 0,
+        }
+    }
+}
+
+#[cfg(feature = "polars")]
+impl Iterator for PolarsDataFrameRecordBatchReader {
+    type Item = std::result::Result<arrow_array::RecordBatch, arrow_schema::ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.chunks.len() {
+            let columns: Vec<arrow_array::ArrayRef> = self.chunks[self.index]
+                .arrays()
+                .iter()
+                .map(|polars_array| arrow_array::ArrayRef::from(&**polars_array))
+                .collect();
+            self.index += 1;
+            Some(arrow_array::RecordBatch::try_new(
+                self.arrow_schema.clone(),
+                columns,
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "polars")]
+impl arrow_array::RecordBatchReader for PolarsDataFrameRecordBatchReader {
+    fn schema(&self) -> Arc<arrow_schema::Schema> {
+        self.arrow_schema.clone()
+    }
+
+    fn next_batch(
+        &mut self,
+    ) -> std::prelude::v1::Result<Option<arrow_array::RecordBatch>, arrow_schema::ArrowError> {
+        self.next().transpose()
+    }
+}
+
+/// A trait for converting the result of a LanceDB query into a Polars DataFrame with aligned
+/// chunks. The resulting Polars DataFrame will have aligned chunks, but the series's
+/// chunks are not guaranteed to be contiguous.
+#[cfg(feature = "polars")]
+pub trait ToPolars {
+    fn to_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
+}
+
+#[cfg(feature = "polars")]
+impl ToPolars for SendableRecordBatchStream {
+    async fn to_polars(self) -> Result<DataFrame> {
+        let arrow_schema = self.schema();
+        let polars_schema = convert_arrow_schema_to_polars_schema(&arrow_schema);
+        let mut acc_df: DataFrame = DataFrame::from(&polars_schema);
+        let record_batches = self.try_collect::<Vec<_>>().await?;
+        for record_batch in record_batches {
+            let new_df = convert_record_batch_to_polars_df(&record_batch, &polars_schema)?;
+            acc_df = acc_df.vstack(&new_df)?;
+        }
+        return Ok(acc_df);
+    }
+}
+
+#[cfg(feature = "polars")]
+fn convert_arrow_schema_to_polars_schema(arrow_schema: &arrow_schema::Schema) -> Schema {
+    Schema::from_iter(arrow_schema.fields().iter().map(|field| {
+        Field::new(
+            field.name(),
+            datatypes::DataType::from(&datatypes::ArrowDataType::from(field.data_type().clone())),
+        )
+    }))
+}
+
+#[cfg(feature = "polars")]
+fn convert_record_batch_to_polars_df(
+    record_batch: &arrow::record_batch::RecordBatch,
+    polars_schema: &Schema,
+) -> Result<DataFrame> {
+    let mut columns: Vec<Series> = Vec::with_capacity(record_batch.num_columns());
+
+    for (i, column) in record_batch.columns().iter().enumerate() {
+        let polars_array = Box::<dyn array::Array>::from(&**column);
+        columns.push(Series::from_arrow(
+            polars_schema.try_get_at_index(i)?.0,
+            polars_array,
+        )?);
+    }
+
+    Ok(DataFrame::from_iter(columns))
+}
+
+#[cfg(all(test, feature = "polars"))]
+mod tests {
+    use super::SendableRecordBatchStream;
+    use crate::arrow::{
+        IntoArrow, PolarsDataFrameRecordBatchReader, SimpleRecordBatchStream, ToPolars,
+    };
+    use polars::df;
+
+    fn get_record_batch_reader_from_polars() -> Box<dyn arrow_array::RecordBatchReader + Send> {
+        let df1 = df!("string" => &["ab"],
+             "int" => &[1],
+             "float" => &[1.0])
+        .unwrap();
+        let df2 = df!("string" => &["bc"],
+             "int" => &[2],
+             "float" => &[2.0])
+        .unwrap();
+
+        PolarsDataFrameRecordBatchReader::new(df1.vstack(&df2).unwrap())
+            .into_arrow()
+            .unwrap()
+    }
+
+    #[test]
+    fn from_polars_to_arrow_non_empty() {
+        let record_batch_reader = get_record_batch_reader_from_polars();
+        let schema = record_batch_reader.schema();
+
+        // Test schema conversion
+        assert_eq!(
+            schema
+                .fields
+                .iter()
+                .map(|field| ((field.name().as_str(), field.data_type())))
+                .collect::<Vec<_>>(),
+            vec![
+                ("string", &arrow_schema::DataType::LargeUtf8),
+                ("int", &arrow_schema::DataType::Int32),
+                ("float", &arrow_schema::DataType::Float64)
+            ]
+        );
+        let record_batches: Vec<arrow_array::RecordBatch> =
+            record_batch_reader.map(|result| result.unwrap()).collect();
+        assert_eq!(record_batches.len(), 2);
+        assert_eq!(schema, record_batches[0].schema());
+        assert_eq!(record_batches[0].schema(), record_batches[1].schema());
+
+        // Test number of rows
+        assert_eq!(record_batches[0].num_rows(), 1);
+        assert_eq!(record_batches[1].num_rows(), 1);
+    }
+
+    #[tokio::test]
+    async fn from_arrow_to_polars_non_empty() {
+        let record_batch_reader = get_record_batch_reader_from_polars();
+        let schema = record_batch_reader.schema();
+        let stream: SendableRecordBatchStream = Box::pin(SimpleRecordBatchStream {
+            schema: schema.clone(),
+            stream: futures::stream::iter(
+                record_batch_reader
+                    .into_iter()
+                    .map(|r| r.map_err(Into::into)),
+            ),
+        });
+        let df = stream.to_polars().await.unwrap();
+
+        // Test number of chunks and rows
+        assert_eq!(df.n_chunks(), 2);
+        assert_eq!(df.height(), 2);
+
+        // Test schema conversion
+        assert_eq!(
+            df.schema()
+                .into_iter()
+                .map(|(name, datatype)| (name.to_string(), datatype))
+                .collect::<Vec<_>>(),
+            vec![
+                ("string".to_string(), polars::prelude::DataType::String),
+                ("int".to_owned(), polars::prelude::DataType::Int32),
+                ("float".to_owned(), polars::prelude::DataType::Float64)
+            ]
+        );
     }
 }

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use arrow_array;
 use std::{pin::Pin, sync::Arc};
 
 pub use arrow_schema;

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -163,7 +163,7 @@ impl PolarsDataFrameRecordBatchReader {
                 )
             })
             .collect();
-        PolarsDataFrameRecordBatchReader {
+        Self {
             chunks: df
                 .iter_chunks(POLARS_ARROW_FLAVOR)
                 .collect::<Vec<ArrowChunk>>()
@@ -214,7 +214,7 @@ impl IntoPolars for SendableRecordBatchStream {
             let new_df = convert_record_batch_to_polars_df(&record_batch?, &polars_schema)?;
             acc_df = acc_df.vstack(&new_df)?;
         }
-        return Ok(acc_df);
+        Ok(acc_df)
     }
 }
 

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -208,13 +208,13 @@ impl arrow_array::RecordBatchReader for PolarsDataFrameRecordBatchReader {
 /// chunks. The resulting Polars DataFrame will have aligned chunks, but the series's
 /// chunks are not guaranteed to be contiguous.
 #[cfg(feature = "polars")]
-pub trait ToPolars {
-    fn to_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
+pub trait IntoPolars {
+    fn into_polars(self) -> impl std::future::Future<Output = Result<DataFrame>> + Send;
 }
 
 #[cfg(feature = "polars")]
-impl ToPolars for SendableRecordBatchStream {
-    async fn to_polars(self) -> Result<DataFrame> {
+impl IntoPolars for SendableRecordBatchStream {
+    async fn into_polars(self) -> Result<DataFrame> {
         let arrow_schema = self.schema();
         let polars_schema = convert_arrow_schema_to_polars_schema(&arrow_schema);
         let mut acc_df: DataFrame = DataFrame::from(&polars_schema);
@@ -259,7 +259,7 @@ fn convert_record_batch_to_polars_df(
 mod tests {
     use super::SendableRecordBatchStream;
     use crate::arrow::{
-        IntoArrow, PolarsDataFrameRecordBatchReader, SimpleRecordBatchStream, ToPolars,
+        IntoArrow, IntoPolars, PolarsDataFrameRecordBatchReader, SimpleRecordBatchStream,
     };
     use polars::df;
 
@@ -319,7 +319,7 @@ mod tests {
                     .map(|r| r.map_err(Into::into)),
             ),
         });
-        let df = stream.to_polars().await.unwrap();
+        let df = stream.into_polars().await.unwrap();
 
         // Test number of chunks and rows
         assert_eq!(df.n_chunks(), 2);

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -279,7 +279,7 @@ mod tests {
             schema
                 .fields
                 .iter()
-                .map(|field| ((field.name().as_str(), field.data_type())))
+                .map(|field| (field.name().as_str(), field.data_type()))
                 .collect::<Vec<_>>(),
             vec![
                 ("string", &arrow_schema::DataType::LargeUtf8),

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -17,12 +17,12 @@ use std::{pin::Pin, sync::Arc};
 pub use arrow_array;
 pub use arrow_schema;
 use futures::{Stream, StreamExt};
-use polars::frame::ArrowChunk;
 
 #[cfg(feature = "polars")]
 use {
     futures::TryStreamExt,
     polars::datatypes,
+    polars::frame::ArrowChunk,
     polars::prelude::{DataFrame, Field, Schema, Series},
     polars_arrow::array,
 };

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -209,17 +209,18 @@ mod tests {
     use crate::arrow::{
         IntoArrow, IntoPolars, PolarsDataFrameRecordBatchReader, SimpleRecordBatchStream,
     };
-    use polars::df;
+    use polars::prelude::{DataFrame, NamedFrom, Series};
 
     fn get_record_batch_reader_from_polars() -> Box<dyn arrow_array::RecordBatchReader + Send> {
-        let df1 = df!("string" => &["ab"],
-             "int" => &[1],
-             "float" => &[1.0])
-        .unwrap();
-        let df2 = df!("string" => &["bc"],
-             "int" => &[2],
-             "float" => &[2.0])
-        .unwrap();
+        let mut string_series = Series::new("string", &["ab"]);
+        let mut int_series = Series::new("int", &[1]);
+        let mut float_series = Series::new("float", &[1.0]);
+        let df1 = DataFrame::new(vec![string_series, int_series, float_series]).unwrap();
+
+        string_series = Series::new("string", &["bc"]);
+        int_series = Series::new("int", &[2]);
+        float_series = Series::new("float", &[2.0]);
+        let df2 = DataFrame::new(vec![string_series, int_series, float_series]).unwrap();
 
         PolarsDataFrameRecordBatchReader::new(df1.vstack(&df2).unwrap())
             .unwrap()

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -117,7 +117,7 @@ impl From<url::ParseError> for Error {
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
         Self::Other {
-            message: "Error when importing or exporting Polars DataFrame into LanceDB".to_string(),
+            message: "Error in Polars DataFrame integration.".to_string(),
             source: Some(Box::new(source)),
         }
     }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -19,6 +19,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum Error {
     #[snafu(display("Invalid table name (\"{name}\"): {reason}"))]
     InvalidTableName { name: String, reason: String },
@@ -49,6 +50,9 @@ pub enum Error {
     Arrow { source: ArrowError },
     #[snafu(display("LanceDBError: not supported: {message}"))]
     NotSupported { message: String },
+    #[cfg(feature = "polars")]
+    #[snafu(display("Polars error: {source}"))]
+    Polars { source: polars::error::PolarsError },
     #[snafu(whatever, display("{message}"))]
     Other {
         message: String,
@@ -110,5 +114,12 @@ impl From<url::ParseError> for Error {
         Self::Http {
             message: e.to_string(),
         }
+    }
+}
+
+#[cfg(feature = "polars")]
+impl From<polars::prelude::PolarsError> for Error {
+    fn from(source: polars::prelude::PolarsError) -> Self {
+        Self::Polars { source }
     }
 }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -52,6 +52,7 @@ pub enum Error {
     NotSupported { message: String },
     #[cfg(feature = "polars")]
     #[snafu(display("Polars error: {source}"))]
+    #[cfg(feature = "polars")]
     Polars { source: polars::error::PolarsError },
     #[snafu(whatever, display("{message}"))]
     Other {

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -50,10 +50,10 @@ pub enum Error {
     Arrow { source: ArrowError },
     #[snafu(display("LanceDBError: not supported: {message}"))]
     NotSupported { message: String },
-    #[cfg(feature = "polars")]
-    #[snafu(display("Polars error: {source}"))]
-    #[cfg(feature = "polars")]
-    Polars { source: polars::error::PolarsError },
+    #[snafu(display("External error: {source}"))]
+    External {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     #[snafu(whatever, display("{message}"))]
     Other {
         message: String,
@@ -121,6 +121,8 @@ impl From<url::ParseError> for Error {
 #[cfg(feature = "polars")]
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
-        Self::Polars { source }
+        Self::External {
+            source: Box::new(source),
+        }
     }
 }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -117,7 +117,7 @@ impl From<url::ParseError> for Error {
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
         Self::Other {
-            message: "Error when importing Polars DataFrame into LanceDB".to_string(),
+            message: "Error when importing or exporting Polars DataFrame into LanceDB".to_string(),
             source: Some(Box::new(source)),
         }
     }

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -19,7 +19,6 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
-#[non_exhaustive]
 pub enum Error {
     #[snafu(display("Invalid table name (\"{name}\"): {reason}"))]
     InvalidTableName { name: String, reason: String },
@@ -50,10 +49,6 @@ pub enum Error {
     Arrow { source: ArrowError },
     #[snafu(display("LanceDBError: not supported: {message}"))]
     NotSupported { message: String },
-    #[snafu(display("External error: {source}"))]
-    External {
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
     #[snafu(whatever, display("{message}"))]
     Other {
         message: String,
@@ -121,8 +116,9 @@ impl From<url::ParseError> for Error {
 #[cfg(feature = "polars")]
 impl From<polars::prelude::PolarsError> for Error {
     fn from(source: polars::prelude::PolarsError) -> Self {
-        Self::External {
-            source: Box::new(source),
+        Self::Other {
+            message: "Error when importing Polars DataFrame into LanceDB".to_string(),
+            source: Some(Box::new(source)),
         }
     }
 }

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -198,6 +198,8 @@ pub mod error;
 pub mod index;
 pub mod io;
 pub mod ipc;
+#[cfg(feature = "polars")]
+mod polars_arrow_convertors;
 pub mod query;
 #[cfg(feature = "remote")]
 pub(crate) mod remote;

--- a/rust/lancedb/src/polars_arrow_convertors.rs
+++ b/rust/lancedb/src/polars_arrow_convertors.rs
@@ -6,8 +6,9 @@
 /// between the arrows s in polars-arrow and arrow-rs using the C FFI.
 ///
 /// The polars-arrow does implement conversions to and from arrow-rs, but
-/// requires a feature flagged dependency on arrow-rs. Unfortunately, the arrow-rs
-/// versions are not compatible, which necessitates using the C FFI.
+/// requires a feature flagged dependency on arrow-rs. The version of arrow-rs
+/// depended on by polars-arrow and LanceDB may not be compatible,
+/// which necessitates using the C FFI.
 use crate::error::Result;
 use polars::prelude::{DataFrame, Series};
 use std::{mem, sync::Arc};

--- a/rust/lancedb/src/polars_arrow_convertors.rs
+++ b/rust/lancedb/src/polars_arrow_convertors.rs
@@ -1,0 +1,122 @@
+/// Polars and LanceDB both use Arrow for their in memory-representation, but use
+/// different Rust Arrow implementations. LanceDB uses the arrow-rs crate and
+/// Polars uses the polars-arrow crate.
+///
+/// This crate defines zero-copy conversions (of the underlying buffers)
+/// between the arrows s in polars-arrow and arrow-rs using the C FFI.
+///
+/// The polars-arrow does implement conversions to and from arrow-rs, but
+/// requires a feature flagged dependency on arrow-rs. Unfortunately, the arrow-rs
+/// versions are not compatible, which necessitates using the C FFI.
+use crate::error::Result;
+use polars::prelude::{DataFrame, Series};
+use std::{mem, sync::Arc};
+
+/// When interpreting Polars dataframes as polars-arrow record batches,
+/// whether to use Arrow string/binary view types instead of the standard
+/// Arrow string/binary types.
+/// For now, we will not use string view types because conversions
+/// for string view types from polars-arrow to arrow-rs are not yet implemented.
+/// See: https://lists.apache.org/thread/w88tpz76ox8h3rxkjl4so6rg3f1rv7wt for the
+/// differences in the types.
+pub const POLARS_ARROW_FLAVOR: bool = false;
+const IS_ARRAY_NULLABLE: bool = true;
+
+/// Converts a Polars DataFrame schema to an Arrow RecordBatch schema.
+pub fn convert_polars_df_schema_to_arrow_rb_schema(
+    polars_df_schema: polars::prelude::Schema,
+) -> Result<Arc<arrow_schema::Schema>> {
+    let arrow_fields: Result<Vec<arrow_schema::Field>> = polars_df_schema
+        .into_iter()
+        .map(|(name, df_dtype)| {
+            let polars_arrow_dtype = df_dtype.to_arrow(POLARS_ARROW_FLAVOR);
+            let polars_field =
+                polars_arrow::datatypes::Field::new(name, polars_arrow_dtype, IS_ARRAY_NULLABLE);
+            convert_polars_arrow_field_to_arrow_rs_field(polars_field)
+        })
+        .collect();
+    Ok(Arc::new(arrow_schema::Schema::new(arrow_fields?)))
+}
+
+/// Converts an Arrow RecordBatch schema to a Polars DataFrame schema.
+pub fn convert_arrow_rb_schema_to_polars_df_schema(
+    arrow_schema: &arrow_schema::Schema,
+) -> Result<polars::prelude::Schema> {
+    let polars_df_fields: Result<Vec<polars::prelude::Field>> = arrow_schema
+        .fields()
+        .iter()
+        .map(|arrow_rs_field| {
+            let polars_arrow_field = convert_arrow_rs_field_to_polars_arrow_field(arrow_rs_field)?;
+            Ok(polars::prelude::Field::new(
+                arrow_rs_field.name(),
+                polars::datatypes::DataType::from(polars_arrow_field.data_type()),
+            ))
+        })
+        .collect();
+    Ok(polars::prelude::Schema::from_iter(polars_df_fields?))
+}
+
+/// Converts an Arrow RecordBatch to a Polars DataFrame, using a provided Polars DataFrame schema.
+pub fn convert_arrow_rb_to_polars_df(
+    arrow_rb: &arrow::record_batch::RecordBatch,
+    polars_schema: &polars::prelude::Schema,
+) -> Result<DataFrame> {
+    let mut columns: Vec<Series> = Vec::with_capacity(arrow_rb.num_columns());
+
+    for (i, column) in arrow_rb.columns().iter().enumerate() {
+        let polars_df_dtype = polars_schema.try_get_at_index(i)?.1;
+        let polars_arrow_dtype = polars_df_dtype.to_arrow(POLARS_ARROW_FLAVOR);
+        let polars_array =
+            convert_arrow_rs_array_to_polars_arrow_array(column, polars_arrow_dtype)?;
+        columns.push(Series::from_arrow(
+            polars_schema.try_get_at_index(i)?.0,
+            polars_array,
+        )?);
+    }
+
+    Ok(DataFrame::from_iter(columns))
+}
+
+/// Converts a polars-arrow Arrow array to an arrow-rs Arrow array.
+pub fn convert_polars_arrow_array_to_arrow_rs_array(
+    polars_array: Box<dyn polars_arrow::array::Array>,
+    arrow_datatype: arrow_schema::DataType,
+) -> std::result::Result<arrow_array::ArrayRef, arrow_schema::ArrowError> {
+    let polars_c_array = polars_arrow::ffi::export_array_to_c(polars_array);
+    let arrow_c_array = unsafe { mem::transmute(polars_c_array) };
+    Ok(arrow_array::make_array(unsafe {
+        arrow::ffi::from_ffi_and_data_type(arrow_c_array, arrow_datatype)
+    }?))
+}
+
+/// Converts an arrow-rs Arrow array to a polars-arrow Arrow array.
+fn convert_arrow_rs_array_to_polars_arrow_array(
+    arrow_rs_array: &Arc<dyn arrow_array::Array>,
+    polars_arrow_dtype: polars::datatypes::ArrowDataType,
+) -> Result<Box<dyn polars_arrow::array::Array>> {
+    let arrow_c_array = arrow::ffi::FFI_ArrowArray::new(&arrow_rs_array.to_data());
+    let polars_c_array = unsafe { mem::transmute(arrow_c_array) };
+    Ok(unsafe { polars_arrow::ffi::import_array_from_c(polars_c_array, polars_arrow_dtype) }?)
+}
+
+fn convert_polars_arrow_field_to_arrow_rs_field(
+    polars_arrow_field: polars_arrow::datatypes::Field,
+) -> Result<arrow_schema::Field> {
+    let polars_c_schema = polars_arrow::ffi::export_field_to_c(&polars_arrow_field);
+    let arrow_c_schema: arrow::ffi::FFI_ArrowSchema = unsafe { mem::transmute(polars_c_schema) };
+    let arrow_rs_dtype = arrow_schema::DataType::try_from(&arrow_c_schema)?;
+    Ok(arrow_schema::Field::new(
+        polars_arrow_field.name,
+        arrow_rs_dtype,
+        IS_ARRAY_NULLABLE,
+    ))
+}
+
+fn convert_arrow_rs_field_to_polars_arrow_field(
+    arrow_rs_field: &arrow_schema::Field,
+) -> Result<polars_arrow::datatypes::Field> {
+    let arrow_rs_dtype = arrow_rs_field.data_type();
+    let arrow_c_schema = arrow::ffi::FFI_ArrowSchema::try_from(arrow_rs_dtype)?;
+    let polars_c_schema: polars_arrow::ffi::ArrowSchema = unsafe { mem::transmute(arrow_c_schema) };
+    Ok(unsafe { polars_arrow::ffi::import_field_from_c(&polars_c_schema) }?)
+}

--- a/rust/lancedb/src/polars_arrow_convertors.rs
+++ b/rust/lancedb/src/polars_arrow_convertors.rs
@@ -3,7 +3,7 @@
 /// Polars uses the polars-arrow crate.
 ///
 /// This crate defines zero-copy conversions (of the underlying buffers)
-/// between the arrows s in polars-arrow and arrow-rs using the C FFI.
+/// between polars-arrow and arrow-rs using the C FFI.
 ///
 /// The polars-arrow does implement conversions to and from arrow-rs, but
 /// requires a feature flagged dependency on arrow-rs. The version of arrow-rs

--- a/rust/lancedb/src/polars_arrow_convertors.rs
+++ b/rust/lancedb/src/polars_arrow_convertors.rs
@@ -14,8 +14,8 @@ use polars::prelude::{DataFrame, Series};
 use std::{mem, sync::Arc};
 
 /// When interpreting Polars dataframes as polars-arrow record batches,
-/// whether to use Arrow string/binary view types instead of the standard
-/// Arrow string/binary types.
+/// one must decide whether to use Arrow string/binary view types
+/// instead of the standard Arrow string/binary types.
 /// For now, we will not use string view types because conversions
 /// for string view types from polars-arrow to arrow-rs are not yet implemented.
 /// See: https://lists.apache.org/thread/w88tpz76ox8h3rxkjl4so6rg3f1rv7wt for the


### PR DESCRIPTION
https://github.com/lancedb/lancedb/issues/1099

Took the same general approach from: https://github.com/lancedb/lancedb/pull/1235. Instead of using high-level convertors  implemented in polars-arrow (with the arrow-rs feature flag, which adds a dependency on arrow-rs), I used convertors based on the C FFI to avoid dependency conflicts.