### PR TITLE
fix(python): run remote SDK futures in background thread

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,6 @@ name = "lancedb"
 # version in Cargo.toml
 dependencies = [
     "deprecation",
-    "nest-asyncio~=1.0",
     "pylance==0.20.0b2",
     "tqdm>=4.27.0",
     "pydantic>=1.10",

--- a/python/python/lancedb/remote/background_loop.py
+++ b/python/python/lancedb/remote/background_loop.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+import asyncio
+import threading
+
+
+class BackgroundEventLoop:
+    """
+    A background event loop that can run futures.
+
+    Used to bridge sync and async code, without messing with users event loops.
+    """
+
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(
+            target=self.loop.run_forever,
+            name="LanceDBBackgroundEventLoop",
+            daemon=True,
+        )
+        self.thread.start()
+
+    def run(self, future):
+        return asyncio.run_coroutine_threadsafe(future, self.loop).result()


### PR DESCRIPTION
Users who call the remote SDK from code that uses futures (either `ThreadPoolExecutor` or `asyncio`) can get odd errors like:

```
Traceback (most recent call last):
  File "/usr/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
RuntimeError: cannot enter context: <_contextvars.Context object at 0x7cfe94cdc900> is already entered
```

This PR fixes that by executing all LanceDB futures in a dedicated thread pool running on a background thread. That way, it doesn't interact with their threadpool.
