### PR TITLE
Chore (python): Better retry loop logging when embedding api fails

### DIFF
--- a/python/python/lancedb/embeddings/utils.py
+++ b/python/python/lancedb/embeddings/utils.py
@@ -255,9 +255,13 @@ def retry_with_exponential_backoff(
                     )
 
                 delay *= exponential_base * (1 + jitter * random.random())
+                # dont use f-string for logging
                 logging.warning(
-                    f"Error occurred: {e}. Retrying in {delay:.2f} seconds. \n\n"
-                    f"Attempt {num_retries}/{max_retries}."
+                    "Error occurred: %s \n Retrying in %s seconds (retry %s of %s) \n",
+                    e,
+                    delay,
+                    num_retries,
+                    max_retries,
                 )
                 time.sleep(delay)
 

--- a/python/python/lancedb/embeddings/utils.py
+++ b/python/python/lancedb/embeddings/utils.py
@@ -255,7 +255,6 @@ def retry_with_exponential_backoff(
                     )
 
                 delay *= exponential_base * (1 + jitter * random.random())
-                # dont use f-string for logging
                 logging.warning(
                     "Error occurred: %s \n Retrying in %s seconds (retry %s of %s) \n",
                     e,

--- a/python/python/lancedb/embeddings/utils.py
+++ b/python/python/lancedb/embeddings/utils.py
@@ -255,7 +255,10 @@ def retry_with_exponential_backoff(
                     )
 
                 delay *= exponential_base * (1 + jitter * random.random())
-                logging.info("Retrying in %s seconds...", delay)
+                logging.warning(
+                    f"Error occurred: {e}. Retrying in {delay:.2f} seconds. \n\n"
+                    f"Attempt {num_retries}/{max_retries}."
+                )
                 time.sleep(delay)
 
     return wrapper


### PR DESCRIPTION
https://github.com/lancedb/lancedb/issues/1266#event-12703166915

This happens because openai API errors out with None values. The current log level didn't really print out the msg on screen. Changed the log level to warning, which better suits this case.

Also, retry loop can be disabled by setting `max_retries=0` (I'm not sure if we should also set this as the default behaviour as hitting api rate is quite common when ingesting large corpus)

```
func = get_registry().get("openai").create(max_retries=0)
````
