### PR TITLE
fix(java): the JVM crash when using jdk 8

### DIFF
--- a/java/core/lancedb-jni/src/ffi.rs
+++ b/java/core/lancedb-jni/src/ffi.rs
@@ -175,8 +175,8 @@ impl JNIEnvExt for JNIEnv<'_> {
         if obj.is_null() {
             return Ok(None);
         }
-        let is_empty = self.call_method(obj, "isEmpty", "()Z", &[])?;
-        if is_empty.z()? {
+        let is_present = self.call_method(obj, "isPresent", "()Z", &[])?;
+        if !is_present.z()? {
             // TODO(lu): put get java object into here cuz can only get java Object
             Ok(None)
         } else {


### PR DESCRIPTION
The Optional::isEmpty does not exist in java 8, so we should use isPresent instead