### PR TITLE
feat(nodejs): add better typehints for registry

### DIFF
--- a/nodejs/__test__/registry.test.ts
+++ b/nodejs/__test__/registry.test.ts
@@ -63,6 +63,7 @@ describe("Registry", () => {
         return data.map(() => [1, 2, 3]);
       }
     }
+
     const func = getRegistry()
       .get<MockEmbeddingFunction>("mock-embedding")!
       .create();

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -35,6 +35,11 @@ export interface FunctionOptions {
   [key: string]: any;
 }
 
+export interface EmbeddingFunctionConstructor<
+  T extends EmbeddingFunction = EmbeddingFunction,
+> {
+  new (modelOptions?: T["TOptions"]): T;
+}
 /**
  * An embedding function that automatically creates vector representation for a given column.
  */
@@ -43,6 +48,12 @@ export abstract class EmbeddingFunction<
   T = any,
   M extends FunctionOptions = FunctionOptions,
 > {
+  /**
+   * @ignore
+   *  This is only used for associating the options type with the class for type checking
+   */
+  // biome-ignore lint/style/useNamingConvention: we want to keep the name as it is
+  readonly TOptions!: M;
   /**
    * Convert the embedding function to a JSON object
    * It is used to serialize the embedding function to the schema

--- a/nodejs/lancedb/embedding/openai.ts
+++ b/nodejs/lancedb/embedding/openai.ts
@@ -43,8 +43,11 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
     }
     const modelName = options?.model ?? "text-embedding-ada-002";
 
+    /**
+     * @type {import("openai").default}
+     */
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    let Openai: import("openai").default;
+    let Openai;
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       Openai = require("openai");

--- a/nodejs/lancedb/embedding/openai.ts
+++ b/nodejs/lancedb/embedding/openai.ts
@@ -13,16 +13,14 @@
 // limitations under the License.
 
 import type OpenAI from "openai";
+import { type EmbeddingCreateParams } from "openai/resources";
 import { Float, Float32 } from "../arrow";
 import { EmbeddingFunction } from "./embedding_function";
 import { register } from "./registry";
 
 export type OpenAIOptions = {
   apiKey: string;
-  model:
-    | "text-embedding-ada-002"
-    | "text-embedding-3-large"
-    | "text-embedding-3-small";
+  model: EmbeddingCreateParams["model"];
 };
 
 @register("openai")
@@ -45,11 +43,8 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
     }
     const modelName = options?.model ?? "text-embedding-ada-002";
 
-    /**
-     * @type {import("openai").default}
-     */
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    let Openai;
+    let Openai: import("openai").default;
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       Openai = require("openai");
@@ -79,6 +74,8 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
         return 3072;
       case "text-embedding-3-small":
         return 1536;
+      default:
+        throw new Error(`Unknown model: ${this.#modelName}`);
     }
   }
 

--- a/nodejs/lancedb/embedding/openai.ts
+++ b/nodejs/lancedb/embedding/openai.ts
@@ -18,20 +18,23 @@ import { EmbeddingFunction } from "./embedding_function";
 import { register } from "./registry";
 
 export type OpenAIOptions = {
-  apiKey?: string;
-  model?: string;
+  apiKey: string;
+  model:
+    | "text-embedding-ada-002"
+    | "text-embedding-3-large"
+    | "text-embedding-3-small";
 };
 
 @register("openai")
 export class OpenAIEmbeddingFunction extends EmbeddingFunction<
   string,
-  OpenAIOptions
+  Partial<OpenAIOptions>
 > {
   #openai: OpenAI;
-  #modelName: string;
+  #modelName: OpenAIOptions["model"];
 
   constructor(
-    options: OpenAIOptions = {
+    options: Partial<OpenAIOptions> = {
       model: "text-embedding-ada-002",
     },
   ) {
@@ -76,8 +79,6 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
         return 3072;
       case "text-embedding-3-small":
         return 1536;
-      default:
-        return null as never;
     }
   }
 

--- a/nodejs/lancedb/embedding/openai.ts
+++ b/nodejs/lancedb/embedding/openai.ts
@@ -30,7 +30,11 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
   #openai: OpenAI;
   #modelName: string;
 
-  constructor(options: OpenAIOptions = { model: "text-embedding-ada-002" }) {
+  constructor(
+    options: OpenAIOptions = {
+      model: "text-embedding-ada-002",
+    },
+  ) {
     super();
     const openAIKey = options?.apiKey ?? process.env.OPENAI_API_KEY;
     if (!openAIKey) {

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -45,8 +45,6 @@ export class EmbeddingFunctionRegistry {
     alias?: string,
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   ): (ctor: T) => any {
-    console.log("registering", name);
-
     const self = this;
     return function (ctor: T) {
       if (!alias) {

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -67,6 +67,15 @@ export class EmbeddingFunctionRegistry {
    */
   get<T extends EmbeddingFunction<unknown>, Name extends string = "">(
     name: Name extends "openai" ? "openai" : string,
+    //This makes it so that you can use string constants as "types", or use an explicitly supplied type
+    // ex:
+    // `registry.get("openai") -> EmbeddingFunctionCreate<OpenAIEmbeddingFunction>`
+    // `registry.get<MyCustomEmbeddingFunction>("my_func") -> EmbeddingFunctionCreate<MyCustomEmbeddingFunction> | undefined`
+    //
+    // the reason this is important is that we always know our built in functions are defined so the user isnt forced to do a non null/undefined
+    // ```ts
+    // const openai: OpenAIEmbeddingFunction = registry.get("openai").create()
+    // ```
   ): Name extends "openai"
     ? EmbeddingFunctionCreate<OpenAIEmbeddingFunction>
     : EmbeddingFunctionCreate<T> | undefined {

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -45,6 +45,8 @@ export class EmbeddingFunctionRegistry {
     alias?: string,
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   ): (ctor: T) => any {
+    console.log("registering", name);
+
     const self = this;
     return function (ctor: T) {
       if (!alias) {
@@ -65,11 +67,8 @@ export class EmbeddingFunctionRegistry {
    * Fetch an embedding function by name
    * @param name The name of the function
    */
-  get<
-    T extends EmbeddingFunction<unknown> = EmbeddingFunction,
-    Name extends string = "",
-  >(
-    name: Name,
+  get<T extends EmbeddingFunction<unknown>, Name extends string = "">(
+    name: Name extends "openai" ? "openai" : string,
   ): Name extends "openai"
     ? EmbeddingFunctionCreate<OpenAIEmbeddingFunction>
     : EmbeddingFunctionCreate<T> | undefined {


### PR DESCRIPTION
previously the `registry` would return `undefined | EmbeddingFunction` even for built in functions such as "openai"

now it'll return the correct type for `getRegistry().get("openai")

as well as pass in the correct options type to `create`

### before
```ts
const options: {model: 'not-a-real-model'}
// this'd compile just fine, but result in runtime error
const openai: EmbeddingFunction | undefined = getRegistry().get("openai").create(options)
// this'd also compile fine
const openai: EmbeddingFunction | undefined = getRegistry().get("openai").create({MODEL: ''})
```
### after
```ts
const options: {model: 'not-a-real-model'}

const openai: OpenAIEmbeddingFunction = getRegistry().get("openai").create(options)
// Type '"not-a-real-model"' is not assignable to type '"text-embedding-ada-002" | "text-embedding-3-large" | "text-embedding-3-small" | undefined'


```