### PR TITLE
ci: use correct runner for vectordb

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -143,7 +143,7 @@ jobs:
 
   node-linux-musl:
     name: vectordb (${{ matrix.config.arch}}-unknown-linux-musl)
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.runner }}
     container: alpine:edge
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
@@ -152,7 +152,10 @@ jobs:
       matrix:
         config:
           - arch: x86_64
+            runner: ubuntu-latest
           - arch: aarch64
+            # For successful fat LTO builds, we need a large runner to avoid OOM errors.
+            runner: buildjet-16vcpu-ubuntu-2204-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -246,7 +249,7 @@ jobs:
 
   nodejs-linux-musl:
     name: lancedb (${{ matrix.config.arch}}-unknown-linux-musl
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.runner }}
     container: alpine:edge
     # Only runs on tags that matches the make-release action
     if: startsWith(github.ref, 'refs/tags/v')
@@ -255,7 +258,10 @@ jobs:
       matrix:
         config:
           - arch: x86_64
+            runner: ubuntu-latest
           - arch: aarch64
+            # For successful fat LTO builds, we need a large runner to avoid OOM errors.
+            runner: buildjet-16vcpu-ubuntu-2204-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We already do this for `gnu` builds, we should do this also for `musl` builds.