### PR TITLE
perf: eliminate iop in refresh

### DIFF
--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -54,9 +54,7 @@ impl DatasetRef {
                 last_consistency_check,
                 ..
             } => {
-                *dataset = dataset
-                    .checkout_version(dataset.latest_version_id().await?)
-                    .await?;
+                dataset.checkout_latest().await?;
                 last_consistency_check.replace(Instant::now());
             }
             Self::TimeTravel { dataset, version } => {


### PR DESCRIPTION
Closes #1741

If we checkout a version, we need to make a `HEAD` request to get the size of the manifest. The new `checkout_latest()` code path can skip this IOP. This makes the refresh slightly faster.