### PR TITLE
fix: index_stats works for FTS indices

### DIFF
--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -119,6 +119,7 @@ pub enum IndexType {
     #[serde(alias = "LABEL_LIST")]
     LabelList,
     // FTS
+    #[serde(alias = "INVERTED", alias = "Inverted")]
     FTS,
 }
 

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -3123,6 +3123,12 @@ mod tests {
         assert_eq!(index.index_type, crate::index::IndexType::FTS);
         assert_eq!(index.columns, vec!["text".to_string()]);
         assert_eq!(index.name, "text_idx");
+
+        let stats = table.index_stats("text_idx").await.unwrap().unwrap();
+        assert_eq!(stats.num_indexed_rows, num_rows);
+        assert_eq!(stats.num_unindexed_rows, 0);
+        assert_eq!(stats.index_type, crate::index::IndexType::FTS);
+        assert_eq!(stats.distance_type, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
When running `index_stats()` for an FTS index, users would get the deserialization error:

```
InvalidInput { message: "error deserializing index statistics: unknown variant `Inverted`, expected one of `IvfPq`, `IvfHnswPq`, `IvfHnswSq`, `BTree`, `Bitmap`, `LabelList`, `FTS` at line 1 column 24" }
```