### PR TITLE
chore(nodejs): make opean optional, and apache-arrow a peer dep

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -77,9 +77,13 @@
     "version": "napi version"
   },
   "dependencies": {
-    "apache-arrow": "^15.0.0",
     "axios": "^1.7.2",
-    "openai": "^4.29.2",
     "reflect-metadata": "^0.2.2"
+  },
+  "optionalDependencies": {
+    "openai": "^4.29.2"
+  },
+  "peerDependencies": {
+    "apache-arrow": "^15.0.0"
   }
 }


### PR DESCRIPTION
fyi, this should have no breaking changes as npm is opt-out instead of opt-in when resolving dependencies

all peer and optional dependencies get installed by default, so users need to manually opt out. 

`npm i --omit optional --omit peer` 
