### PR TITLE
fix: return LanceMergeInsertBuilder in overridden merge_insert method on remote table

### DIFF
--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -336,7 +336,7 @@ class RemoteTable(Table):
 
         See [`Table.merge_insert`][lancedb.table.Table.merge_insert] for more details.
         """
-        super().merge_insert(on)
+        return super().merge_insert(on)
 
     def _do_merge(
         self,


### PR DESCRIPTION
https://github.com/lancedb/lancedb/pull/1464 added an override for merge_insert but relied on implicit return statement. Client code using RemoteTable and relying on the returned LanceMergeInsertBuilder would fail with AttributeError.