### PR TITLE
fix(rust): remote SDK bugs

### DIFF
--- a/rust/lancedb/src/remote/util.rs
+++ b/rust/lancedb/src/remote/util.rs
@@ -9,7 +9,7 @@ pub fn batches_to_ipc_bytes(batches: impl RecordBatchReader) -> Result<Vec<u8>> 
     let buf = Vec::with_capacity(WRITE_BUF_SIZE);
     let mut buf = Cursor::new(buf);
     {
-        let mut writer = arrow_ipc::writer::FileWriter::try_new(&mut buf, &batches.schema())?;
+        let mut writer = arrow_ipc::writer::StreamWriter::try_new(&mut buf, &batches.schema())?;
 
         for batch in batches {
             let batch = batch?;


### PR DESCRIPTION
A few bugs uncovered by integration tests:

* We didn't prepend `/v1` to the Table endpoint URLs
* `/create_index` takes `metric_type` not `distance_type`. (This is also an error in the OpenAPI docs.)
* `/create_index` expects the `metric_type` parameter to always be lowercase.
* We were writing an IPC file message when we were supposed to send an IPC stream message.