### PR TITLE
fix(rust): open_table embedding_registry propagation

### DIFF
--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -1077,6 +1077,7 @@ impl ConnectionInternal for Database {
 
     async fn do_open_table(&self, mut options: OpenTableBuilder) -> Result<Table> {
         let table_uri = self.table_uri(&options.name)?;
+        let embedding_registry = self.embedding_registry.clone();
 
         // Inherit storage options from the connection
         let storage_options = options
@@ -1113,7 +1114,7 @@ impl ConnectionInternal for Database {
             )
             .await?,
         );
-        Ok(Table::new(native_table))
+        Ok(Table::new_with_embedding_registry(native_table, embedding_registry))
     }
 
     async fn rename_table(&self, _old_name: &str, _new_name: &str) -> Result<()> {


### PR DESCRIPTION
If a table exists already, embedding_registry is not propagated to it, so code like this:
```rust
        let embedder = Arc::new(FastEmbedder::new()?);
        connection.embedding_registry()
            .register(embedder.name(), embedder.clone())?;
        
        let table = connection
            .create_empty_table(table_name, schema.clone())
            .add_embedding(EmbeddingDefinition::new(
                "content",
                embedder.name(),
                Some("embeddings"),
            ))?
            .mode(
                CreateTableMode::ExistOk(
                    Box::new(|builder: OpenTableBuilder| {
                        println!("Table {} exists, opening.", table_name.to_string());
                        builder
                    })
                )
            )
            .execute()
            .await?;
```
produces such error
`Error: Embedding function 'fastembed' was not found. : No embedding function found in the connection's embedding_registry`