### PR TITLE
feat: support fuzzy matching in full text search

### DIFF
--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -1426,6 +1426,7 @@ class LanceTable(Table):
         query_type: str = "auto",
         ordering_field_name: Optional[str] = None,
         fts_columns: Union[str, List[str]] = None,
+        fuzzy_fields: Optional[Dict[str, Tuple[bool, int, bool]]] = None,
     ) -> LanceQueryBuilder:
         """Create a search query to find the nearest neighbors
         of the given query vector. We currently support [vector search][search]
@@ -1505,6 +1506,7 @@ class LanceTable(Table):
             query_type,
             vector_column_name=vector_column_name,
             ordering_field_name=ordering_field_name,
+            fuzzy_fields=fuzzy_fields,
         )
 
     @classmethod


### PR DESCRIPTION
This pull request introduces support for fuzzy matching in full text search. The changes include modifications to the `search_index` function and related classes to accept and handle fuzzy matching parameters. It uses **tantivy-py's**  `FuzzyTermQuery`.

**Changes**

- Modified `search_index` function in `fts.py` to accept `fuzzy_fields `parameter.
- Updated create method in `query.py` to pass `fuzzy_fields` to the `search_index` function.
- Added `fuzzy_field`s parameter to `LanceQueryBuilder` class in `query.py`.
- Updated search method in `table.py` to accept and pass `fuzzy_fields` to the `LanceQueryBuilder`.

**Example usage**
```python
fuzzy_fields = {
    'keywords': (True, 2, True),
    'id': (False, 0, True),
    'title': (True, 2, True),
    'combined_text': (False, 2, True),
}

input = ""
fts = tbl.search(input, query_type="fts", fuzzy_fields=fuzzy_fields).limit(10).to_pandas()
```