### PR TITLE
docs: add missing whitespace before markdown table to fix rendering issue

### DIFF
--- a/docs/src/embeddings/default_embedding_functions.md
+++ b/docs/src/embeddings/default_embedding_functions.md
@@ -390,6 +390,7 @@ Supported parameters (to be passed in `create` method) are:
 | `query_input_type` | `str` | `"search_query"` | The type of input data to be used for the query. |
 
 Cohere supports following input types:
+
 | Input Type               | Description                          |
 |-------------------------|---------------------------------------|
 | "`search_document`"     | Used for embeddings stored in a vector|


### PR DESCRIPTION
### Fix markdown table rendering issue

This PR adds a missing whitespace before a markdown table in the documentation. This issue causes the table to not render properly in mkdocs, while it does render properly in GitHub's markdown viewer.

#### Change Details:
- Added a single line of whitespace before the markdown table to ensure proper rendering in mkdocs.

#### Note:
- I wasn't able to test this fix in the mkdocs environment, but it should be safe as it only involves adding whitespace which won't break anything.


---


Cohere supports following input types:

| Input Type               | Description                          |
|-------------------------|---------------------------------------|
| "`search_document`"     | Used for embeddings stored in a vector|
|                         | database for search use-cases.        |
| "`search_query`"        | Used for embeddings of search queries |
|                         | run against a vector DB               |
| "`semantic_similarity`" | Specifies the given text will be used |
|                         | for Semantic Textual Similarity (STS) |
| "`classification`"      | Used for embeddings passed through a  |
|                         | text classifier.                      |
| "`clustering`"          | Used for the embeddings run through a |
|                         | clustering algorithm                  |

Usage Example:
