### PR TITLE
fix: create and use AsyncLanceMergeInsertBuilder for async batch merge

### DIFF
--- a/python/python/lancedb/merge.py
+++ b/python/python/lancedb/merge.py
@@ -105,3 +105,13 @@ class LanceMergeInsertBuilder(object):
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         """
         return self._table._do_merge(self, new_data, on_bad_vectors, fill_value)
+
+
+class AsyncLanceMergeInsertBuilder(LanceMergeInsertBuilder):
+    async def execute(
+        self,
+        new_data: DATA,
+        on_bad_vectors: str = "error",
+        fill_value: float = 0.0,
+    ):
+        return await self._table._do_merge(self, new_data, on_bad_vectors, fill_value)

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -35,7 +35,7 @@ from lance.dependencies import _check_for_hugging_face
 
 from .common import DATA, VEC, VECTOR_COLUMN_NAME, sanitize_uri
 from .embeddings import EmbeddingFunctionConfig, EmbeddingFunctionRegistry
-from .merge import LanceMergeInsertBuilder
+from .merge import LanceMergeInsertBuilder, AsyncLanceMergeInsertBuilder
 from .pydantic import LanceModel, model_to_dict
 from .query import (
     AsyncQuery,
@@ -2669,9 +2669,9 @@ class AsyncTable:
             data = pa.RecordBatchReader.from_batches(data.schema, data.to_batches())
         await self._inner.add(data, mode)
 
-    def merge_insert(self, on: Union[str, Iterable[str]]) -> LanceMergeInsertBuilder:
+    def merge_insert(self, on: Union[str, Iterable[str]]) -> AsyncLanceMergeInsertBuilder:
         """
-        Returns a [`LanceMergeInsertBuilder`][lancedb.merge.LanceMergeInsertBuilder]
+        Returns a [`AsyncLanceMergeInsertBuilder`][lancedb.merge.AsyncLanceMergeInsertBuilder]
         that can be used to create a "merge insert" operation
 
         This operation can add rows, update rows, and remove rows all in a single
@@ -2727,7 +2727,7 @@ class AsyncTable:
         """
         on = [on] if isinstance(on, str) else list(on.iter())
 
-        return LanceMergeInsertBuilder(self, on)
+        return AsyncLanceMergeInsertBuilder(self, on)
 
     def vector_search(
         self,


### PR DESCRIPTION
Sync merge couldn't be executed on the async table, so I created an async version of `LanceMergeInsertBuilder` for this purpose.