### PR TITLE
docs: addresses typos in HF embedding example docs

### DIFF
--- a/docs/src/embeddings/default_embedding_functions.md
+++ b/docs/src/embeddings/default_embedding_functions.md
@@ -193,7 +193,7 @@ from lancedb.pydantic import LanceModel, Vector
 
 model = get_registry().get("huggingface").create(name='facebook/bart-base')
 
-class TextModel(LanceModel):
+class Words(LanceModel):
     text: str = model.SourceField()
     vector: Vector(model.ndims()) = model.VectorField()
 

--- a/docs/src/embeddings/default_embedding_functions.md
+++ b/docs/src/embeddings/default_embedding_functions.md
@@ -199,7 +199,7 @@ class TextModel(LanceModel):
 
 df = pd.DataFrame({"text": ["hi hello sayonara", "goodbye world"]})
 table = db.create_table("greets", schema=Words)
-table.add()
+table.add(df)
 query = "old greeting"
 actual = table.search(query).limit(1).to_pydantic(Words)[0]
 print(actual.text)


### PR DESCRIPTION
* `table.add` requires `data` parameter on the docs page regarding use of embedding models from HF
* also changed the name of example class from `TextModel`  to `Words` since that is what is used as parameter in the `db.create_table` call
* Per https://lancedb.github.io/lancedb/python/python/#lancedb.table.Table.add