### PR TITLE
ci: fix vectordb release process

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,6 +25,43 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
+  node-linux-release-test:
+    name: node-linux (${{ matrix.config.arch}}-unknown-linux-gnu
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # - arch: x86_64
+          #   runner: ubuntu-latest
+          - arch: aarch64
+            # For successful fat LTO builds, we need a large runner to avoid OOM errors.
+            runner: warp-ubuntu-latest-arm64-4x
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # To avoid OOM errors on ARM, we create a swap file.
+      - name: Configure aarch64 build
+        if: ${{ matrix.config.arch == 'aarch64' }}
+        run: |
+          free -h
+          sudo fallocate -l 16G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          echo "/swapfile swap swap defaults 0 0" >> sudo /etc/fstab
+          # print info
+          swapon --show
+          free -h
+      - name: Build Linux Artifacts
+        run: |
+          bash ci/build_linux_artifacts.sh ${{ matrix.config.arch }}
+      # - name: Upload Linux Artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: node-native-linux-${{ matrix.config.arch }}
+      #     path: |
+      #       node/dist/lancedb-vectordb-linux*.tgz
   linux:
     name: Linux (Node ${{ matrix.node-version }})
     timeout-minutes: 30

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,43 +25,6 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
-  node-linux-release-test:
-    name: node-linux (${{ matrix.config.arch}}-unknown-linux-gnu
-    runs-on: ${{ matrix.config.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          # - arch: x86_64
-          #   runner: ubuntu-latest
-          - arch: aarch64
-            # For successful fat LTO builds, we need a large runner to avoid OOM errors.
-            runner: warp-ubuntu-latest-arm64-4x
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      # To avoid OOM errors on ARM, we create a swap file.
-      - name: Configure aarch64 build
-        if: ${{ matrix.config.arch == 'aarch64' }}
-        run: |
-          free -h
-          sudo fallocate -l 16G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          echo "/swapfile swap swap defaults 0 0" >> sudo /etc/fstab
-          # print info
-          swapon --show
-          free -h
-      - name: Build Linux Artifacts
-        run: |
-          bash ci/build_linux_artifacts.sh ${{ matrix.config.arch }}
-      # - name: Upload Linux Artifacts
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: node-native-linux-${{ matrix.config.arch }}
-      #     path: |
-      #       node/dist/lancedb-vectordb-linux*.tgz
   linux:
     name: Linux (Node ${{ matrix.node-version }})
     timeout-minutes: 30

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   node:
+    name: vectordb Typescript
     runs-on: ubuntu-latest
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
@@ -39,6 +40,7 @@ jobs:
             node/vectordb-*.tgz
 
   node-macos:
+    name: vectordb ${{ matrix.config.arch }}
     strategy:
       matrix:
         config:
@@ -69,6 +71,7 @@ jobs:
             node/dist/lancedb-vectordb-darwin*.tgz
 
   nodejs-macos:
+    name: lancedb ${{ matrix.config.arch }}
     strategy:
       matrix:
         config:
@@ -99,7 +102,7 @@ jobs:
             nodejs/dist/*.node
 
   node-linux:
-    name: node-linux (${{ matrix.config.arch}}-unknown-linux-gnu
+    name: vectordb (${{ matrix.config.arch}}-unknown-linux-gnu)
     runs-on: ${{ matrix.config.runner }}
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
@@ -139,7 +142,7 @@ jobs:
             node/dist/lancedb-vectordb-linux*.tgz
 
   nodejs-linux:
-    name: nodejs-linux (${{ matrix.config.arch}}-unknown-linux-gnu
+    name: lancedb (${{ matrix.config.arch}}-unknown-linux-gnu
     runs-on: ${{ matrix.config.runner }}
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
@@ -190,6 +193,7 @@ jobs:
             !nodejs/dist/*.node
 
   node-windows:
+    name: vectordb ${{ matrix.target }}
     runs-on: windows-2022
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
@@ -223,6 +227,7 @@ jobs:
             node/dist/lancedb-vectordb-win32*.tgz
 
   nodejs-windows:
+    name: lancedb ${{ matrix.target }}
     runs-on: windows-2022
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
@@ -256,6 +261,7 @@ jobs:
             nodejs/dist/*.node
 
   release:
+    name: vectordb NPM Publish
     needs: [node, node-macos, node-linux, node-windows]
     runs-on: ubuntu-latest
     # Only runs on tags that matches the make-release action
@@ -284,8 +290,18 @@ jobs:
           for filename in *.tgz; do
             npm publish $PUBLISH_ARGS $filename
           done
+      - name: Notify Slack Action
+        uses: ravsamhq/notify-slack-action@2.3.0
+        if: ${{ always() }}
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "{workflow} is failing"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   release-nodejs:
+    name: lancedb NPM Publish
     needs: [nodejs-macos, nodejs-linux, nodejs-windows]
     runs-on: ubuntu-latest
     # Only runs on tags that matches the make-release action
@@ -333,6 +349,15 @@ jobs:
           else
             npm publish --access public
           fi
+      - name: Notify Slack Action
+        uses: ravsamhq/notify-slack-action@2.3.0
+        if: ${{ always() }}
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "{workflow} is failing"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   update-package-lock:
     needs: [release]

--- a/ci/manylinux_node/Dockerfile
+++ b/ci/manylinux_node/Dockerfile
@@ -18,8 +18,8 @@ COPY install_protobuf.sh install_protobuf.sh
 RUN ./install_protobuf.sh ${ARCH}
 
 ENV DOCKER_USER=${DOCKER_USER}
-# Create a group and user
-RUN echo ${ARCH} && adduser --user-group --create-home --uid ${DOCKER_USER} build_user
+# Create a group and user, but only if it doesn't exist
+RUN echo ${ARCH} && id -u ${DOCKER_USER} >/dev/null 2>&1 || adduser --user-group --create-home --uid ${DOCKER_USER} build_user
 
 # We switch to the user to install Rust and Node, since those like to be 
 # installed at the user level.


### PR DESCRIPTION
* Labelled jobs `vectordb` and `lancedb` so it's clear which package they are for
* Fix permission issue in aarch64 Linux `vectordb` build that has been blocking release for two months.
* Added Slack notifications for failure of these publish jobs.