### PR TITLE
chore: typing for lance.connect

### DIFF
--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -15,7 +15,7 @@ import importlib.metadata
 import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, Any
 
 __version__ = importlib.metadata.version("lancedb")
 
@@ -35,7 +35,7 @@ def connect(
     host_override: Optional[str] = None,
     read_consistency_interval: Optional[timedelta] = None,
     request_thread_pool: Optional[Union[int, ThreadPoolExecutor]] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> DBConnection:
     """Connect to a LanceDB database.
 


### PR DESCRIPTION
Feel free to close if this is a distraction, but untyped keywords in lance.connect is throwing pylance errors in strict mode. 

<img width="683" alt="Screenshot 2024-07-11 at 1 21 04 PM" src="https://github.com/lancedb/lancedb/assets/33043305/fe6cd4d9-4e59-413d-87f2-aabb9ff84cc4">
