### PR TITLE
chore: add precommit hooks for rust

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,14 @@ repos:
 - repo: local
   hooks:
   - id: fmt
-    name: fmt
+    name: cargo fmt
     description: Format files with cargo fmt.
     entry: cargo fmt
     language: system
     types: [rust]
     args: [--]
+    files: '.*\.rs$'
+
   - id: cargo-check
     name: cargo check
     description: Check the package for errors.
@@ -36,12 +38,14 @@ repos:
     types: [rust]
     pass_filenames: false
     args: [--all]
+    files: '.*\.rs$'
 
   - id: clippy
-    name: clippy
+    name: cargo clippy
     description: Lint rust sources
     entry: cargo clippy
     language: system
     args: [--workspace, --, -D, warnings]
     types: [rust]
     pass_filenames: false
+    files: '.*\.rs$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,29 @@ repos:
       types: [text]
       files: "nodejs/.*"
       exclude: nodejs/lancedb/native.d.ts|nodejs/dist/.*
+- repo: local
+  hooks:
+  - id: fmt
+    name: fmt
+    description: Format files with cargo fmt.
+    entry: cargo fmt
+    language: system
+    types: [rust]
+    args: [--]
+  - id: cargo-check
+    name: cargo check
+    description: Check the package for errors.
+    entry: cargo check
+    language: system
+    types: [rust]
+    pass_filenames: false
+    args: [--all]
+
+  - id: clippy
+    name: clippy
+    description: Lint rust sources
+    entry: cargo clippy
+    language: system
+    args: [--workspace, --, -D, warnings]
+    types: [rust]
+    pass_filenames: false

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -19,6 +19,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+
 pub enum Error {
     #[snafu(display("Invalid table name (\"{name}\"): {reason}"))]
     InvalidTableName { name: String, reason: String },


### PR DESCRIPTION
I've noticed a few failures slip through the cracks, such as https://github.com/lancedb/lancedb/pull/1330. Since we are already using precommit hooks, it makes sense to validate rust like we do with ts and py. 