### PR TITLE
ci: fix arm windows release build

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -330,6 +330,10 @@ jobs:
           7z x node.zip
           Move-Item -Path "node-v22.11.0-win-arm64" -Destination "C:\node"
           Add-Content $env:GITHUB_PATH "C:\node"
+      - name: Install npm dependencies
+        run: |
+          cd node
+          npm ci
       - name: Build Windows native node modules
         run: .\ci\build_windows_artifacts.ps1 aarch64-pc-windows-msvc
       - name: Upload Windows ARM64 Artifacts

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -199,7 +199,7 @@ jobs:
     name: vectordb ${{ matrix.target }}
     runs-on: windows-2022
     # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       fail-fast: false
       matrix:
@@ -347,7 +347,7 @@ jobs:
     name: lancedb ${{ matrix.target }}
     runs-on: windows-2022
     # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       fail-fast: false
       matrix:
@@ -380,7 +380,7 @@ jobs:
   nodejs-windows-arm64:
     name: lancedb win32-arm64-msvc
     runs-on: windows-4x-arm
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
       - name: Install Git

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -323,6 +323,13 @@ jobs:
       - name: Add Protoc to PATH
         run: Add-Content $env:GITHUB_PATH "C:\protoc\bin"
         shell: powershell
+      - name: Install node and npm
+        shell: powershell
+        run: |
+          Invoke-WebRequest -Uri "https://nodejs.org/dist/v22.11.0/node-v22.11.0-win-arm64.zip" -OutFile "node.zip"
+          7z x node.zip
+          Move-Item -Path "node-v22.11.0-win-arm64" -Destination "C:\node"
+          Add-Content $env:GITHUB_PATH "C:\node"
       - name: Build Windows native node modules
         run: .\ci\build_windows_artifacts.ps1 aarch64-pc-windows-msvc
       - name: Upload Windows ARM64 Artifacts

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -195,39 +195,39 @@ jobs:
   #           nodejs/dist/*
   #           !nodejs/dist/*.node
 
-  # node-windows:
-  #   name: vectordb ${{ matrix.target }}
-  #   runs-on: windows-2022
-  #   # Only runs on tags that matches the make-release action
-  #   if: startsWith(github.ref, 'refs/tags/v')
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       target: [x86_64-pc-windows-msvc]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: Install Protoc v21.12
-  #       working-directory: C:\
-  #       run: |
-  #         New-Item -Path 'C:\protoc' -ItemType Directory
-  #         Set-Location C:\protoc
-  #         Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
-  #         7z x protoc.zip
-  #         Add-Content $env:GITHUB_PATH "C:\protoc\bin"
-  #       shell: powershell
-  #     - name: Install npm dependencies
-  #       run: |
-  #         cd node
-  #         npm ci
-  #     - name: Build Windows native node modules
-  #       run: .\ci\build_windows_artifacts.ps1 ${{ matrix.target }}
-  #     - name: Upload Windows Artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: node-native-windows
-  #         path: |
-  #           node/dist/lancedb-vectordb-win32*.tgz
+  node-windows:
+    name: vectordb ${{ matrix.target }}
+    runs-on: windows-2022
+    # Only runs on tags that matches the make-release action
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-pc-windows-msvc]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Protoc v21.12
+        working-directory: C:\
+        run: |
+          New-Item -Path 'C:\protoc' -ItemType Directory
+          Set-Location C:\protoc
+          Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
+          7z x protoc.zip
+          Add-Content $env:GITHUB_PATH "C:\protoc\bin"
+        shell: powershell
+      - name: Install npm dependencies
+        run: |
+          cd node
+          npm ci
+      - name: Build Windows native node modules
+        run: .\ci\build_windows_artifacts.ps1 ${{ matrix.target }}
+      - name: Upload Windows Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-native-windows
+          path: |
+            node/dist/lancedb-vectordb-win32*.tgz
 
   node-windows-arm64:
     name: vectordb win32-arm64-msvc
@@ -343,132 +343,143 @@ jobs:
           path: |
             node/dist/*.node
 
-  # nodejs-windows:
-  #   name: lancedb ${{ matrix.target }}
-  #   runs-on: windows-2022
-  #   # Only runs on tags that matches the make-release action
-  #   if: startsWith(github.ref, 'refs/tags/v')
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       target: [x86_64-pc-windows-msvc]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: Install Protoc v21.12
-  #       working-directory: C:\
-  #       run: |
-  #         New-Item -Path 'C:\protoc' -ItemType Directory
-  #         Set-Location C:\protoc
-  #         Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
-  #         7z x protoc.zip
-  #         Add-Content $env:GITHUB_PATH "C:\protoc\bin"
-  #       shell: powershell
-  #     - name: Install npm dependencies
-  #       run: |
-  #         cd nodejs
-  #         npm ci
-  #     - name: Build Windows native node modules
-  #       run: .\ci\build_windows_artifacts_nodejs.ps1 ${{ matrix.target }}
-  #     - name: Upload Windows Artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: nodejs-native-windows
-  #         path: |
-  #           nodejs/dist/*.node
+  nodejs-windows:
+    name: lancedb ${{ matrix.target }}
+    runs-on: windows-2022
+    # Only runs on tags that matches the make-release action
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-pc-windows-msvc]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Protoc v21.12
+        working-directory: C:\
+        run: |
+          New-Item -Path 'C:\protoc' -ItemType Directory
+          Set-Location C:\protoc
+          Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
+          7z x protoc.zip
+          Add-Content $env:GITHUB_PATH "C:\protoc\bin"
+        shell: powershell
+      - name: Install npm dependencies
+        run: |
+          cd nodejs
+          npm ci
+      - name: Build Windows native node modules
+        run: .\ci\build_windows_artifacts_nodejs.ps1 ${{ matrix.target }}
+      - name: Upload Windows Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nodejs-native-windows
+          path: |
+            nodejs/dist/*.node
 
-  # nodejs-windows-arm64:
-  #   name: lancedb win32-arm64-msvc
-  #   runs-on: windows-4x-arm
-  #   if: startsWith(github.ref, 'refs/tags/v')
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Install Git
-  #       run: |
-  #         Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.44.0.windows.1/Git-2.44.0-64-bit.exe" -OutFile "git-installer.exe"
-  #         Start-Process -FilePath "git-installer.exe" -ArgumentList "/VERYSILENT", "/NORESTART" -Wait
-  #       shell: powershell
-  #     - name: Add Git to PATH
-  #       run: |
-  #         Add-Content $env:GITHUB_PATH "C:\Program Files\Git\bin"
-  #         $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-  #       shell: powershell
-  #     - name: Configure Git symlinks
-  #       run: git config --global core.symlinks true
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.13"
-  #     - name: Install Visual Studio Build Tools
-  #       run: |
-  #         Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile "vs_buildtools.exe"
-  #         Start-Process -FilePath "vs_buildtools.exe" -ArgumentList "--quiet", "--wait", "--norestart", "--nocache", `
-  #           "--installPath", "C:\BuildTools", `
-  #           "--add", "Microsoft.VisualStudio.Component.VC.Tools.ARM64", `
-  #           "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", `
-  #           "--add", "Microsoft.VisualStudio.Component.Windows11SDK.22621", `
-  #           "--add", "Microsoft.VisualStudio.Component.VC.ATL", `
-  #           "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC", `
-  #           "--add", "Microsoft.VisualStudio.Component.VC.Llvm.Clang" -Wait
-  #       shell: powershell
-  #     - name: Add Visual Studio Build Tools to PATH
-  #       run: |
-  #         $vsPath = "C:\BuildTools\VC\Tools\MSVC"
-  #         $latestVersion = (Get-ChildItem $vsPath | Sort-Object {[version]$_.Name} -Descending)[0].Name
-  #         Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\arm64"
-  #         Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\x64"
-  #         Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\arm64"
-  #         Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64"
-  #         Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+  nodejs-windows-arm64:
+    name: lancedb win32-arm64-msvc
+    runs-on: windows-4x-arm
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Git
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.44.0.windows.1/Git-2.44.0-64-bit.exe" -OutFile "git-installer.exe"
+          Start-Process -FilePath "git-installer.exe" -ArgumentList "/VERYSILENT", "/NORESTART" -Wait
+        shell: powershell
+      - name: Add Git to PATH
+        run: |
+          Add-Content $env:GITHUB_PATH "C:\Program Files\Git\bin"
+          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+        shell: powershell
+      - name: Configure Git symlinks
+        run: git config --global core.symlinks true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Visual Studio Build Tools
+        run: |
+          Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile "vs_buildtools.exe"
+          Start-Process -FilePath "vs_buildtools.exe" -ArgumentList "--quiet", "--wait", "--norestart", "--nocache", `
+            "--installPath", "C:\BuildTools", `
+            "--add", "Microsoft.VisualStudio.Component.VC.Tools.ARM64", `
+            "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", `
+            "--add", "Microsoft.VisualStudio.Component.Windows11SDK.22621", `
+            "--add", "Microsoft.VisualStudio.Component.VC.ATL", `
+            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC", `
+            "--add", "Microsoft.VisualStudio.Component.VC.Llvm.Clang" -Wait
+        shell: powershell
+      - name: Add Visual Studio Build Tools to PATH
+        run: |
+          $vsPath = "C:\BuildTools\VC\Tools\MSVC"
+          $latestVersion = (Get-ChildItem $vsPath | Sort-Object {[version]$_.Name} -Descending)[0].Name
+          Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\arm64"
+          Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\x64"
+          Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\arm64"
+          Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64"
+          Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\Llvm\x64\bin"
 
-  #         $env:LIB = ""
-  #         Add-Content $env:GITHUB_ENV "LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\arm64;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\arm64"
-  #       shell: powershell
-  #     - name: Install Rust
-  #       run: |
-  #         Invoke-WebRequest https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
-  #         .\rustup-init.exe -y --default-host aarch64-pc-windows-msvc
-  #       shell: powershell
-  #     - name: Add Rust to PATH
-  #       run: |
-  #         Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
-  #       shell: powershell
+          $env:LIB = ""
+          Add-Content $env:GITHUB_ENV "LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\arm64;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\arm64"
+        shell: powershell
+      - name: Install Rust
+        run: |
+          Invoke-WebRequest https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+          .\rustup-init.exe -y --default-host aarch64-pc-windows-msvc
+        shell: powershell
+      - name: Add Rust to PATH
+        run: |
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
+        shell: powershell
 
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         workspaces: rust
-  #     - name: Install 7-Zip ARM
-  #       run: |
-  #         New-Item -Path 'C:\7zip' -ItemType Directory
-  #         Invoke-WebRequest https://7-zip.org/a/7z2408-arm64.exe -OutFile C:\7zip\7z-installer.exe
-  #         Start-Process -FilePath C:\7zip\7z-installer.exe -ArgumentList '/S' -Wait
-  #       shell: powershell
-  #     - name: Add 7-Zip to PATH
-  #       run: Add-Content $env:GITHUB_PATH "C:\Program Files\7-Zip"
-  #       shell: powershell
-  #     - name: Install Protoc v21.12
-  #       working-directory: C:\
-  #       run: |
-  #         if (Test-Path 'C:\protoc') {
-  #             Write-Host "Protoc directory exists, skipping installation"
-  #             return
-  #         }
-  #         New-Item -Path 'C:\protoc' -ItemType Directory
-  #         Set-Location C:\protoc
-  #         Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
-  #         & 'C:\Program Files\7-Zip\7z.exe' x protoc.zip
-  #       shell: powershell
-  #     - name: Add Protoc to PATH
-  #       run: Add-Content $env:GITHUB_PATH "C:\protoc\bin"
-  #       shell: powershell
-  #     - name: Build Windows native node modules
-  #       run: .\ci\build_windows_artifacts_nodejs.ps1 aarch64-pc-windows-msvc
-  #     - name: Upload Windows ARM64 Artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: nodejs-native-windows-arm64
-  #         path: |
-  #           nodejs/dist/*.node
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: Install 7-Zip ARM
+        run: |
+          New-Item -Path 'C:\7zip' -ItemType Directory
+          Invoke-WebRequest https://7-zip.org/a/7z2408-arm64.exe -OutFile C:\7zip\7z-installer.exe
+          Start-Process -FilePath C:\7zip\7z-installer.exe -ArgumentList '/S' -Wait
+        shell: powershell
+      - name: Add 7-Zip to PATH
+        run: Add-Content $env:GITHUB_PATH "C:\Program Files\7-Zip"
+        shell: powershell
+      - name: Install Protoc v21.12
+        working-directory: C:\
+        run: |
+          if (Test-Path 'C:\protoc') {
+              Write-Host "Protoc directory exists, skipping installation"
+              return
+          }
+          New-Item -Path 'C:\protoc' -ItemType Directory
+          Set-Location C:\protoc
+          Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
+          & 'C:\Program Files\7-Zip\7z.exe' x protoc.zip
+        shell: powershell
+      - name: Add Protoc to PATH
+        run: Add-Content $env:GITHUB_PATH "C:\protoc\bin"
+        shell: powershell
+      - name: Install node and npm
+        shell: powershell
+        run: |
+          Invoke-WebRequest -Uri "https://nodejs.org/dist/v22.11.0/node-v22.11.0-win-arm64.zip" -OutFile "node.zip"
+          7z x node.zip
+          Move-Item -Path "node-v22.11.0-win-arm64" -Destination "C:\node"
+          Add-Content $env:GITHUB_PATH "C:\node"
+      - name: Install npm dependencies
+        run: |
+          cd node
+          npm ci
+      - name: Build Windows native node modules
+        run: .\ci\build_windows_artifacts_nodejs.ps1 aarch64-pc-windows-msvc
+      - name: Upload Windows ARM64 Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nodejs-native-windows-arm64
+          path: |
+            nodejs/dist/*.node
 
   # release:
   #   name: vectordb NPM Publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,235 +1,238 @@
 name: NPM Publish
 
 on:
-  push:
-    tags:
-      - "v*"
+  pull_request:
+    paths:
+      - .github/workflows/npm-publish.yml
+  # push:
+  #   tags:
+  #     - "v*"
 
 jobs:
-  node:
-    name: vectordb Typescript
-    runs-on: ubuntu-latest
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    defaults:
-      run:
-        shell: bash
-        working-directory: node
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20
-          cache: "npm"
-          cache-dependency-path: node/package-lock.json
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y protobuf-compiler libssl-dev
-      - name: Build
-        run: |
-          npm ci
-          npm run tsc
-          npm pack
-      - name: Upload Linux Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-package
-          path: |
-            node/vectordb-*.tgz
+  # node:
+  #   name: vectordb Typescript
+  #   runs-on: ubuntu-latest
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: node
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 20
+  #         cache: "npm"
+  #         cache-dependency-path: node/package-lock.json
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt update
+  #         sudo apt install -y protobuf-compiler libssl-dev
+  #     - name: Build
+  #       run: |
+  #         npm ci
+  #         npm run tsc
+  #         npm pack
+  #     - name: Upload Linux Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: node-package
+  #         path: |
+  #           node/vectordb-*.tgz
 
-  node-macos:
-    name: vectordb ${{ matrix.config.arch }}
-    strategy:
-      matrix:
-        config:
-          - arch: x86_64-apple-darwin
-            runner: macos-13
-          - arch: aarch64-apple-darwin
-            # xlarge is implicitly arm64.
-            runner: macos-14
-    runs-on: ${{ matrix.config.runner }}
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: brew install protobuf
-      - name: Install npm dependencies
-        run: |
-          cd node
-          npm ci
-      - name: Build MacOS native node modules
-        run: bash ci/build_macos_artifacts.sh ${{ matrix.config.arch }}
-      - name: Upload Darwin Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-native-darwin-${{ matrix.config.arch }}
-          path: |
-            node/dist/lancedb-vectordb-darwin*.tgz
+  # node-macos:
+  #   name: vectordb ${{ matrix.config.arch }}
+  #   strategy:
+  #     matrix:
+  #       config:
+  #         - arch: x86_64-apple-darwin
+  #           runner: macos-13
+  #         - arch: aarch64-apple-darwin
+  #           # xlarge is implicitly arm64.
+  #           runner: macos-14
+  #   runs-on: ${{ matrix.config.runner }}
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Install system dependencies
+  #       run: brew install protobuf
+  #     - name: Install npm dependencies
+  #       run: |
+  #         cd node
+  #         npm ci
+  #     - name: Build MacOS native node modules
+  #       run: bash ci/build_macos_artifacts.sh ${{ matrix.config.arch }}
+  #     - name: Upload Darwin Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: node-native-darwin-${{ matrix.config.arch }}
+  #         path: |
+  #           node/dist/lancedb-vectordb-darwin*.tgz
 
-  nodejs-macos:
-    name: lancedb ${{ matrix.config.arch }}
-    strategy:
-      matrix:
-        config:
-          - arch: x86_64-apple-darwin
-            runner: macos-13
-          - arch: aarch64-apple-darwin
-            # xlarge is implicitly arm64.
-            runner: macos-14
-    runs-on: ${{ matrix.config.runner }}
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: brew install protobuf
-      - name: Install npm dependencies
-        run: |
-          cd nodejs
-          npm ci
-      - name: Build MacOS native nodejs modules
-        run: bash ci/build_macos_artifacts_nodejs.sh ${{ matrix.config.arch }}
-      - name: Upload Darwin Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: nodejs-native-darwin-${{ matrix.config.arch }}
-          path: |
-            nodejs/dist/*.node
+  # nodejs-macos:
+  #   name: lancedb ${{ matrix.config.arch }}
+  #   strategy:
+  #     matrix:
+  #       config:
+  #         - arch: x86_64-apple-darwin
+  #           runner: macos-13
+  #         - arch: aarch64-apple-darwin
+  #           # xlarge is implicitly arm64.
+  #           runner: macos-14
+  #   runs-on: ${{ matrix.config.runner }}
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Install system dependencies
+  #       run: brew install protobuf
+  #     - name: Install npm dependencies
+  #       run: |
+  #         cd nodejs
+  #         npm ci
+  #     - name: Build MacOS native nodejs modules
+  #       run: bash ci/build_macos_artifacts_nodejs.sh ${{ matrix.config.arch }}
+  #     - name: Upload Darwin Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: nodejs-native-darwin-${{ matrix.config.arch }}
+  #         path: |
+  #           nodejs/dist/*.node
 
-  node-linux:
-    name: vectordb (${{ matrix.config.arch}}-unknown-linux-gnu)
-    runs-on: ${{ matrix.config.runner }}
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - arch: x86_64
-            runner: ubuntu-latest
-          - arch: aarch64
-            # For successful fat LTO builds, we need a large runner to avoid OOM errors.
-            runner: warp-ubuntu-latest-arm64-4x
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      # To avoid OOM errors on ARM, we create a swap file.
-      - name: Configure aarch64 build
-        if: ${{ matrix.config.arch == 'aarch64' }}
-        run: |
-          free -h
-          sudo fallocate -l 16G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          echo "/swapfile swap swap defaults 0 0" >> sudo /etc/fstab
-          # print info
-          swapon --show
-          free -h
-      - name: Build Linux Artifacts
-        run: |
-          bash ci/build_linux_artifacts.sh ${{ matrix.config.arch }}
-      - name: Upload Linux Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-native-linux-${{ matrix.config.arch }}
-          path: |
-            node/dist/lancedb-vectordb-linux*.tgz
+  # node-linux:
+  #   name: vectordb (${{ matrix.config.arch}}-unknown-linux-gnu)
+  #   runs-on: ${{ matrix.config.runner }}
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       config:
+  #         - arch: x86_64
+  #           runner: ubuntu-latest
+  #         - arch: aarch64
+  #           # For successful fat LTO builds, we need a large runner to avoid OOM errors.
+  #           runner: warp-ubuntu-latest-arm64-4x
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     # To avoid OOM errors on ARM, we create a swap file.
+  #     - name: Configure aarch64 build
+  #       if: ${{ matrix.config.arch == 'aarch64' }}
+  #       run: |
+  #         free -h
+  #         sudo fallocate -l 16G /swapfile
+  #         sudo chmod 600 /swapfile
+  #         sudo mkswap /swapfile
+  #         sudo swapon /swapfile
+  #         echo "/swapfile swap swap defaults 0 0" >> sudo /etc/fstab
+  #         # print info
+  #         swapon --show
+  #         free -h
+  #     - name: Build Linux Artifacts
+  #       run: |
+  #         bash ci/build_linux_artifacts.sh ${{ matrix.config.arch }}
+  #     - name: Upload Linux Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: node-native-linux-${{ matrix.config.arch }}
+  #         path: |
+  #           node/dist/lancedb-vectordb-linux*.tgz
 
-  nodejs-linux:
-    name: lancedb (${{ matrix.config.arch}}-unknown-linux-gnu
-    runs-on: ${{ matrix.config.runner }}
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - arch: x86_64
-            runner: ubuntu-latest
-          - arch: aarch64
-            # For successful fat LTO builds, we need a large runner to avoid OOM errors.
-            runner: buildjet-16vcpu-ubuntu-2204-arm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      # Buildjet aarch64 runners have only 1.5 GB RAM per core, vs 3.5 GB per core for
-      # x86_64 runners. To avoid OOM errors on ARM, we create a swap file.
-      - name: Configure aarch64 build
-        if: ${{ matrix.config.arch == 'aarch64' }}
-        run: |
-          free -h
-          sudo fallocate -l 16G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          echo "/swapfile swap swap defaults 0 0" >> sudo /etc/fstab
-          # print info
-          swapon --show
-          free -h
-      - name: Build Linux Artifacts
-        run: |
-          bash ci/build_linux_artifacts_nodejs.sh ${{ matrix.config.arch }}
-      - name: Upload Linux Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: nodejs-native-linux-${{ matrix.config.arch }}
-          path: |
-            nodejs/dist/*.node
-      # The generic files are the same in all distros so we just pick
-      # one to do the upload.
-      - name: Upload Generic Artifacts
-        if: ${{ matrix.config.arch == 'x86_64' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: nodejs-dist
-          path: |
-            nodejs/dist/*
-            !nodejs/dist/*.node
+  # nodejs-linux:
+  #   name: lancedb (${{ matrix.config.arch}}-unknown-linux-gnu
+  #   runs-on: ${{ matrix.config.runner }}
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       config:
+  #         - arch: x86_64
+  #           runner: ubuntu-latest
+  #         - arch: aarch64
+  #           # For successful fat LTO builds, we need a large runner to avoid OOM errors.
+  #           runner: buildjet-16vcpu-ubuntu-2204-arm
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     # Buildjet aarch64 runners have only 1.5 GB RAM per core, vs 3.5 GB per core for
+  #     # x86_64 runners. To avoid OOM errors on ARM, we create a swap file.
+  #     - name: Configure aarch64 build
+  #       if: ${{ matrix.config.arch == 'aarch64' }}
+  #       run: |
+  #         free -h
+  #         sudo fallocate -l 16G /swapfile
+  #         sudo chmod 600 /swapfile
+  #         sudo mkswap /swapfile
+  #         sudo swapon /swapfile
+  #         echo "/swapfile swap swap defaults 0 0" >> sudo /etc/fstab
+  #         # print info
+  #         swapon --show
+  #         free -h
+  #     - name: Build Linux Artifacts
+  #       run: |
+  #         bash ci/build_linux_artifacts_nodejs.sh ${{ matrix.config.arch }}
+  #     - name: Upload Linux Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: nodejs-native-linux-${{ matrix.config.arch }}
+  #         path: |
+  #           nodejs/dist/*.node
+  #     # The generic files are the same in all distros so we just pick
+  #     # one to do the upload.
+  #     - name: Upload Generic Artifacts
+  #       if: ${{ matrix.config.arch == 'x86_64' }}
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: nodejs-dist
+  #         path: |
+  #           nodejs/dist/*
+  #           !nodejs/dist/*.node
 
-  node-windows:
-    name: vectordb ${{ matrix.target }}
-    runs-on: windows-2022
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64-pc-windows-msvc]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Protoc v21.12
-        working-directory: C:\
-        run: |
-          New-Item -Path 'C:\protoc' -ItemType Directory
-          Set-Location C:\protoc
-          Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
-          7z x protoc.zip
-          Add-Content $env:GITHUB_PATH "C:\protoc\bin"
-        shell: powershell
-      - name: Install npm dependencies
-        run: |
-          cd node
-          npm ci
-      - name: Build Windows native node modules
-        run: .\ci\build_windows_artifacts.ps1 ${{ matrix.target }}
-      - name: Upload Windows Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-native-windows
-          path: |
-            node/dist/lancedb-vectordb-win32*.tgz
+  # node-windows:
+  #   name: vectordb ${{ matrix.target }}
+  #   runs-on: windows-2022
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       target: [x86_64-pc-windows-msvc]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Install Protoc v21.12
+  #       working-directory: C:\
+  #       run: |
+  #         New-Item -Path 'C:\protoc' -ItemType Directory
+  #         Set-Location C:\protoc
+  #         Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
+  #         7z x protoc.zip
+  #         Add-Content $env:GITHUB_PATH "C:\protoc\bin"
+  #       shell: powershell
+  #     - name: Install npm dependencies
+  #       run: |
+  #         cd node
+  #         npm ci
+  #     - name: Build Windows native node modules
+  #       run: .\ci\build_windows_artifacts.ps1 ${{ matrix.target }}
+  #     - name: Upload Windows Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: node-native-windows
+  #         path: |
+  #           node/dist/lancedb-vectordb-win32*.tgz
 
   node-windows-arm64:
     name: vectordb win32-arm64-msvc
     runs-on: windows-4x-arm
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
       - name: Install Git
@@ -271,7 +274,7 @@ jobs:
           Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\Llvm\x64\bin"
 
           # Add MSVC runtime libraries to LIB
-          $env:LIB = "C:\BuildTools\VC\Tools\MSVC\$latestVersion\lib\arm64;" + 
+          $env:LIB = "C:\BuildTools\VC\Tools\MSVC\$latestVersion\lib\arm64;" +
                      "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\arm64;" +
                      "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\arm64"
           Add-Content $env:GITHUB_ENV "LIB=$env:LIB"
@@ -329,328 +332,328 @@ jobs:
           path: |
             node/dist/*.node
 
-  nodejs-windows:
-    name: lancedb ${{ matrix.target }}
-    runs-on: windows-2022
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64-pc-windows-msvc]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Protoc v21.12
-        working-directory: C:\
-        run: |
-          New-Item -Path 'C:\protoc' -ItemType Directory
-          Set-Location C:\protoc
-          Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
-          7z x protoc.zip
-          Add-Content $env:GITHUB_PATH "C:\protoc\bin"
-        shell: powershell
-      - name: Install npm dependencies
-        run: |
-          cd nodejs
-          npm ci
-      - name: Build Windows native node modules
-        run: .\ci\build_windows_artifacts_nodejs.ps1 ${{ matrix.target }}
-      - name: Upload Windows Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: nodejs-native-windows
-          path: |
-            nodejs/dist/*.node
+  # nodejs-windows:
+  #   name: lancedb ${{ matrix.target }}
+  #   runs-on: windows-2022
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       target: [x86_64-pc-windows-msvc]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Install Protoc v21.12
+  #       working-directory: C:\
+  #       run: |
+  #         New-Item -Path 'C:\protoc' -ItemType Directory
+  #         Set-Location C:\protoc
+  #         Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
+  #         7z x protoc.zip
+  #         Add-Content $env:GITHUB_PATH "C:\protoc\bin"
+  #       shell: powershell
+  #     - name: Install npm dependencies
+  #       run: |
+  #         cd nodejs
+  #         npm ci
+  #     - name: Build Windows native node modules
+  #       run: .\ci\build_windows_artifacts_nodejs.ps1 ${{ matrix.target }}
+  #     - name: Upload Windows Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: nodejs-native-windows
+  #         path: |
+  #           nodejs/dist/*.node
 
-  nodejs-windows-arm64:
-    name: lancedb win32-arm64-msvc
-    runs-on: windows-4x-arm
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Git
-        run: |
-          Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.44.0.windows.1/Git-2.44.0-64-bit.exe" -OutFile "git-installer.exe"
-          Start-Process -FilePath "git-installer.exe" -ArgumentList "/VERYSILENT", "/NORESTART" -Wait
-        shell: powershell
-      - name: Add Git to PATH
-        run: |
-          Add-Content $env:GITHUB_PATH "C:\Program Files\Git\bin"
-          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-        shell: powershell
-      - name: Configure Git symlinks
-        run: git config --global core.symlinks true
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install Visual Studio Build Tools
-        run: |
-          Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile "vs_buildtools.exe"
-          Start-Process -FilePath "vs_buildtools.exe" -ArgumentList "--quiet", "--wait", "--norestart", "--nocache", `
-            "--installPath", "C:\BuildTools", `
-            "--add", "Microsoft.VisualStudio.Component.VC.Tools.ARM64", `
-            "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", `
-            "--add", "Microsoft.VisualStudio.Component.Windows11SDK.22621", `
-            "--add", "Microsoft.VisualStudio.Component.VC.ATL", `
-            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC", `
-            "--add", "Microsoft.VisualStudio.Component.VC.Llvm.Clang" -Wait
-        shell: powershell
-      - name: Add Visual Studio Build Tools to PATH
-        run: |
-          $vsPath = "C:\BuildTools\VC\Tools\MSVC"
-          $latestVersion = (Get-ChildItem $vsPath | Sort-Object {[version]$_.Name} -Descending)[0].Name
-          Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\arm64"
-          Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\x64"
-          Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\arm64"
-          Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64"
-          Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+  # nodejs-windows-arm64:
+  #   name: lancedb win32-arm64-msvc
+  #   runs-on: windows-4x-arm
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install Git
+  #       run: |
+  #         Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.44.0.windows.1/Git-2.44.0-64-bit.exe" -OutFile "git-installer.exe"
+  #         Start-Process -FilePath "git-installer.exe" -ArgumentList "/VERYSILENT", "/NORESTART" -Wait
+  #       shell: powershell
+  #     - name: Add Git to PATH
+  #       run: |
+  #         Add-Content $env:GITHUB_PATH "C:\Program Files\Git\bin"
+  #         $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+  #       shell: powershell
+  #     - name: Configure Git symlinks
+  #       run: git config --global core.symlinks true
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.13"
+  #     - name: Install Visual Studio Build Tools
+  #       run: |
+  #         Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile "vs_buildtools.exe"
+  #         Start-Process -FilePath "vs_buildtools.exe" -ArgumentList "--quiet", "--wait", "--norestart", "--nocache", `
+  #           "--installPath", "C:\BuildTools", `
+  #           "--add", "Microsoft.VisualStudio.Component.VC.Tools.ARM64", `
+  #           "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", `
+  #           "--add", "Microsoft.VisualStudio.Component.Windows11SDK.22621", `
+  #           "--add", "Microsoft.VisualStudio.Component.VC.ATL", `
+  #           "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC", `
+  #           "--add", "Microsoft.VisualStudio.Component.VC.Llvm.Clang" -Wait
+  #       shell: powershell
+  #     - name: Add Visual Studio Build Tools to PATH
+  #       run: |
+  #         $vsPath = "C:\BuildTools\VC\Tools\MSVC"
+  #         $latestVersion = (Get-ChildItem $vsPath | Sort-Object {[version]$_.Name} -Descending)[0].Name
+  #         Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\arm64"
+  #         Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\MSVC\$latestVersion\bin\Hostx64\x64"
+  #         Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\arm64"
+  #         Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64"
+  #         Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\Llvm\x64\bin"
 
-          $env:LIB = ""
-          Add-Content $env:GITHUB_ENV "LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\arm64;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\arm64"
-        shell: powershell
-      - name: Install Rust
-        run: |
-          Invoke-WebRequest https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
-          .\rustup-init.exe -y --default-host aarch64-pc-windows-msvc
-        shell: powershell
-      - name: Add Rust to PATH
-        run: |
-          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
-        shell: powershell
+  #         $env:LIB = ""
+  #         Add-Content $env:GITHUB_ENV "LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\arm64;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\arm64"
+  #       shell: powershell
+  #     - name: Install Rust
+  #       run: |
+  #         Invoke-WebRequest https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+  #         .\rustup-init.exe -y --default-host aarch64-pc-windows-msvc
+  #       shell: powershell
+  #     - name: Add Rust to PATH
+  #       run: |
+  #         Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
+  #       shell: powershell
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: rust
-      - name: Install 7-Zip ARM
-        run: |
-          New-Item -Path 'C:\7zip' -ItemType Directory
-          Invoke-WebRequest https://7-zip.org/a/7z2408-arm64.exe -OutFile C:\7zip\7z-installer.exe
-          Start-Process -FilePath C:\7zip\7z-installer.exe -ArgumentList '/S' -Wait
-        shell: powershell
-      - name: Add 7-Zip to PATH
-        run: Add-Content $env:GITHUB_PATH "C:\Program Files\7-Zip"
-        shell: powershell
-      - name: Install Protoc v21.12
-        working-directory: C:\
-        run: |
-          if (Test-Path 'C:\protoc') {
-              Write-Host "Protoc directory exists, skipping installation"
-              return
-          }
-          New-Item -Path 'C:\protoc' -ItemType Directory
-          Set-Location C:\protoc
-          Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
-          & 'C:\Program Files\7-Zip\7z.exe' x protoc.zip
-        shell: powershell
-      - name: Add Protoc to PATH
-        run: Add-Content $env:GITHUB_PATH "C:\protoc\bin"
-        shell: powershell
-      - name: Build Windows native node modules
-        run: .\ci\build_windows_artifacts_nodejs.ps1 aarch64-pc-windows-msvc
-      - name: Upload Windows ARM64 Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: nodejs-native-windows-arm64
-          path: |
-            nodejs/dist/*.node
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         workspaces: rust
+  #     - name: Install 7-Zip ARM
+  #       run: |
+  #         New-Item -Path 'C:\7zip' -ItemType Directory
+  #         Invoke-WebRequest https://7-zip.org/a/7z2408-arm64.exe -OutFile C:\7zip\7z-installer.exe
+  #         Start-Process -FilePath C:\7zip\7z-installer.exe -ArgumentList '/S' -Wait
+  #       shell: powershell
+  #     - name: Add 7-Zip to PATH
+  #       run: Add-Content $env:GITHUB_PATH "C:\Program Files\7-Zip"
+  #       shell: powershell
+  #     - name: Install Protoc v21.12
+  #       working-directory: C:\
+  #       run: |
+  #         if (Test-Path 'C:\protoc') {
+  #             Write-Host "Protoc directory exists, skipping installation"
+  #             return
+  #         }
+  #         New-Item -Path 'C:\protoc' -ItemType Directory
+  #         Set-Location C:\protoc
+  #         Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
+  #         & 'C:\Program Files\7-Zip\7z.exe' x protoc.zip
+  #       shell: powershell
+  #     - name: Add Protoc to PATH
+  #       run: Add-Content $env:GITHUB_PATH "C:\protoc\bin"
+  #       shell: powershell
+  #     - name: Build Windows native node modules
+  #       run: .\ci\build_windows_artifacts_nodejs.ps1 aarch64-pc-windows-msvc
+  #     - name: Upload Windows ARM64 Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: nodejs-native-windows-arm64
+  #         path: |
+  #           nodejs/dist/*.node
 
-  release:
-    name: vectordb NPM Publish
-    needs: [node, node-macos, node-linux, node-windows, node-windows-arm64]
-    runs-on: ubuntu-latest
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: node-*
-      - name: Display structure of downloaded files
-        run: ls -R
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20
-          registry-url: "https://registry.npmjs.org"
-      - name: Publish to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.LANCEDB_NPM_REGISTRY_TOKEN }}
-        run: |
-          # Tag beta as "preview" instead of default "latest". See lancedb 
-          # npm publish step for more info.
-          if [[ $GITHUB_REF =~ refs/tags/v(.*)-beta.* ]]; then
-            PUBLISH_ARGS="--tag preview"
-          fi
+  # release:
+  #   name: vectordb NPM Publish
+  #   needs: [node, node-macos, node-linux, node-windows, node-windows-arm64]
+  #   runs-on: ubuntu-latest
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: node-*
+  #     - name: Display structure of downloaded files
+  #       run: ls -R
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 20
+  #         registry-url: "https://registry.npmjs.org"
+  #     - name: Publish to NPM
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.LANCEDB_NPM_REGISTRY_TOKEN }}
+  #       run: |
+  #         # Tag beta as "preview" instead of default "latest". See lancedb
+  #         # npm publish step for more info.
+  #         if [[ $GITHUB_REF =~ refs/tags/v(.*)-beta.* ]]; then
+  #           PUBLISH_ARGS="--tag preview"
+  #         fi
 
-          mv */*.tgz .
-          for filename in *.tgz; do
-            npm publish $PUBLISH_ARGS $filename
-          done
-      - name: Notify Slack Action
-        uses: ravsamhq/notify-slack-action@2.3.0
-        if: ${{ always() }}
-        with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-          notification_title: "{workflow} is failing"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+  #         mv */*.tgz .
+  #         for filename in *.tgz; do
+  #           npm publish $PUBLISH_ARGS $filename
+  #         done
+  #     - name: Notify Slack Action
+  #       uses: ravsamhq/notify-slack-action@2.3.0
+  #       if: ${{ always() }}
+  #       with:
+  #         status: ${{ job.status }}
+  #         notify_when: "failure"
+  #         notification_title: "{workflow} is failing"
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
-  release-nodejs:
-    name: lancedb NPM Publish
-    needs: [nodejs-macos, nodejs-linux, nodejs-windows, nodejs-windows-arm64]
-    runs-on: ubuntu-latest
-    # Only runs on tags that matches the make-release action
-    if: startsWith(github.ref, 'refs/tags/v')
-    defaults:
-      run:
-        shell: bash
-        working-directory: nodejs
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: nodejs-dist
-          path: nodejs/dist
-      - uses: actions/download-artifact@v4
-        name: Download arch-specific binaries
-        with:
-          pattern: nodejs-*
-          path: nodejs/nodejs-artifacts
-          merge-multiple: true
-      - name: Display structure of downloaded files
-        run: find .
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20
-          registry-url: "https://registry.npmjs.org"
-      - name: Install napi-rs
-        run: npm install -g @napi-rs/cli
-      - name: Prepare artifacts
-        run: npx napi artifacts -d nodejs-artifacts
-      - name: Display structure of staged files
-        run: find npm
-      - name: Publish to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.LANCEDB_NPM_REGISTRY_TOKEN }}
-        # By default, things are published to the latest tag. This is what is
-        # installed by default if the user does not specify a version. This is
-        # good for stable releases, but for pre-releases, we want to publish to
-        # the "preview" tag so they can install with `npm install lancedb@preview`.
-        # See: https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420
-        run: |
-          if [[ $GITHUB_REF =~ refs/tags/v(.*)-beta.* ]]; then
-            npm publish --access public --tag preview
-          else
-            npm publish --access public
-          fi
-      - name: Notify Slack Action
-        uses: ravsamhq/notify-slack-action@2.3.0
-        if: ${{ always() }}
-        with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-          notification_title: "{workflow} is failing"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+  # release-nodejs:
+  #   name: lancedb NPM Publish
+  #   needs: [nodejs-macos, nodejs-linux, nodejs-windows, nodejs-windows-arm64]
+  #   runs-on: ubuntu-latest
+  #   # Only runs on tags that matches the make-release action
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: nodejs
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: nodejs-dist
+  #         path: nodejs/dist
+  #     - uses: actions/download-artifact@v4
+  #       name: Download arch-specific binaries
+  #       with:
+  #         pattern: nodejs-*
+  #         path: nodejs/nodejs-artifacts
+  #         merge-multiple: true
+  #     - name: Display structure of downloaded files
+  #       run: find .
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 20
+  #         registry-url: "https://registry.npmjs.org"
+  #     - name: Install napi-rs
+  #       run: npm install -g @napi-rs/cli
+  #     - name: Prepare artifacts
+  #       run: npx napi artifacts -d nodejs-artifacts
+  #     - name: Display structure of staged files
+  #       run: find npm
+  #     - name: Publish to NPM
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.LANCEDB_NPM_REGISTRY_TOKEN }}
+  #       # By default, things are published to the latest tag. This is what is
+  #       # installed by default if the user does not specify a version. This is
+  #       # good for stable releases, but for pre-releases, we want to publish to
+  #       # the "preview" tag so they can install with `npm install lancedb@preview`.
+  #       # See: https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420
+  #       run: |
+  #         if [[ $GITHUB_REF =~ refs/tags/v(.*)-beta.* ]]; then
+  #           npm publish --access public --tag preview
+  #         else
+  #           npm publish --access public
+  #         fi
+  #     - name: Notify Slack Action
+  #       uses: ravsamhq/notify-slack-action@2.3.0
+  #       if: ${{ always() }}
+  #       with:
+  #         status: ${{ job.status }}
+  #         notify_when: "failure"
+  #         notification_title: "{workflow} is failing"
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
-  update-package-lock:
-    needs: [release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          persist-credentials: false
-          fetch-depth: 0
-          lfs: true
-      - uses: ./.github/workflows/update_package_lock
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  # update-package-lock:
+  #   needs: [release]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: main
+  #         persist-credentials: false
+  #         fetch-depth: 0
+  #         lfs: true
+  #     - uses: ./.github/workflows/update_package_lock
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  update-package-lock-nodejs:
-    needs: [release-nodejs]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          persist-credentials: false
-          fetch-depth: 0
-          lfs: true
-      - uses: ./.github/workflows/update_package_lock_nodejs
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  # update-package-lock-nodejs:
+  #   needs: [release-nodejs]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: main
+  #         persist-credentials: false
+  #         fetch-depth: 0
+  #         lfs: true
+  #     - uses: ./.github/workflows/update_package_lock_nodejs
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  gh-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Extract version
-        id: extract_version
-        env:
-          GITHUB_REF: ${{ github.ref }}
-        run: |
-          set -e
-          echo "Extracting tag and version from $GITHUB_REF"
-          if [[ $GITHUB_REF =~ refs/tags/v(.*) ]]; then
-            VERSION=${BASH_REMATCH[1]}
-            TAG=v$VERSION
-            echo "tag=$TAG" >> $GITHUB_OUTPUT
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "Failed to extract version from $GITHUB_REF"
-            exit 1
-          fi
-          echo "Extracted version $VERSION from $GITHUB_REF"
-          if [[ $VERSION =~ beta ]]; then
-            echo "This is a beta release"
+  # gh-release:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         lfs: true
+  #     - name: Extract version
+  #       id: extract_version
+  #       env:
+  #         GITHUB_REF: ${{ github.ref }}
+  #       run: |
+  #         set -e
+  #         echo "Extracting tag and version from $GITHUB_REF"
+  #         if [[ $GITHUB_REF =~ refs/tags/v(.*) ]]; then
+  #           VERSION=${BASH_REMATCH[1]}
+  #           TAG=v$VERSION
+  #           echo "tag=$TAG" >> $GITHUB_OUTPUT
+  #           echo "version=$VERSION" >> $GITHUB_OUTPUT
+  #         else
+  #           echo "Failed to extract version from $GITHUB_REF"
+  #           exit 1
+  #         fi
+  #         echo "Extracted version $VERSION from $GITHUB_REF"
+  #         if [[ $VERSION =~ beta ]]; then
+  #           echo "This is a beta release"
 
-            # Get last release (that is not this one)
-            FROM_TAG=$(git tag --sort='version:refname' \
-              | grep ^v \
-              | grep -vF "$TAG" \
-              | python ci/semver_sort.py v \
-              | tail -n 1)
-          else
-            echo "This is a stable release"
-            # Get last stable tag (ignore betas)
-            FROM_TAG=$(git tag --sort='version:refname' \
-              | grep ^v \
-              | grep -vF "$TAG" \
-              | grep -v beta \
-              | python ci/semver_sort.py v \
-              | tail -n 1)
-          fi
-          echo "Found from tag $FROM_TAG"
-          echo "from_tag=$FROM_TAG" >> $GITHUB_OUTPUT
-      - name: Create Release Notes
-        id: release_notes
-        uses: mikepenz/release-changelog-builder-action@v4
-        with:
-          configuration: .github/release_notes.json
-          toTag: ${{ steps.extract_version.outputs.tag }}
-          fromTag: ${{ steps.extract_version.outputs.from_tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create GH release
-        uses: softprops/action-gh-release@v2
-        with:
-          prerelease: ${{ contains('beta', github.ref) }}
-          tag_name: ${{ steps.extract_version.outputs.tag }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: false
-          name: Node/Rust LanceDB v${{ steps.extract_version.outputs.version }}
-          body: ${{ steps.release_notes.outputs.changelog }}
+  #           # Get last release (that is not this one)
+  #           FROM_TAG=$(git tag --sort='version:refname' \
+  #             | grep ^v \
+  #             | grep -vF "$TAG" \
+  #             | python ci/semver_sort.py v \
+  #             | tail -n 1)
+  #         else
+  #           echo "This is a stable release"
+  #           # Get last stable tag (ignore betas)
+  #           FROM_TAG=$(git tag --sort='version:refname' \
+  #             | grep ^v \
+  #             | grep -vF "$TAG" \
+  #             | grep -v beta \
+  #             | python ci/semver_sort.py v \
+  #             | tail -n 1)
+  #         fi
+  #         echo "Found from tag $FROM_TAG"
+  #         echo "from_tag=$FROM_TAG" >> $GITHUB_OUTPUT
+  #     - name: Create Release Notes
+  #       id: release_notes
+  #       uses: mikepenz/release-changelog-builder-action@v4
+  #       with:
+  #         configuration: .github/release_notes.json
+  #         toTag: ${{ steps.extract_version.outputs.tag }}
+  #         fromTag: ${{ steps.extract_version.outputs.from_tag }}
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Create GH release
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         prerelease: ${{ contains('beta', github.ref) }}
+  #         tag_name: ${{ steps.extract_version.outputs.tag }}
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         generate_release_notes: false
+  #         name: Node/Rust LanceDB v${{ steps.extract_version.outputs.version }}
+  #         body: ${{ steps.release_notes.outputs.changelog }}

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -22,7 +22,7 @@
         "axios": "^1.4.0"
       },
       "devDependencies": {
-        "@neon-rs/cli": "^0.0.160",
+        "@neon-rs/cli": "^0.1.81",
         "@types/chai": "^4.3.4",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.1",
@@ -109,9 +109,9 @@
       "peer": true
     },
     "node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.160.tgz",
-      "integrity": "sha512-PTgCEmBHEPKJbxwlHVXB3aGES+NqpeBvn6hJNYWIkET3ZQCSJnScMlIDQXEkWndK7J+hW3Or3H32a93B/MbbfQ==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.80.tgz",
+      "integrity": "sha512-QawKsQCs8rYqtq8JSEQBLuX/Tb4FcMVzg8ykSxqYy0qrgunr26MCqxGSsgzTUu4S7y3OH3RXN9lD+/JJZJB81w==",
       "cpu": [
         "arm"
       ],
@@ -122,9 +122,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.160.tgz",
-      "integrity": "sha512-YSVUuc8TUTi/XmZVg9KrH0bDywKLqC1zeTyZYAYDDmqVDZW9KeTnbBUECKRs56iyHeO+kuEkVW7MKf7j2zb/FA==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-l7s5I90Eol597qEfbQn6P7EFyxcedRpcwjXAPOqjTR7D7dHzMIxVXeLmYeiwSUsebTeQ9FWBi5H9thxJDJdShw==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +135,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.160.tgz",
-      "integrity": "sha512-U+YlAR+9tKpBljnNPWMop5YhvtwfIPQSAaUYN2llteC7ZNU5/cv8CGT1vm7uFNxr2LeGuAtRbzIh2gUmTV8mng==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-B8d5wjp3WosHh95nHX+MKHdb2n2/0PlajkuuULLy8sDPbC83mBoGQ6m15cY3g3nGiB9Wsot1GR6QkyaEVYZ5HQ==",
       "cpu": [
         "x64"
       ],
@@ -148,9 +148,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.160.tgz",
-      "integrity": "sha512-wqAelTzVv1E7Ls4aviqUbem5xjzCaJQxQtVnLhv6pf1k0UyEHCS2WdufFFmWcojGe7QglI4uve3KTe01MKYj0A==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-q4vm0QJesAzMm0iOmTOMPQjVTgkQZCr1+NKluTb4343VDRceRQ6Hb01dzT2nm7dvsZYltP38WrsLavbrbXj08Q==",
       "cpu": [
         "arm"
       ],
@@ -160,10 +160,49 @@
         "linux"
       ]
     },
+    "node_modules/@cargo-messages/linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm64-gnu/-/linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-fz7iaDWF0dK51Dg9+UzHNMHt28jTU27OZLDXHwKhWsf6VSJUAmAaM5auwTjhUbF0HXKxueak6i4MdswyArcy3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cargo-messages/linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm64-musl/-/linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-jgDDHZvWg3242zGwwlw9zx/tjMZEIjzef77T68p6BYSIlqEh8Xmla7rYO7QqaxsSdhs9QcJLLrWiAzOT2bkPYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.160.tgz",
-      "integrity": "sha512-LQ6e7O7YYkWfDNIi/53q2QG/+lZok72LOG+NKDVCrrY4TYUcrTqWAybOV6IlkVntKPnpx8YB95umSQGeVuvhpQ==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-Ku5OyfoxBdcQ7tYUyL7iBCZ46l7Tl0MDAmf9V/7D4K/NLIg02ducK1wrCQ+MaUAJu2pxu7gTgfR6SGeZtQOYoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cargo-messages/linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-musl/-/linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-/e5oQ6kSzEjdfzznqsMOtgqMc01MWYGI0yEn1iMwgB8K+cN9ma/sTXMVpKw7PRov2lQWCuSIhG3WZeF+PmloGA==",
       "cpu": [
         "x64"
       ],
@@ -174,9 +213,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.160.tgz",
-      "integrity": "sha512-VDMBhyun02gIDwmEhkYP1W9Z0tYqn4drgY5Iua1qV2tYOU58RVkWhzUYxM9rzYbnwKZlltgM46J/j5QZ3VaFrA==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.80.tgz",
+      "integrity": "sha512-8f8skn92zZDhZ74nh1ODp9eqV1XsGPlHITny+BQ+pOls0b62G39ECIkcdlGVeG0qBrR+8aJ6Tnr8KjqZXv7kwQ==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +226,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.160.tgz",
-      "integrity": "sha512-vnoglDxF6zj0W/Co9D0H/bgnrhUuO5EumIf9v3ujLtBH94rAX11JsXh/FgC/8wQnQSsLyWSq70YxNS2wdETxjA==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-L6sM4HDOM09egXhyYhb1X9/IJZ056HHSfmEHCnnLw0NN5eotOhQS/Mp2rBmttMs6OAPjci4ugrNnTQcqzVd0BQ==",
       "cpu": [
         "x64"
       ],
@@ -328,21 +367,24 @@
       }
     },
     "node_modules/@neon-rs/cli": {
-      "version": "0.0.160",
-      "resolved": "https://registry.npmjs.org/@neon-rs/cli/-/cli-0.0.160.tgz",
-      "integrity": "sha512-GQjzHPJVTOARbX3nP/fAWqBq7JlQ8XgfYlCa+iwzIXf0LC1EyfJTX+vqGD/36b9lKoyY01Z/aDUB9o/qF6ztHA==",
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/@neon-rs/cli/-/cli-0.1.81.tgz",
+      "integrity": "sha512-7mfLsXjXBEypMn+AxdIkCGJNdX2i9NWbeZgLKdOUcFrEnvQAAcx8pjtouxL3a/AFKYRu4QKucnFO3G+07aydtg==",
       "dev": true,
       "bin": {
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.160",
-        "@cargo-messages/darwin-arm64": "0.0.160",
-        "@cargo-messages/darwin-x64": "0.0.160",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.160",
-        "@cargo-messages/linux-x64-gnu": "0.0.160",
-        "@cargo-messages/win32-arm64-msvc": "0.0.160",
-        "@cargo-messages/win32-x64-msvc": "0.0.160"
+        "@cargo-messages/android-arm-eabi": "0.1.80",
+        "@cargo-messages/darwin-arm64": "0.1.80",
+        "@cargo-messages/darwin-x64": "0.1.80",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.80",
+        "@cargo-messages/linux-arm64-gnu": "0.1.80",
+        "@cargo-messages/linux-arm64-musl": "0.1.80",
+        "@cargo-messages/linux-x64-gnu": "0.1.80",
+        "@cargo-messages/linux-x64-musl": "0.1.80",
+        "@cargo-messages/win32-arm64-msvc": "0.1.80",
+        "@cargo-messages/win32-x64-msvc": "0.1.80"
       }
     },
     "node_modules/@neon-rs/load": {

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
   "author": "Lance Devs",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@neon-rs/cli": "^0.0.160",
+    "@neon-rs/cli": "^0.1.81",
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.1",


### PR DESCRIPTION
Latest release failed with https://github.com/lancedb/lancedb/actions/runs/11830863629/job/32965091276

```
Building nodejs library for aarch64-pc-windows-msvc
npm : The term 'npm' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the 
spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\a\lancedb\lancedb\ci\build_windows_artifacts_nodejs.ps1:29 char:5
+     npm run build-release
+     ~~~
    + CategoryInfo          : ObjectNotFound: (npm:String) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : CommandNotFoundException
```