### PR TITLE
chore: update depricated `promote=True` argument in pyarrow `concat_tables`

### DIFF
--- a/python/python/lancedb/rerankers/base.py
+++ b/python/python/lancedb/rerankers/base.py
@@ -120,9 +120,8 @@ class Reranker(ABC):
             The results from the FTS search
         """
         combined = pa.concat_tables(
-            [vector_results, fts_results],
-            promote_options=u"default"
-            )
+            [vector_results, fts_results], promote_options="default"
+        )
         row_id = combined.column("_rowid")
 
         # deduplicate

--- a/python/python/lancedb/rerankers/base.py
+++ b/python/python/lancedb/rerankers/base.py
@@ -119,7 +119,7 @@ class Reranker(ABC):
         fts_results : pa.Table
             The results from the FTS search
         """
-        combined = pa.concat_tables([vector_results, fts_results], promote=True)
+        combined = pa.concat_tables([vector_results, fts_results], promote_options=u"default")
         row_id = combined.column("_rowid")
 
         # deduplicate

--- a/python/python/lancedb/rerankers/base.py
+++ b/python/python/lancedb/rerankers/base.py
@@ -119,7 +119,10 @@ class Reranker(ABC):
         fts_results : pa.Table
             The results from the FTS search
         """
-        combined = pa.concat_tables([vector_results, fts_results], promote_options=u"default")
+        combined = pa.concat_tables(
+            [vector_results, fts_results],
+            promote_options=u"default"
+            )
         row_id = combined.column("_rowid")
 
         # deduplicate


### PR DESCRIPTION
Also depends on bumping pyarrow version in lance https://github.com/lancedb/lance/pull/2517 .

Since pyarrow 15, `concat_tables` with `promote=True` throws a warning. This can be fixed by updating the pyarrow version requirement to `>=14, <16.0.1` and using the updated api.