### PR TITLE
fix(python): add urllib3>=2.0.0 python dependency constraint

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "packaging",
     "cachetools",
     "overrides>=0.7",
+    "urllib3>=2.0.0"
 ]
 description = "lancedb"
 authors = [{ name = "LanceDB Devs", email = "dev@lancedb.com" }]


### PR DESCRIPTION
fixes https://github.com/lancedb/lancedb/issues/933