### PR TITLE
ci: better test for test_syntax

### DIFF
--- a/python/python/tests/test_fts.py
+++ b/python/python/tests/test_fts.py
@@ -213,7 +213,7 @@ def test_syntax(table):
     # https://github.com/lancedb/lancedb/issues/769
     table.create_fts_index("text")
     with pytest.raises(ValueError, match="Syntax Error"):
-        table.search("they could have been dogs OR cats").limit(10).to_list()
+        table.search("they could have been dogs OR").limit(10).to_list()
 
     # these should work
 


### PR DESCRIPTION
The syntax error was fixed in tantivy 0.22.0, so I changed the test case to something more wrong.