### PR TITLE
chore: remove working-directory from pypi upload step

### DIFF
--- a/.github/workflows/upload_wheel/action.yml
+++ b/.github/workflows/upload_wheel/action.yml
@@ -27,7 +27,6 @@ runs:
         echo "repo=pypi" >> $GITHUB_OUTPUT
       fi
   - name: Publish to PyPI
-    working-directory: python
     shell: bash
     env:
       FURY_TOKEN: ${{ inputs.fury_token }}


### PR DESCRIPTION
The wheels are built to `WORKDIR/target/wheels` and the step was configured to look for them at `WORKDIR/python/target/wheels`.