### PR TITLE
docs(rust): fix doctests

### DIFF
--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -625,7 +625,7 @@ impl ConnectBuilder {
 
     /// Set the LanceDB Cloud client configuration.
     ///
-    /// ```
+    /// ```no_run
     /// # use lancedb::connect;
     /// # use lancedb::remote::*;
     /// connect("db://my_database")

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! LanceDB runs in process, to use it in your Rust project, put the following in your `Cargo.toml`:
 //!
-//! ```ignore
+//! ```shell
 //! cargo install lancedb
 //! ```
 //!

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -348,7 +348,7 @@ pub trait QueryBase {
     ///
     /// The filter should be supplied as an SQL query string.  For example:
     ///
-    /// ```ignore
+    /// ```sql
     /// x > 10
     /// y > 0 AND y < 100
     /// x > 5 OR y = 'test'
@@ -364,8 +364,18 @@ pub trait QueryBase {
     ///
     /// This method is only valid on tables that have a full text search index.
     ///
-    /// ```ignore
-    /// query.full_text_search(FullTextSearchQuery::new("hello world"))
+    /// ```
+    /// use lance_index::scalar::FullTextSearchQuery;
+    /// use lancedb::query::{QueryBase, ExecutableQuery};
+    ///
+    /// # use lancedb::Table;
+    /// # async fn query(table: &Table) -> Result<(), Box<dyn std::error::Error>> {
+    /// let results = table.query()
+    ///     .full_text_search(FullTextSearchQuery::new("hello world".into()))
+    ///     .execute()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn full_text_search(self, query: FullTextSearchQuery) -> Self;
 


### PR DESCRIPTION
* One doctest was running for > 60 seconds in CI, since it was (unsuccessfully) trying to connect to LanceDB Cloud.
* Fixed the example for `Query::full_text_query()`, which was incorrect.