### PR TITLE
ci: musl missing node/package.json targets

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -84,6 +84,8 @@
       "aarch64-apple-darwin": "@lancedb/vectordb-darwin-arm64",
       "x86_64-unknown-linux-gnu": "@lancedb/vectordb-linux-x64-gnu",
       "aarch64-unknown-linux-gnu": "@lancedb/vectordb-linux-arm64-gnu",
+      "x86_64-unknown-linux-musl": "@lancedb/vectordb-linux-x64-musl",
+      "aarch64-unknown-linux-musl": "@lancedb/vectordb-linux-arm64-musl",
       "x86_64-pc-windows-msvc": "@lancedb/vectordb-win32-x64-msvc",
       "aarch64-pc-windows-msvc": "@lancedb/vectordb-win32-arm64-msvc"
     }


### PR DESCRIPTION
I missed targets when manually merging draft PR to updated main
I was copying from: https://github.com/lancedb/lancedb/pull/1816/files#diff-d6e19f28e97cfeda63a9bd9426f10f1d2454eeed375ee1235e8ba842ceeb46a0

fixes:
error: Rust target x86_64-unknown-linux-musl not found in package.json.