### PR TITLE
fix: re-add hostOverride arg to ConnectionOptions

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -220,7 +220,8 @@ export async function connect(
     region: partOpts.region ?? defaultRegion,
     timeout: partOpts.timeout ?? defaultRequestTimeout,
     readConsistencyInterval: partOpts.readConsistencyInterval ?? undefined,
-    storageOptions: partOpts.storageOptions ?? undefined
+    storageOptions: partOpts.storageOptions ?? undefined,
+    hostOverride: partOpts.hostOverride ?? undefined
   }
   if (opts.uri.startsWith("db://")) {
     // Remote connection


### PR DESCRIPTION
Fixes issue where hostOverride was no-longer passed through to RemoteConnection