### PR TITLE
fix: support list of numpy f16 floats as query vector

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -1634,9 +1634,7 @@ class AsyncQuery(AsyncQueryBase):
         if (
             isinstance(query_vector, list)
             and len(query_vector) > 0
-            and not isinstance(
-                query_vector[0], (float, int, np.float16, np.float32, np.float64)
-            )
+            and isinstance(query_vector[0], (list, np.ndarray, pa.Array))
         ):
             # multiple have been passed
             query_vectors = [AsyncQuery._query_vec_to_array(v) for v in query_vector]

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -1634,7 +1634,9 @@ class AsyncQuery(AsyncQueryBase):
         if (
             isinstance(query_vector, list)
             and len(query_vector) > 0
-            and not np.isrealobj(query_vector[0])
+            and not isinstance(
+                query_vector[0], (float, int, np.float16, np.float32, np.float64)
+            )
         ):
             # multiple have been passed
             query_vectors = [AsyncQuery._query_vec_to_array(v) for v in query_vector]

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -1,15 +1,5 @@
-#  Copyright 2023 LanceDB Developers
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 from __future__ import annotations
 
@@ -1644,7 +1634,7 @@ class AsyncQuery(AsyncQueryBase):
         if (
             isinstance(query_vector, list)
             and len(query_vector) > 0
-            and not isinstance(query_vector[0], (float, int))
+            and not np.isrealobj(query_vector[0])
         ):
             # multiple have been passed
             query_vectors = [AsyncQuery._query_vec_to_array(v) for v in query_vector]


### PR DESCRIPTION
User reported on Discord, when using `table.vector_search([np.float16(1.0), np.float16(2.0), ...])`, it yields `TypeError: 'numpy.float16' object is not iterable`

