### PR TITLE
fix: iter in merge_insert

### DIFF
--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -655,7 +655,7 @@ class Table(ABC):
         2  3  y
         3  4  z
         """
-        on = [on] if isinstance(on, str) else list(on.iter())
+        on = [on] if isinstance(on, str) else list(iter(on))
 
         return LanceMergeInsertBuilder(self, on)
 


### PR DESCRIPTION
`iter()` isn't a function but calls the dunder function `__iter__()`.

Otherwise a list and other iterables can't be used for this.

Just try `list([42].iter())` vs. `list(iter([42]))` == `list([43].__iter__())`