### PR TITLE
fix: can't do full text search when queryType='auto'

### DIFF
--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -164,8 +164,8 @@ describe("embedding functions", () => {
     });
 
     const db = await connect(tmpDir.name);
-    const _ = await db.createTable(
-      "test",
+    const table = await db.createTable(
+      "mock_embedding_test",
       [
         { id: 1, text: "hello" },
         { id: 2, text: "world" },
@@ -175,10 +175,12 @@ describe("embedding functions", () => {
       },
     );
 
-    getRegistry().reset();
-    const db2 = await connect(tmpDir.name);
+    await table.add([{ id: 3, text: "hello world" }]);
+    expect(await table.countRows()).toBe(3);
 
-    expect(db2.openTable("test")).rejects.toThrow(
+    getRegistry().reset();
+
+    expect(db.openTable("mock_embedding_test")).rejects.toThrow(
       `Function "mock" not found in registry`,
     );
   });

--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -164,7 +164,7 @@ describe("embedding functions", () => {
     });
 
     const db = await connect(tmpDir.name);
-    await db.createTable(
+    const _ = await db.createTable(
       "test",
       [
         { id: 1, text: "hello" },
@@ -178,9 +178,7 @@ describe("embedding functions", () => {
     getRegistry().reset();
     const db2 = await connect(tmpDir.name);
 
-    const tbl = await db2.openTable("test");
-
-    expect(tbl.add([{ id: 3, text: "hello" }])).rejects.toThrow(
+    expect(db2.openTable("test")).rejects.toThrow(
       `Function "mock" not found in registry`,
     );
   });

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -820,7 +820,7 @@ describe.each([arrow13, arrow14, arrow15, arrow16, arrow17])(
       ];
       const table = await db.createTable("test", data);
 
-      expect(table.search("hello", "vector").toArray()).rejects.toThrow(
+      expect(() => table.search("hello", "vector").toArray()).toThrow(
         "No embedding functions are defined in the table",
       );
     });

--- a/nodejs/examples/full_text_search.ts
+++ b/nodejs/examples/full_text_search.ts
@@ -49,4 +49,4 @@ let result = await tbl
 console.log(result);
 // --8<-- [end:full_text_search]
 
-console.log("SQL search: done");
+console.log("FTS search: done");

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -254,7 +254,7 @@ export class LocalConnection extends Connection {
     if (typeof nameOrOptions !== "string" && "name" in nameOrOptions) {
       const { name, data, ...options } = nameOrOptions;
 
-      return this.createTable(name, data, options);
+      return await this.createTable(name, data, options);
     }
     if (data === undefined) {
       throw new Error("data is required");

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Data, Schema, SchemaLike, TableLike } from "./arrow";
+import { Data, Schema, SchemaLike, TableLike, tableFromIPC } from "./arrow";
 import { fromTableToBuffer, makeEmptyTable } from "./arrow";
 import { EmbeddingFunctionConfig, getRegistry } from "./embedding/registry";
 import { Connection as LanceDbConnection } from "./native";
@@ -238,7 +238,10 @@ export class LocalConnection extends Connection {
       options?.indexCacheSize,
     );
 
-    return new LocalTable(innerTable);
+    const schemaBuf = await innerTable.schema();
+    const tbl = tableFromIPC(schemaBuf);
+
+    return new LocalTable(innerTable, tbl.schema);
   }
 
   async createTable(
@@ -272,7 +275,10 @@ export class LocalConnection extends Connection {
       dataStorageVersion,
     );
 
-    return new LocalTable(innerTable);
+    const schemaBuf = await innerTable.schema();
+    const tbl = tableFromIPC(schemaBuf);
+
+    return new LocalTable(innerTable, tbl.schema);
   }
 
   async createEmptyTable(
@@ -309,7 +315,10 @@ export class LocalConnection extends Connection {
       cleanseStorageOptions(options?.storageOptions),
       dataStorageVersion,
     );
-    return new LocalTable(innerTable);
+    const schemaBuf = await innerTable.schema();
+    const tbl = tableFromIPC(schemaBuf);
+
+    return new LocalTable(innerTable, tbl.schema);
   }
 
   async dropTable(name: string): Promise<void> {

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -602,18 +602,12 @@ export class LocalTable extends Table {
       });
     }
 
-    // The query type is auto or vector
-    // fall back to full text search if no embedding functions are defined and the query is a string
-    if (queryType === "auto" && getRegistry().length() === 0) {
-      return this.query().fullTextSearch(query, {
-        columns: ftsColumns,
-      });
-    }
-
     // TODO: Support multiple embedding functions
     const embeddingFunc: EmbeddingFunctionConfig | undefined =
       this.getEmbeddingFunctions().values().next().value;
     if (!embeddingFunc) {
+      // The query type is auto and string
+      // fall back to full text search if no embedding functions are defined and the query is a string
       if (queryType === "auto" && typeof query === "string") {
         return this.query().fullTextSearch(query, {
           columns: ftsColumns,

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -613,7 +613,11 @@ export class LocalTable extends Table {
           columns: ftsColumns,
         });
       }
-      throw new Error("No embedding functions are defined in the table");
+      return this.query().nearestTo(
+        Promise.reject(
+          new Error("No embedding functions are defined in the table"),
+        ),
+      );
     }
     const queryPromise = embeddingFunc.function.computeQueryEmbeddings(query);
     return this.query().nearestTo(queryPromise);

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -456,12 +456,12 @@ export abstract class Table {
 
 export class LocalTable extends Table {
   private readonly inner: _NativeTable;
-  private readonly schema_: Schema;
+  private readonly registeredEmbeddings: Map<string, EmbeddingFunctionConfig>;
 
   constructor(inner: _NativeTable, schema: Schema) {
     super();
     this.inner = inner;
-    this.schema_ = schema;
+    this.registeredEmbeddings = getRegistry().parseFunctions(schema.metadata);
   }
   get name(): string {
     return this.inner.name;
@@ -479,8 +479,7 @@ export class LocalTable extends Table {
   }
 
   private getEmbeddingFunctions(): Map<string, EmbeddingFunctionConfig> {
-    const registry = getRegistry();
-    return registry.parseFunctions(this.schema_.metadata);
+    return this.registeredEmbeddings;
   }
 
   /** Get the schema of the table. */
@@ -494,7 +493,7 @@ export class LocalTable extends Table {
     const mode = options?.mode ?? "append";
     const schema = await this.schema();
     const registry = getRegistry();
-    const functions = await registry.parseFunctions(schema.metadata);
+    const functions = registry.parseFunctions(schema.metadata);
 
     const buffer = await fromDataToBuffer(
       data,

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -612,11 +612,7 @@ export class LocalTable extends Table {
           columns: ftsColumns,
         });
       }
-      return this.query().nearestTo(
-        Promise.reject(
-          new Error("No embedding functions are defined in the table"),
-        ),
-      );
+      throw new Error("No embedding functions are defined in the table");
     }
     const queryPromise = embeddingFunc.function.computeQueryEmbeddings(query);
     return this.query().nearestTo(queryPromise);


### PR DESCRIPTION
When queryType='auto' and the query is a string,
we would check whether there are any embedding functions registered, if so, then it's a vector search with the embedding, otherwise it's full text search.

The current TypeScript implementation always register 2 embedding functions, then it breaks the check. But it won't enable the embedding functions if the schema doesn't contain the metadata "embedding_functions".

fix #1557 