### PR TITLE
Remove native.d.ts from .npmignore

### DIFF
--- a/nodejs/.npmignore
+++ b/nodejs/.npmignore
@@ -20,6 +20,5 @@ Cargo.toml
 biome.json
 build.rs
 jest.config.js
-native.d.ts
 tsconfig.json
 typedoc.json


### PR DESCRIPTION
Presently the `opts` argument to `lancedb.connect` is typed `any`, even though it shouldn't be.

<img width="560" alt="image" src="https://github.com/user-attachments/assets/5c974ce8-5a59-44a1-935d-cbb808f0ea24">

Clicking into the type definitions for the published package, it has the correct type signature:

<img width="831" alt="image" src="https://github.com/user-attachments/assets/6e39a519-13ff-4ca8-95ae-85538ac59d5d">

However, `ConnectionOptions` is imported from `native.js` (along with a number of other imports a bit further down):

<img width="384" alt="image" src="https://github.com/user-attachments/assets/10c1b055-ae78-4088-922e-2816af64c23c">

This is not otherwise an issue, except that the type definitions for `native.js` are not included in the published package:

<img width="217" alt="image" src="https://github.com/user-attachments/assets/f15cd3b6-a8de-4011-9fa2-391858da20ec">

I haven't compiled the Rust code and run the build script, but I strongly suspect that disincluding the type definitions in `.npmignore` is ultimately the root cause here.