### PR TITLE
chore: impl Debug & Clone for Index params

### DIFF
--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -29,6 +29,7 @@ pub mod scalar;
 pub mod vector;
 
 /// Supported index types.
+#[derive(Debug, Clone)]
 pub enum Index {
     Auto,
     /// A `BTree` index is an sorted index on scalar columns.


### PR DESCRIPTION
we don't really need these trait in lancedb, but all fields in `Index` implement the 2 traits, so do it for possibility to use `Index` somewhere