### PR TITLE
fix: unterminated string literal on table update

### DIFF
--- a/python/python/lancedb/util.py
+++ b/python/python/lancedb/util.py
@@ -219,7 +219,7 @@ def value_to_sql(value):
 
 @value_to_sql.register(str)
 def _(value: str):
-    return f"'{value}'"
+    return f'"{value}"'
 
 
 @value_to_sql.register(bytes)

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -90,11 +90,7 @@ def test_local_join_uri_windows():
 def test_value_to_sql_string(tmp_path):
     # Make sure we can convert Python string literals to SQL strings, even if
     # they contain characters meaningful in SQL, such as ' and \.
-    values = [
-        "anthony's",
-        'a "test" string',
-        "anthony's \"favorite color\" wasn't red"
-    ]
+    values = ["anthony's", 'a "test" string', "anthony's \"favorite color\" wasn't red"]
     expected_values = [
         "'anthony''s'",
         "'a \"test\" string'",
@@ -113,5 +109,5 @@ def test_value_to_sql_string(tmp_path):
         [{"search": value, "replace": "something"} for value in values],
     )
     for value in values:
-        table.update(where=f'search = {value_to_sql(value)}', values={"replace": value})
+        table.update(where=f"search = {value_to_sql(value)}", values={"replace": value})
         assert table.to_pandas().query("search == @value")["replace"].item() == value

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -15,7 +15,7 @@ import os
 import pathlib
 
 import pytest
-from lancedb.util import get_uri_scheme, join_uri
+from lancedb.util import get_uri_scheme, join_uri, value_to_sql
 
 
 def test_normalize_uri():
@@ -84,3 +84,24 @@ def test_local_join_uri_windows():
         assert joined == str(pathlib.Path(base) / "table.lance")
         joined = join_uri(pathlib.Path(base), "table.lance")
         assert joined == pathlib.Path(base) / "table.lance"
+
+
+def test_value_to_sql_string():
+    target_ids = [
+        1,
+        "2",
+        "'3'",
+        "'",
+    ]
+    # fmt: off
+    expected_formatting = [
+        '"id = \'1\'"',
+        '"id = \'2\'"',
+        '"id = \'\'3\'\'"',
+        '"id = \'\'\'"',
+    ]
+    # fmt: on
+    for target, expected in zip(target_ids, expected_formatting):
+        where = f"id = '{target}'"
+        got = value_to_sql(where)
+        assert got == expected


### PR DESCRIPTION
resolves #1429 
(python)

```python
-    return f"'{value}'"
+    return f'"{value}"'
```