### PR TITLE
fix: infer schema from huggingface dataset

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -732,7 +732,7 @@ class AsyncConnection(object):
             fill_value = 0.0
 
         if data is not None:
-            data = _sanitize_data(
+            data, schema = _sanitize_data(
                 data,
                 schema,
                 metadata=metadata,

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -245,7 +245,7 @@ class RemoteDBConnection(DBConnection):
             schema = schema.to_arrow_schema()
 
         if data is not None:
-            data = _sanitize_data(
+            data, schema = _sanitize_data(
                 data,
                 schema,
                 metadata=None,

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -210,7 +210,7 @@ class RemoteTable(Table):
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
 
         """
-        data = _sanitize_data(
+        data, _ = _sanitize_data(
             data,
             self.schema,
             metadata=None,
@@ -337,7 +337,7 @@ class RemoteTable(Table):
         on_bad_vectors: str,
         fill_value: float,
     ):
-        data = _sanitize_data(
+        data, _ = _sanitize_data(
             new_data,
             self.schema,
             metadata=None,

--- a/python/python/tests/test_huggingface.py
+++ b/python/python/tests/test_huggingface.py
@@ -124,3 +124,17 @@ def test_bad_hf_dataset(tmp_path: Path, mock_embedding_function, hf_dataset_with
     # this should still work because we don't add the split column
     # if it already exists
     train_table.add(hf_dataset_with_split)
+
+
+def test_generator(tmp_path: Path):
+    db = lancedb.connect(tmp_path)
+
+    def gen():
+        yield {"pokemon": "bulbasaur", "type": "grass"}
+        yield {"pokemon": "squirtle", "type": "water"}
+
+    ds = datasets.Dataset.from_generator(gen)
+    tbl = db.create_table("pokemon", ds)
+
+    assert len(tbl) == 2
+    assert tbl.schema == ds.features.arrow_schema


### PR DESCRIPTION
Closes #1383

When creating a table from a HuggingFace dataset, infer the arrow schema directly