### PR TITLE
feat: flexible null handling and insert subschemas in Python

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -104,7 +104,6 @@ jobs:
         OPENAI_BASE_URL: http://0.0.0.0:8000
       run: |
         python ci/mock_openai.py &
-        ss -ltnp | grep :8000
         cd nodejs/examples
         npm test
   macos:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ rust-version = "1.80.0" # TODO: lower this once we upgrade Lance again.
 [workspace.dependencies]
 lance = { "version" = "=0.19.2", "features" = [
     "dynamodb",
-], git = "https://github.com/lancedb/lance.git", tag = "v0.19.2" }
-lance-index = { "version" = "=0.19.2", git = "https://github.com/lancedb/lance.git", tag = "v0.19.2" }
-lance-linalg = { "version" = "=0.19.2", git = "https://github.com/lancedb/lance.git", tag = "v0.19.2" }
-lance-table = { "version" = "=0.19.2", git = "https://github.com/lancedb/lance.git", tag = "v0.19.2" }
-lance-testing = { "version" = "=0.19.2", git = "https://github.com/lancedb/lance.git", tag = "v0.19.2" }
-lance-datafusion = { "version" = "=0.19.2", git = "https://github.com/lancedb/lance.git", tag = "v0.19.2" }
-lance-encoding = { "version" = "=0.19.2", git = "https://github.com/lancedb/lance.git", tag = "v0.19.2" }
+]}
+lance-index = "=0.19.2"
+lance-linalg = "=0.19.2"
+lance-table = "=0.19.2"
+lance-testing = "=0.19.2"
+lance-datafusion = "=0.19.2"
+lance-encoding = "=0.19.2"
 # Note that this one does not include pyarrow
 arrow = { version = "52.2", optional = false }
 arrow-array = "52.2"

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -790,6 +790,27 @@ Use the `drop_table()` method on the database to remove a table.
       This permanently removes the table and is not recoverable, unlike deleting rows.
       If the table does not exist an exception is raised.
 
+## Handling bad vectors
+
+In LanceDB Python, you can use the `on_bad_vectors` parameter to choose how
+invalid vector values are handled. Invalid vectors are vectors that are not valid
+because:
+
+1. They are the wrong dimension
+2. They contain NaN values
+3. They are null but are on a non-nullable field
+
+By default, LanceDB will raise an error if it encounters a bad vector. You can
+also choose one of the following options:
+
+* `drop`: Ignore rows with bad vectors
+* `fill`: Replace bad values (NaNs) or missing values (too few dimensions) with
+    the fill value specified in the `fill_value` parameter. An input like
+    `[1.0, NaN, 3.0]` will be replaced with `[1.0, 0.0, 3.0]` if `fill_value=0.0`.
+* `null`: Replace bad vectors with null (only works if the column is nullable).
+    A bad vector `[1.0, NaN, 3.0]` will be replaced with `null` if the column is
+    nullable. If the vector column is non-nullable, then bad vectors will cause an
+    error
 
 ## Consistency
 

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -910,7 +910,7 @@ function validateSchemaEmbeddings(
   }
 
   if (missingEmbeddingFields.length > 0 && embeddings === undefined) {
-    throw new Error(
+    console.warn(
       `Table has embeddings: "${missingEmbeddingFields
         .map((f) => f.name)
         .join(",")}", but no embedding function was provided`,

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -910,7 +910,7 @@ function validateSchemaEmbeddings(
   }
 
   if (missingEmbeddingFields.length > 0 && embeddings === undefined) {
-    console.warn(
+    throw new Error(
       `Table has embeddings: "${missingEmbeddingFields
         .map((f) => f.name)
         .join(",")}", but no embedding function was provided`,

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2243,7 +2243,7 @@ def _sanitize_vector_column(
                 data, fill_value, on_bad_vectors, vec_arr, vector_column_name
             )
     else:
-        if pc.any(pc.is_null(vec_arr.values, nan_is_null=True)).as_py():
+        if pc.any(pc.is_nan(vec_arr.values)).as_py():
             data = _sanitize_nans(
                 data, fill_value, on_bad_vectors, vec_arr, vector_column_name
             )

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -90,7 +90,7 @@ def test_embedding_with_bad_results(tmp_path):
             self, texts: Union[List[str], np.ndarray]
         ) -> list[Union[np.array, None]]:
             return [
-                None if i % 2 == 0 else np.random.randn(self.ndims())
+                [np.NAN] * 128 if i % 2 == 0 else np.random.randn(self.ndims())
                 for i in range(len(texts))
             ]
 

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -81,23 +81,23 @@ def test_embedding_function(tmp_path):
 
 
 def test_embedding_with_bad_results(tmp_path):
-    @register("mock-embedding")
-    class MockEmbeddingFunction(TextEmbeddingFunction):
+    @register("null-embedding")
+    class NullEmbeddingFunction(TextEmbeddingFunction):
         def ndims(self):
             return 128
 
         def generate_embeddings(
             self, texts: Union[List[str], np.ndarray]
         ) -> list[Union[np.array, None]]:
-            # Return NaN to produce bad vectors
+            # Return None, which is bad if field is non-nullable
             return [
-                [np.NAN] * 128 if i % 2 == 0 else np.random.randn(self.ndims())
+                None if i % 2 == 0 else np.random.randn(self.ndims())
                 for i in range(len(texts))
             ]
 
     db = lancedb.connect(tmp_path)
     registry = EmbeddingFunctionRegistry.get_instance()
-    model = registry.get("mock-embedding").create()
+    model = registry.get("null-embedding").create()
 
     class Schema(LanceModel):
         text: str = model.SourceField()
@@ -116,6 +116,24 @@ def test_embedding_with_bad_results(tmp_path):
     df = table.to_pandas()
     assert len(table) == 1
     assert df.iloc[0]["text"] == "bar"
+
+    @register("nan-embedding")
+    class NanEmbeddingFunction(TextEmbeddingFunction):
+        def ndims(self):
+            return 128
+
+        def generate_embeddings(
+            self, texts: Union[List[str], np.ndarray]
+        ) -> list[Union[np.array, None]]:
+            # Return NaN to produce bad vectors
+            return [
+                [np.NAN] * 128 if i % 2 == 0 else np.random.randn(self.ndims())
+                for i in range(len(texts))
+            ]
+
+    db = lancedb.connect(tmp_path)
+    registry = EmbeddingFunctionRegistry.get_instance()
+    model = registry.get("nan-embedding").create()
 
     table = db.create_table("test2", schema=Schema, mode="overwrite")
     table.alter_columns(dict(path="vector", nullable=True))

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -332,7 +332,7 @@ def test_add_nullability(tmp_path):
         schema=nullable_schema,
     )
     # We can't add nullable schema if it contains nulls
-    with pytest.raises(Exception, match="Invalid user input"):
+    with pytest.raises(Exception, match="Vector column vector has NaNs"):
         table.add(data)
 
     # But we can make it nullable


### PR DESCRIPTION
* Test that we can insert subschemas (omit nullable columns) in Python.
    * More work is needed to support this in Node. See: https://github.com/lancedb/lancedb/issues/1832
* Test that we can insert data with nullable schema but no nulls in non-nullable schema.
* Add `"null"` option for `on_bad_vectors` where we fill with null if the vector is bad.
* Make null values not considered bad if the field itself is nullable.
