### PR TITLE
fix: error msg when query vector dim is wrong

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -704,6 +704,9 @@ export interface VectorIndex {
 export interface IndexStats {
   numIndexedRows: number | null
   numUnindexedRows: number | null
+  index_type: string | null
+  distance_type: string | null
+  completed_at: string | null
 }
 
 /**

--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -509,7 +509,8 @@ export class RemoteTable<T = number[]> implements Table<T> {
     return (await results.body()).indexes?.map((index: any) => ({
       columns: index.columns,
       name: index.index_name,
-      uuid: index.index_uuid
+      uuid: index.index_uuid,
+      status: index.status
     }))
   }
 
@@ -520,7 +521,10 @@ export class RemoteTable<T = number[]> implements Table<T> {
     const body = await results.body()
     return {
       numIndexedRows: body?.num_indexed_rows,
-      numUnindexedRows: body?.num_unindexed_rows
+      numUnindexedRows: body?.num_unindexed_rows,
+      index_type: body?.index_type,
+      distance_type: body?.distance_type,
+      completed_at: body?.completed_at
     }
   }
 

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -1001,6 +1001,6 @@ mod tests {
             .err()
             .unwrap()
             .to_string()
-            .contains("No vector column found to match with the query vector dimension"));
+            .contains("No vector column found to match with the query vector dimension: 3"));
     }
 }

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -989,5 +989,18 @@ mod tests {
         let first_batch = results.next().await.unwrap().unwrap();
         assert_eq!(first_batch.num_rows(), 1);
         assert!(results.next().await.is_none());
+
+        // query with wrong vector dimension
+        let error_result = table
+            .vector_search(&[1.0, 2.0, 3.0])
+            .unwrap()
+            .limit(1)
+            .execute()
+            .await;
+        assert!(error_result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("No vector column found to match with the query vector dimension"));
     }
 }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1506,7 +1506,7 @@ impl NativeTable {
                 if dim != query_vector.len() as i32 {
                     return Err(Error::InvalidInput {
                         message: format!(
-                            "The dimension of the query vector does not match with the dimension of the vector column '{}':
+                            "The dimension of the query vector does not match with the dimension of the vector column '{}': \
                                 query dim={}, expected vector dim={}",
                             column,
                             query_vector.len(),
@@ -2550,8 +2550,7 @@ mod tests {
                 .unwrap()
                 .get_index_type(index_uuid)
                 .await
-                .unwrap()
-                .map(|index_type| index_type.to_string()),
+                .unwrap(),
             Some("IVF".to_string())
         );
         assert_eq!(

--- a/rust/lancedb/src/utils.rs
+++ b/rust/lancedb/src/utils.rs
@@ -101,7 +101,7 @@ pub fn validate_table_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Find one default column to create index.
+/// Find one default column to create index or perform vector query.
 pub(crate) fn default_vector_column(schema: &Schema, dim: Option<i32>) -> Result<String> {
     // Try to find one fixed size list array column.
     let candidates = schema
@@ -118,14 +118,14 @@ pub(crate) fn default_vector_column(schema: &Schema, dim: Option<i32>) -> Result
         })
         .collect::<Vec<_>>();
     if candidates.is_empty() {
-        Err(Error::Schema {
-            message: "No vector column found to create index".to_string(),
+        Err(Error::InvalidInput {
+            message: "No vector column found to match with the query vector dimension".to_string(),
         })
     } else if candidates.len() != 1 {
         Err(Error::Schema {
             message: format!(
                 "More than one vector columns found, \
-                    please specify which column to create index: {:?}",
+                    please specify which column to create index or query: {:?}",
                 candidates
             ),
         })

--- a/rust/lancedb/src/utils.rs
+++ b/rust/lancedb/src/utils.rs
@@ -119,7 +119,10 @@ pub(crate) fn default_vector_column(schema: &Schema, dim: Option<i32>) -> Result
         .collect::<Vec<_>>();
     if candidates.is_empty() {
         Err(Error::InvalidInput {
-            message: "No vector column found to match with the query vector dimension".to_string(),
+            message: format!(
+                "No vector column found to match with the query vector dimension: {}",
+                dim.unwrap_or_default()
+            ),
         })
     } else if candidates.len() != 1 {
         Err(Error::Schema {


### PR DESCRIPTION
- changed the error msg for table.search with wrong query vector dim 
- added missing fields for listIndices and indexStats to be consistent with Python API - will make changes in node integ test