### PR TITLE
chore: sync bumpversion.toml with actual version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.4.21-beta.0"
+current_version = "0.4.20"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.


### PR DESCRIPTION
Attempting to create a new minor version failed with:

```
   Specified version (0.4.21-beta.0) does not match last tagged version (0.4.20) 
```

It seems the last release commit for rust/node was made without the new process and did not adjust bumpversion.toml correctly (or maybe bumpversion.toml did not exist at that time)