### PR TITLE
fix(python): remove dependency on retry package

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,6 @@ dependencies = [
     "deprecation",
     "pylance==0.18.2",
     "requests>=2.31.0",
-    "retry>=0.9.2",
     "tqdm>=4.27.0",
     "pydantic>=1.10",
     "attrs>=21.3.0",

--- a/python/python/lancedb/embeddings/utils.py
+++ b/python/python/lancedb/embeddings/utils.py
@@ -42,10 +42,13 @@ def retry(tries=10, delay=1, max_delay=30, backoff=3, jitter=1):
                     if i + 1 == tries:
                         raise
                     else:
-                        sleep = min(delay * (backoff ** i) + jitter, max_delay)
+                        sleep = min(delay * (backoff**i) + jitter, max_delay)
                         time.sleep(sleep)
+
         return wrapped
+
     return wrapper
+
 
 pd = safe_import_pandas()
 

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -11,6 +11,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from typing import List, Union
+from unittest.mock import MagicMock, patch
 
 import lance
 import lancedb
@@ -25,6 +26,7 @@ from lancedb.embeddings import (
 )
 from lancedb.embeddings.base import TextEmbeddingFunction
 from lancedb.embeddings.registry import get_registry, register
+from lancedb.embeddings.utils import retry
 from lancedb.pydantic import LanceModel, Vector
 
 
@@ -225,3 +227,11 @@ def test_embedding_function_safe_model_dump(embedding_type):
                 f"{embedding_type}: Private attribute '{key}' "
                 f"is present in dumped model"
             )
+
+@patch('time.sleep')
+def test_retry(mock_sleep):
+    test_function = MagicMock(side_effect=[Exception] * 9 + ['result'])
+    test_function = retry()(test_function)
+    result = test_function()
+    assert mock_sleep.call_count == 9
+    assert result == 'result'

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -228,10 +228,11 @@ def test_embedding_function_safe_model_dump(embedding_type):
                 f"is present in dumped model"
             )
 
-@patch('time.sleep')
+
+@patch("time.sleep")
 def test_retry(mock_sleep):
-    test_function = MagicMock(side_effect=[Exception] * 9 + ['result'])
+    test_function = MagicMock(side_effect=[Exception] * 9 + ["result"])
     test_function = retry()(test_function)
     result = test_function()
     assert mock_sleep.call_count == 9
-    assert result == 'result'
+    assert result == "result"


### PR DESCRIPTION
## user story

fixes https://github.com/lancedb/lancedb/issues/1480

https://github.com/invl/retry has not had an update in 8 years, one if its sub-dependencies via requirements.txt (https://github.com/pytest-dev/py) is no longer maintained and has a high severity vulnerability (CVE-2022-42969).

retry is only used for a single function in the python codebase for a deprecated helper function `with_embeddings`, which was created for an older tutorial (https://github.com/lancedb/lancedb/pull/12) [but is now deprecated](https://lancedb.github.io/lancedb/embeddings/legacy/).

## changes

i backported a limited range of functionality of the `@retry()` decorator directly into lancedb so that we no longer have a dependency to the `retry` package.

## tests

```
/Users/james/src/lancedb/python $ ruff check .
All checks passed!
/Users/james/src/lancedb/python $ pytest python/tests/test_embeddings.py
python/tests/test_embeddings.py .......s....                                                                                                                        [100%]
================================================================ 11 passed, 1 skipped, 2 warnings in 7.08s ================================================================
```