### PR TITLE
fix: parse index_stats for scalar index

### DIFF
--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -38,6 +38,7 @@ url.workspace = true
 regex.workspace = true
 serde = { version = "^1" }
 serde_json = { version = "1" }
+serde_with = { version = "3.8.1" }
 # For remote feature
 reqwest = { version = "0.11.24", features = ["gzip", "json"], optional = true }
 polars-arrow = { version = ">=0.37,<0.40.0", optional = true }

--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -14,6 +14,9 @@
 
 use std::sync::Arc;
 
+use serde::Deserialize;
+use serde_with::skip_serializing_none;
+
 use crate::{table::TableInternal, Result};
 
 use self::{
@@ -82,4 +85,20 @@ pub struct IndexConfig {
     /// Currently this is always a Vec of size 1.  In the future there may
     /// be more columns to represent composite indices.
     pub columns: Vec<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Deserialize)]
+pub struct IndexMetadata {
+    pub metric_type: Option<String>,
+    pub index_type: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Deserialize)]
+pub struct IndexStatistics {
+    pub num_indexed_rows: usize,
+    pub num_unindexed_rows: usize,
+    pub index_type: Option<String>,
+    pub indices: Vec<IndexMetadata>,
 }

--- a/rust/lancedb/src/index/vector.rs
+++ b/rust/lancedb/src/index/vector.rs
@@ -53,9 +53,14 @@ pub struct VectorIndexMetadata {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct VectorIndexStatistics {
+pub struct IndexMetadata {
     pub num_indexed_rows: usize,
     pub num_unindexed_rows: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VectorIndexStatistics {
+    pub num_indexed_and_unindexed_rows: IndexMetadata,
     pub index_type: String,
     pub indices: Vec<VectorIndexMetadata>,
 }

--- a/rust/lancedb/src/index/vector.rs
+++ b/rust/lancedb/src/index/vector.rs
@@ -24,6 +24,7 @@ use serde::Deserialize;
 use lance::table::format::{Index, Manifest};
 
 use crate::DistanceType;
+use serde_with::skip_serializing_none;
 
 pub struct VectorIndex {
     pub columns: Vec<String>,
@@ -46,22 +47,20 @@ impl VectorIndex {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Deserialize)]
 pub struct VectorIndexMetadata {
-    pub metric_type: String,
-    pub index_type: String,
+    pub metric_type: Option<String>,
+    pub index_type: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct IndexMetadata {
-    pub num_indexed_rows: usize,
-    pub num_unindexed_rows: usize,
-}
-
+#[skip_serializing_none]
 #[derive(Debug, Deserialize)]
 pub struct VectorIndexStatistics {
-    pub num_indexed_and_unindexed_rows: IndexMetadata,
-    pub index_type: String,
+    // pub row_stats: IndexRowStatistics,
+    pub num_indexed_rows: usize,
+    pub num_unindexed_rows: usize,
+    pub index_type: Option<String>,
     pub indices: Vec<VectorIndexMetadata>,
 }
 

--- a/rust/lancedb/src/index/vector.rs
+++ b/rust/lancedb/src/index/vector.rs
@@ -19,12 +19,10 @@
 //! values
 use std::cmp::max;
 
-use serde::Deserialize;
-
 use lance::table::format::{Index, Manifest};
 
 use crate::DistanceType;
-use serde_with::skip_serializing_none;
+
 
 pub struct VectorIndex {
     pub columns: Vec<String>,
@@ -45,22 +43,6 @@ impl VectorIndex {
             index_uuid: index.uuid.to_string(),
         }
     }
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Deserialize)]
-pub struct VectorIndexMetadata {
-    pub metric_type: Option<String>,
-    pub index_type: Option<String>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Deserialize)]
-pub struct VectorIndexStatistics {
-    pub num_indexed_rows: usize,
-    pub num_unindexed_rows: usize,
-    pub index_type: Option<String>,
-    pub indices: Vec<VectorIndexMetadata>,
 }
 
 /// Builder for an IVF PQ index.

--- a/rust/lancedb/src/index/vector.rs
+++ b/rust/lancedb/src/index/vector.rs
@@ -23,7 +23,6 @@ use lance::table::format::{Index, Manifest};
 
 use crate::DistanceType;
 
-
 pub struct VectorIndex {
     pub columns: Vec<String>,
     pub index_name: String,

--- a/rust/lancedb/src/index/vector.rs
+++ b/rust/lancedb/src/index/vector.rs
@@ -57,7 +57,6 @@ pub struct VectorIndexMetadata {
 #[skip_serializing_none]
 #[derive(Debug, Deserialize)]
 pub struct VectorIndexStatistics {
-    // pub row_stats: IndexRowStatistics,
     pub num_indexed_rows: usize,
     pub num_unindexed_rows: usize,
     pub index_type: Option<String>,

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -48,11 +48,9 @@ use crate::arrow::IntoArrow;
 use crate::connection::NoData;
 use crate::embeddings::{EmbeddingDefinition, EmbeddingRegistry, MaybeEmbedded, MemoryRegistry};
 use crate::error::{Error, Result};
-use crate::index::IndexStatistics;
-use crate::index::vector::{
-    IvfHnswSqIndexBuilder, IvfPqIndexBuilder, VectorIndex,
-};
+use crate::index::vector::{IvfHnswSqIndexBuilder, IvfPqIndexBuilder, VectorIndex};
 use crate::index::IndexConfig;
+use crate::index::IndexStatistics;
 use crate::index::{
     vector::{suggested_num_partitions, suggested_num_sub_vectors},
     Index, IndexBuilder,

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -48,8 +48,9 @@ use crate::arrow::IntoArrow;
 use crate::connection::NoData;
 use crate::embeddings::{EmbeddingDefinition, EmbeddingRegistry, MaybeEmbedded, MemoryRegistry};
 use crate::error::{Error, Result};
+use crate::index::IndexStatistics;
 use crate::index::vector::{
-    IvfHnswSqIndexBuilder, IvfPqIndexBuilder, VectorIndex, VectorIndexStatistics,
+    IvfHnswSqIndexBuilder, IvfPqIndexBuilder, VectorIndex,
 };
 use crate::index::IndexConfig;
 use crate::index::{
@@ -1244,7 +1245,7 @@ impl NativeTable {
             .collect())
     }
 
-    async fn load_index_stats(&self, index_uuid: &str) -> Result<Option<VectorIndexStatistics>> {
+    async fn load_index_stats(&self, index_uuid: &str) -> Result<Option<IndexStatistics>> {
         let index = self
             .load_indices()
             .await?
@@ -1255,7 +1256,7 @@ impl NativeTable {
         }
         let dataset = self.dataset.get().await?;
         let index_stats = dataset.index_statistics(&index.unwrap().index_name).await?;
-        let index_stats: VectorIndexStatistics = whatever!(
+        let index_stats: IndexStatistics = whatever!(
             serde_json::from_str(&index_stats),
             "error deserializing index statistics {index_stats}",
         );


### PR DESCRIPTION
parse the index stats for scalar index - it is different from the index stats for vector index