### PR TITLE
docs: add installation note about yarn

### DIFF
--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -35,6 +35,15 @@
             }
             })
             ```
+
+        !!! note "Yarn users"
+
+            Unlike other package managers, Yarn does not automatically resolve peer dependencies. If you are using Yarn, you will need to manually install 'apache-arrow':
+
+            ```shell
+            yarn add apache-arrow
+            ```
+
     === "vectordb (deprecated)"
 
         ```shell
@@ -53,6 +62,15 @@
             }
             })
             ```
+
+        !!! note "Yarn users"
+
+            Unlike other package managers, Yarn does not automatically resolve peer dependencies. If you are using Yarn, you will need to manually install 'apache-arrow':
+
+            ```shell
+            yarn add apache-arrow
+            ```
+
 === "Rust"
 
     ```shell


### PR DESCRIPTION
I noticed that setting up a simple project with [Yarn](https://yarnpkg.com/) failed because unlike others [npm, pnpm, bun], yarn does not automatically resolve peer dependencies, so i added a quick note about it in the installation guide.