### PR TITLE
feat: add remote db uri path with folder prefix

### DIFF
--- a/rust/lancedb/src/remote/client.rs
+++ b/rust/lancedb/src/remote/client.rs
@@ -226,6 +226,14 @@ impl RestfulLanceDbClient<Sender> {
             });
         }
         let db_name = parsed_url.host_str().unwrap();
+        let db_prefix = {
+            let prefix = parsed_url.path().trim_start_matches('/');
+            if prefix.is_empty() {
+                None
+            } else {
+                Some(prefix)
+            }
+        };
 
         // Get the timeouts
         let connect_timeout = Self::get_timeout(
@@ -255,6 +263,7 @@ impl RestfulLanceDbClient<Sender> {
                 region,
                 db_name,
                 host_override.is_some(),
+                db_prefix,
             )?)
             .user_agent(client_config.user_agent)
             .build()
@@ -287,6 +296,7 @@ impl<S: HttpSend> RestfulLanceDbClient<S> {
         region: &str,
         db_name: &str,
         has_host_override: bool,
+        db_prefix: Option<&str>,
     ) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -309,6 +319,17 @@ impl<S: HttpSend> RestfulLanceDbClient<S> {
                 "x-lancedb-database",
                 HeaderValue::from_str(db_name).map_err(|_| Error::InvalidInput {
                     message: format!("non-ascii database name '{}' provided", db_name),
+                })?,
+            );
+        }
+        if db_prefix.is_some() {
+            headers.insert(
+                "x-lancedb-database-prefix",
+                HeaderValue::from_str(db_prefix.unwrap()).map_err(|_| Error::InvalidInput {
+                    message: format!(
+                        "non-ascii database prefix '{}' provided",
+                        db_prefix.unwrap()
+                    ),
                 })?,
             );
         }


### PR DESCRIPTION
Add remote database folder prefix
support db://bucket/path/to/folder/