### PR TITLE
fix(python): return ValueError if passed unknown args to `connect()`

### DIFF
--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -107,6 +107,9 @@ def connect(
             request_thread_pool=request_thread_pool,
             **kwargs,
         )
+
+    if kwargs:
+        raise ValueError(f"Unknown keyword arguments: {kwargs}")
     return LanceDBConnection(uri, read_consistency_interval=read_consistency_interval)
 
 


### PR DESCRIPTION
It's confusing to users that keyword arguments from the async API like `storage_options` are accepted by `connect()`, but don't do anything. We should error if unknown arguments are passed instead.