### PR TITLE
fix(python): don't cache schema, which is mutable

### DIFF
--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -43,7 +43,7 @@ class RemoteTable(Table):
     def __len__(self) -> int:
         self.count_rows(None)
 
-    @cached_property
+    @property
     def schema(self) -> pa.Schema:
         """The [Arrow Schema](https://arrow.apache.org/docs/python/api/datatypes.html#)
         of this Table


### PR DESCRIPTION
We can't cache things that are mutable, unless we have a strategy for cache invalidation. There isn't a simple way to implement that, so it's best we don't try to cache it.