### PR TITLE
fix: use JS naming convention in new index stats fields

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -712,9 +712,9 @@ export interface VectorIndex {
 export interface IndexStats {
   numIndexedRows: number | null
   numUnindexedRows: number | null
-  index_type: string | null
-  distance_type: string | null
-  completed_at: string | null
+  indexType: string | null
+  distanceType: string | null
+  completedAt: string | null
 }
 
 /**

--- a/node/src/remote/index.ts
+++ b/node/src/remote/index.ts
@@ -522,9 +522,9 @@ export class RemoteTable<T = number[]> implements Table<T> {
     return {
       numIndexedRows: body?.num_indexed_rows,
       numUnindexedRows: body?.num_unindexed_rows,
-      index_type: body?.index_type,
-      distance_type: body?.distance_type,
-      completed_at: body?.completed_at
+      indexType: body?.index_type,
+      distanceType: body?.distance_type,
+      completedAt: body?.completed_at
     }
   }
 


### PR DESCRIPTION
Changes new index stats fields in node client from snake case to camel case.