### PR TITLE
docs: fix get_registry() usage

### DIFF
--- a/docs/src/embeddings/available_embedding_models/multimodal_embedding_functions/imagebind_embedding.md
+++ b/docs/src/embeddings/available_embedding_models/multimodal_embedding_functions/imagebind_embedding.md
@@ -17,7 +17,7 @@ from lancedb.pydantic import LanceModel, Vector
 from lancedb.embeddings import get_registry
 
 db = lancedb.connect(tmp_path)
-func = get_registry.get("imagebind").create()
+func = get_registry().get("imagebind").create()
 
 class ImageBindModel(LanceModel):
     text: str

--- a/docs/src/embeddings/available_embedding_models/multimodal_embedding_functions/openclip_embedding.md
+++ b/docs/src/embeddings/available_embedding_models/multimodal_embedding_functions/openclip_embedding.md
@@ -20,7 +20,7 @@ from lancedb.pydantic import LanceModel, Vector
 from lancedb.embeddings import get_registry
 
 db = lancedb.connect(tmp_path)
-func = get_registry.get("open-clip").create()
+func = get_registry().get("open-clip").create()
 
 class Images(LanceModel):
     label: str


### PR DESCRIPTION
Docs used `get_registry.get(...)` whereas what works is `get_registry().get(...)`. Fixing the two instances I found. I tested the open clip version by trying it locally in a Jupyter notebook.