### PR TITLE
feat: add hybrid search to node and rust SDKs

### DIFF
--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -12,7 +12,10 @@ categories.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+async-trait.workspace = true
 arrow-ipc.workspace = true
+arrow-array.workspace = true
+arrow-schema.workspace = true
 env_logger.workspace = true
 futures.workspace = true
 lancedb = { path = "../rust/lancedb", features = ["remote"] }

--- a/nodejs/__test__/arrow.test.ts
+++ b/nodejs/__test__/arrow.test.ts
@@ -563,18 +563,20 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
           { text: "cat", vector: [0.3, 0.4] },
         ];
         const table = await convertToTable(records);
-        const batch = table.batches[0]
+        const batch = table.batches[0];
 
-        const buffer = await fromRecordBatchToBuffer(batch)
-        const result = await fromBufferToRecordBatch(buffer)
+        const buffer = await fromRecordBatchToBuffer(batch);
+        const result = await fromBufferToRecordBatch(buffer);
 
-        expect(JSON.stringify(batch.toArray())).toEqual(JSON.stringify(result?.toArray()));
+        expect(JSON.stringify(batch.toArray())).toEqual(
+          JSON.stringify(result?.toArray()),
+        );
       });
 
-      it("converting from buffer returns null if buffer has no record batches", async function() {
-        const result = await fromBufferToRecordBatch(Buffer.from([0x01, 0x02])) // bad data
-        expect(result).toEqual(null)
-      })
+      it("converting from buffer returns null if buffer has no record batches", async function () {
+        const result = await fromBufferToRecordBatch(Buffer.from([0x01, 0x02])); // bad data
+        expect(result).toEqual(null);
+      });
     });
   },
 );

--- a/nodejs/__test__/rerankers.test.ts
+++ b/nodejs/__test__/rerankers.test.ts
@@ -1,16 +1,5 @@
-// Copyright 2024 Lance Developers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 import { RecordBatch } from "apache-arrow";
 import * as tmp from "tmp";

--- a/nodejs/__test__/rerankers.test.ts
+++ b/nodejs/__test__/rerankers.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as tmp from "tmp";
+import { connect, Connection, makeArrowTable, Table, Index } from "../lancedb";
+import { RecordBatch } from "apache-arrow";
+import { RRFReranker } from "../lancedb/rerankers";
+
+describe("rerankers", function () {
+  let tmpDir: tmp.DirResult;
+  let conn: Connection;
+  let table: Table;
+
+  beforeEach(async () => {
+    tmpDir = tmp.dirSync({ unsafeCleanup: true });
+    conn = await connect(tmpDir.name)
+    table = await conn.createTable("mytable", [
+      { vector: [0.1, 0.1], text: "dog" },
+      { vector: [0.2, 0.2], text: "cat" },
+    ])
+    await table.createIndex("text", {
+      config: Index.fts(),
+      replace: true
+    })
+  })
+
+  it("will query with the custom reranker", async function () {
+    const expectedResult = [
+      { text: "albert", _relevance_score: 0.99 },
+    ]
+    class MyCustomReranker {
+      async rerankHybrid(
+        query: string,
+        vecResults: RecordBatch,
+        ftsResults: RecordBatch,
+      ): Promise<RecordBatch> {
+        // no reranker logic, just return some static data
+        const table = makeArrowTable(expectedResult)
+        return table.batches[0]
+      }
+    }
+
+    let result = await table.query()
+      .nearestTo([0.1, 0.1])
+      .fullTextSearch("dog")
+      .rerank(new MyCustomReranker())
+      .select(["text"])
+      .limit(5)
+      .toArray()
+
+    result = JSON.parse(JSON.stringify(result)) // convert StructRow to Object
+    expect(result).toEqual([{text: "albert", _relevance_score: 0.99 }])
+  })
+
+  it("will query with RRFReranker", async function() {
+    // smoke test to see if the Javascript wrapping Typescript is wired up correctly
+    const result = await table.query()
+      .nearestTo([0.1, 0.1])
+      .fullTextSearch("dog")
+      .rerank(await RRFReranker.create())
+      .select(["text"])
+      .limit(5)
+      .toArray()
+
+    expect(result).toHaveLength(2)
+  })
+})

--- a/nodejs/__test__/rerankers.test.ts
+++ b/nodejs/__test__/rerankers.test.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as tmp from "tmp";
-import { connect, Connection, makeArrowTable, Table, Index } from "../lancedb";
 import { RecordBatch } from "apache-arrow";
+import * as tmp from "tmp";
+import { Connection, Index, Table, connect, makeArrowTable } from "../lancedb";
 import { RRFReranker } from "../lancedb/rerankers";
 
 describe("rerankers", function () {
@@ -24,55 +24,67 @@ describe("rerankers", function () {
 
   beforeEach(async () => {
     tmpDir = tmp.dirSync({ unsafeCleanup: true });
-    conn = await connect(tmpDir.name)
+    conn = await connect(tmpDir.name);
     table = await conn.createTable("mytable", [
       { vector: [0.1, 0.1], text: "dog" },
       { vector: [0.2, 0.2], text: "cat" },
-    ])
+    ]);
     await table.createIndex("text", {
       config: Index.fts(),
-      replace: true
-    })
-  })
+      replace: true,
+    });
+  });
 
   it("will query with the custom reranker", async function () {
     const expectedResult = [
-      { text: "albert", _relevance_score: 0.99 },
-    ]
+      {
+        text: "albert",
+        // biome-ignore lint/style/useNamingConvention: this is the lance field name
+        _relevance_score: 0.99,
+      },
+    ];
     class MyCustomReranker {
       async rerankHybrid(
-        query: string,
-        vecResults: RecordBatch,
-        ftsResults: RecordBatch,
+        _query: string,
+        _vecResults: RecordBatch,
+        _ftsResults: RecordBatch,
       ): Promise<RecordBatch> {
         // no reranker logic, just return some static data
-        const table = makeArrowTable(expectedResult)
-        return table.batches[0]
+        const table = makeArrowTable(expectedResult);
+        return table.batches[0];
       }
     }
 
-    let result = await table.query()
+    let result = await table
+      .query()
       .nearestTo([0.1, 0.1])
       .fullTextSearch("dog")
       .rerank(new MyCustomReranker())
       .select(["text"])
       .limit(5)
-      .toArray()
+      .toArray();
 
-    result = JSON.parse(JSON.stringify(result)) // convert StructRow to Object
-    expect(result).toEqual([{text: "albert", _relevance_score: 0.99 }])
-  })
+    result = JSON.parse(JSON.stringify(result)); // convert StructRow to Object
+    expect(result).toEqual([
+      {
+        text: "albert",
+        // biome-ignore lint/style/useNamingConvention: this is the lance field name
+        _relevance_score: 0.99,
+      },
+    ]);
+  });
 
-  it("will query with RRFReranker", async function() {
-    // smoke test to see if the Javascript wrapping Typescript is wired up correctly
-    const result = await table.query()
+  it("will query with RRFReranker", async function () {
+    // smoke test to see if the Rust wrapping Typescript is wired up correctly
+    const result = await table
+      .query()
       .nearestTo([0.1, 0.1])
       .fullTextSearch("dog")
       .rerank(await RRFReranker.create())
       .select(["text"])
       .limit(5)
-      .toArray()
+      .toArray();
 
-    expect(result).toHaveLength(2)
-  })
-})
+    expect(result).toHaveLength(2);
+  });
+});

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -27,8 +27,9 @@ import {
   List,
   Null,
   RecordBatch,
-  RecordBatchFileWriter,
   RecordBatchFileReader,
+  RecordBatchFileWriter,
+  RecordBatchReader,
   RecordBatchStreamWriter,
   Schema,
   Struct,
@@ -38,7 +39,6 @@ import {
   makeData,
   type makeTable,
   vectorFromArray,
-  RecordBatchReader,
 } from "apache-arrow";
 import { Buffers } from "apache-arrow/data";
 import { type EmbeddingFunction } from "./embedding/embedding_function";
@@ -814,21 +814,26 @@ export async function fromDataToBuffer(
 
 /**
  * Read a single record batch from a buffer.
- * 
+ *
  * Returns null if the buffer does not contain a record batch
-*/
-export async function fromBufferToRecordBatch(data: Buffer): Promise<RecordBatch | null> {
-  const iter = await RecordBatchFileReader.readAll(Buffer.from(data)).next().value
-  const recordBatch = iter?.next().value
-  return recordBatch || null
+ */
+export async function fromBufferToRecordBatch(
+  data: Buffer,
+): Promise<RecordBatch | null> {
+  const iter = await RecordBatchFileReader.readAll(Buffer.from(data)).next()
+    .value;
+  const recordBatch = iter?.next().value;
+  return recordBatch || null;
 }
 
 /**
  * Create a buffer containing a single record batch
  */
-export async function fromRecordBatchToBuffer(batch: RecordBatch): Promise<Buffer> {
-  const writer = new RecordBatchFileWriter().writeAll([batch])
-  return Buffer.from(await writer.toUint8Array())
+export async function fromRecordBatchToBuffer(
+  batch: RecordBatch,
+): Promise<Buffer> {
+  const writer = new RecordBatchFileWriter().writeAll([batch]);
+  return Buffer.from(await writer.toUint8Array());
 }
 
 /**

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -28,6 +28,7 @@ import {
   Null,
   RecordBatch,
   RecordBatchFileWriter,
+  RecordBatchFileReader,
   RecordBatchStreamWriter,
   Schema,
   Struct,
@@ -37,6 +38,7 @@ import {
   makeData,
   type makeTable,
   vectorFromArray,
+  RecordBatchReader,
 } from "apache-arrow";
 import { Buffers } from "apache-arrow/data";
 import { type EmbeddingFunction } from "./embedding/embedding_function";
@@ -808,6 +810,25 @@ export async function fromDataToBuffer(
     const table = await convertToTable(data, embeddings, { schema });
     return fromTableToBuffer(table);
   }
+}
+
+/**
+ * Read a single record batch from a buffer.
+ * 
+ * Returns null if the buffer does not contain a record batch
+*/
+export async function fromBufferToRecordBatch(data: Buffer): Promise<RecordBatch | null> {
+  const iter = await RecordBatchFileReader.readAll(Buffer.from(data)).next().value
+  const recordBatch = iter?.next().value
+  return recordBatch || null
+}
+
+/**
+ * Create a buffer containing a single record batch
+ */
+export async function fromRecordBatchToBuffer(batch: RecordBatch): Promise<Buffer> {
+  const writer = new RecordBatchFileWriter().writeAll([batch])
+  return Buffer.from(await writer.toUint8Array())
 }
 
 /**

--- a/nodejs/lancedb/index.ts
+++ b/nodejs/lancedb/index.ts
@@ -62,6 +62,7 @@ export { Index, IndexOptions, IvfPqOptions } from "./indices";
 export { Table, AddDataOptions, UpdateOptions, OptimizeOptions } from "./table";
 
 export * as embedding from "./embedding";
+export * as rerankers from "./rerankers"
 
 /**
  * Connect to a LanceDB instance at the given URI.

--- a/nodejs/lancedb/index.ts
+++ b/nodejs/lancedb/index.ts
@@ -62,7 +62,7 @@ export { Index, IndexOptions, IvfPqOptions } from "./indices";
 export { Table, AddDataOptions, UpdateOptions, OptimizeOptions } from "./table";
 
 export * as embedding from "./embedding";
-export * as rerankers from "./rerankers"
+export * as rerankers from "./rerankers";
 
 /**
  * Connect to a LanceDB instance at the given URI.

--- a/nodejs/lancedb/query.ts
+++ b/nodejs/lancedb/query.ts
@@ -14,6 +14,8 @@
 
 import {
   Table as ArrowTable,
+  fromBufferToRecordBatch,
+  fromRecordBatchToBuffer,
   type IntoVector,
   RecordBatch,
   tableFromIPC,
@@ -25,6 +27,7 @@ import {
   Table as NativeTable,
   VectorQuery as NativeVectorQuery,
 } from "./native";
+import { Reranker } from "./rerankers";
 export class RecordBatchIterator implements AsyncIterator<RecordBatch> {
   private promisedInner?: Promise<NativeBatchIterator>;
   private inner?: NativeBatchIterator;
@@ -541,6 +544,25 @@ export class VectorQuery extends QueryBase<NativeVectorQuery> {
       });
       return this;
     }
+  }
+
+  rerank(reranker: Reranker): VectorQuery {
+    super.doCall((inner) => inner.rerank({
+      rerankHybrid: async (_, args) => {
+        const vecResults = await fromBufferToRecordBatch(args.vecResults)
+        const ftsResults = await fromBufferToRecordBatch(args.ftsResults)
+        const result = await reranker.rerankHybrid(
+          args.query,
+          vecResults as RecordBatch,
+          ftsResults as RecordBatch,
+        )
+
+        const buffer = fromRecordBatchToBuffer(result)
+        return buffer
+      }
+    }))
+
+    return this;
   }
 }
 

--- a/nodejs/lancedb/query.ts
+++ b/nodejs/lancedb/query.ts
@@ -14,10 +14,10 @@
 
 import {
   Table as ArrowTable,
-  fromBufferToRecordBatch,
-  fromRecordBatchToBuffer,
   type IntoVector,
   RecordBatch,
+  fromBufferToRecordBatch,
+  fromRecordBatchToBuffer,
   tableFromIPC,
 } from "./arrow";
 import { type IvfPqOptions } from "./indices";
@@ -547,20 +547,22 @@ export class VectorQuery extends QueryBase<NativeVectorQuery> {
   }
 
   rerank(reranker: Reranker): VectorQuery {
-    super.doCall((inner) => inner.rerank({
-      rerankHybrid: async (_, args) => {
-        const vecResults = await fromBufferToRecordBatch(args.vecResults)
-        const ftsResults = await fromBufferToRecordBatch(args.ftsResults)
-        const result = await reranker.rerankHybrid(
-          args.query,
-          vecResults as RecordBatch,
-          ftsResults as RecordBatch,
-        )
+    super.doCall((inner) =>
+      inner.rerank({
+        rerankHybrid: async (_, args) => {
+          const vecResults = await fromBufferToRecordBatch(args.vecResults);
+          const ftsResults = await fromBufferToRecordBatch(args.ftsResults);
+          const result = await reranker.rerankHybrid(
+            args.query,
+            vecResults as RecordBatch,
+            ftsResults as RecordBatch,
+          );
 
-        const buffer = fromRecordBatchToBuffer(result)
-        return buffer
-      }
-    }))
+          const buffer = fromRecordBatchToBuffer(result);
+          return buffer;
+        },
+      }),
+    );
 
     return this;
   }

--- a/nodejs/lancedb/rerankers/index.ts
+++ b/nodejs/lancedb/rerankers/index.ts
@@ -1,0 +1,28 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { RecordBatch } from "apache-arrow";
+
+export * from "./rrf"
+
+// Interface for a reranker. A reranker is used to rerank the results from a
+// vector and FTS search. This is useful for combining the results from both
+// search methods.
+export interface Reranker {
+  rerankHybrid(
+    query: string,
+    vecResults: RecordBatch,
+    ftsResults: RecordBatch,
+  ): Promise<RecordBatch>;
+}

--- a/nodejs/lancedb/rerankers/index.ts
+++ b/nodejs/lancedb/rerankers/index.ts
@@ -1,16 +1,5 @@
-// Copyright 2024 Lance Developers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 import { RecordBatch } from "apache-arrow";
 

--- a/nodejs/lancedb/rerankers/index.ts
+++ b/nodejs/lancedb/rerankers/index.ts
@@ -14,7 +14,7 @@
 
 import { RecordBatch } from "apache-arrow";
 
-export * from "./rrf"
+export * from "./rrf";
 
 // Interface for a reranker. A reranker is used to rerank the results from a
 // vector and FTS search. This is useful for combining the results from both

--- a/nodejs/lancedb/rerankers/rrf.ts
+++ b/nodejs/lancedb/rerankers/rrf.ts
@@ -1,0 +1,50 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import { RecordBatch } from "apache-arrow"
+import { fromBufferToRecordBatch, fromRecordBatchToBuffer } from "../arrow"
+import { RrfReranker as NativeRRFReranker } from "../native"
+
+/**
+ * Reranks the results using the Reciprocal Rank Fusion (RRF) algorithm.
+ * 
+ * Internally this uses the Rust implementation
+ */
+export class RRFReranker {
+  private inner: NativeRRFReranker
+
+  constructor(inner: NativeRRFReranker) {
+    this.inner = inner
+  }
+
+  public static async create(k:number = 60) {
+    return new RRFReranker(await NativeRRFReranker.tryNew(new Float32Array([k])))
+  }
+
+  async rerankHybrid(
+    query: string,
+    vecResults: RecordBatch,
+    ftsResults: RecordBatch,
+  ): Promise<RecordBatch> {
+    const buffer = await this.inner.rerankHybrid(
+      query,
+      await fromRecordBatchToBuffer(vecResults),
+      await fromRecordBatchToBuffer(ftsResults),
+    )
+    const recordBatch = await fromBufferToRecordBatch(buffer)
+
+    return recordBatch as RecordBatch
+  }
+}

--- a/nodejs/lancedb/rerankers/rrf.ts
+++ b/nodejs/lancedb/rerankers/rrf.ts
@@ -12,25 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-import { RecordBatch } from "apache-arrow"
-import { fromBufferToRecordBatch, fromRecordBatchToBuffer } from "../arrow"
-import { RrfReranker as NativeRRFReranker } from "../native"
+import { RecordBatch } from "apache-arrow";
+import { fromBufferToRecordBatch, fromRecordBatchToBuffer } from "../arrow";
+import { RrfReranker as NativeRRFReranker } from "../native";
 
 /**
  * Reranks the results using the Reciprocal Rank Fusion (RRF) algorithm.
- * 
+ *
  * Internally this uses the Rust implementation
  */
 export class RRFReranker {
-  private inner: NativeRRFReranker
+  private inner: NativeRRFReranker;
 
   constructor(inner: NativeRRFReranker) {
-    this.inner = inner
+    this.inner = inner;
   }
 
-  public static async create(k:number = 60) {
-    return new RRFReranker(await NativeRRFReranker.tryNew(new Float32Array([k])))
+  public static async create(k: number = 60) {
+    return new RRFReranker(
+      await NativeRRFReranker.tryNew(new Float32Array([k])),
+    );
   }
 
   async rerankHybrid(
@@ -42,9 +43,9 @@ export class RRFReranker {
       query,
       await fromRecordBatchToBuffer(vecResults),
       await fromRecordBatchToBuffer(ftsResults),
-    )
-    const recordBatch = await fromBufferToRecordBatch(buffer)
+    );
+    const recordBatch = await fromBufferToRecordBatch(buffer);
 
-    return recordBatch as RecordBatch
+    return recordBatch as RecordBatch;
   }
 }

--- a/nodejs/lancedb/rerankers/rrf.ts
+++ b/nodejs/lancedb/rerankers/rrf.ts
@@ -1,16 +1,5 @@
-// Copyright 2024 Lance Developers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 import { RecordBatch } from "apache-arrow";
 import { fromBufferToRecordBatch, fromRecordBatchToBuffer } from "../arrow";

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -24,6 +24,7 @@ mod iterator;
 pub mod merge;
 mod query;
 pub mod remote;
+mod rerankers;
 mod table;
 mod util;
 

--- a/nodejs/src/query.rs
+++ b/nodejs/src/query.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::ExecutableQuery;
 use lancedb::query::Query as LanceDbQuery;
@@ -25,6 +27,8 @@ use napi_derive::napi;
 use crate::error::convert_error;
 use crate::error::NapiErrorExt;
 use crate::iterator::RecordBatchIterator;
+use crate::rerankers::Reranker;
+use crate::rerankers::RerankerCallbacks;
 use crate::util::parse_distance_type;
 
 #[napi]
@@ -216,6 +220,14 @@ impl VectorQuery {
     #[napi]
     pub fn with_row_id(&mut self) {
         self.inner = self.inner.clone().with_row_id();
+    }
+
+    #[napi]
+    pub fn rerank(&mut self, callbacks: RerankerCallbacks) {
+        self.inner = self
+            .inner
+            .clone()
+            .rerank(Arc::new(Reranker::new(callbacks)));
     }
 
     #[napi(catch_unwind)]

--- a/nodejs/src/rerankers.rs
+++ b/nodejs/src/rerankers.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 Lance Developers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use arrow_array::RecordBatch;
 use async_trait::async_trait;

--- a/nodejs/src/rerankers.rs
+++ b/nodejs/src/rerankers.rs
@@ -1,0 +1,156 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow_array::RecordBatch;
+use async_trait::async_trait;
+use napi::{
+    bindgen_prelude::*,
+    threadsafe_function::{ErrorStrategy, ThreadsafeFunction},
+};
+use napi_derive::napi;
+
+use lancedb::ipc::batches_to_ipc_file;
+use lancedb::rerankers::Reranker as LanceDBReranker;
+use lancedb::{error::Error, ipc::ipc_file_to_batches};
+
+use crate::error::NapiErrorExt;
+
+/// Reranker implementation that "wraps" a NodeJS Reranker implementation.
+/// This contains closures over the callbacks that can be used to invoke the
+/// reranking methods on the NodeJS implementation and handles serializing the
+/// record batches to Arrow IPC buffers.
+#[napi]
+pub struct Reranker {
+    rerank_hybrid: ThreadsafeFunction<RerankHybridCallbackArgs, ErrorStrategy::CalleeHandled>,
+}
+
+#[napi]
+impl Reranker {
+    #[napi]
+    pub fn new(callbacks: RerankerCallbacks) -> Self {
+        let rerank_hybrid = callbacks
+            .rerank_hybrid
+            .create_threadsafe_function(0, move |ctx| Ok(vec![ctx.value]))
+            .unwrap();
+
+        Self { rerank_hybrid }
+    }
+}
+
+#[async_trait]
+impl lancedb::rerankers::Reranker for Reranker {
+    async fn rerank_hybrid(
+        &self,
+        query: &str,
+        vector_results: RecordBatch,
+        fts_results: RecordBatch,
+    ) -> lancedb::error::Result<RecordBatch> {
+        let callback_args = RerankHybridCallbackArgs {
+            query: query.to_string(),
+            vec_results: batches_to_ipc_file(&[vector_results])?,
+            fts_results: batches_to_ipc_file(&[fts_results])?,
+        };
+        let promised_buffer: Promise<Buffer> = self
+            .rerank_hybrid
+            .call_async(Ok(callback_args))
+            .await
+            .map_err(|e| Error::Runtime {
+                message: format!("napi error status={}, reason={}", e.status, e.reason),
+            })?;
+        let buffer = promised_buffer.await.map_err(|e| Error::Runtime {
+            message: format!("napi error status={}, reason={}", e.status, e.reason),
+        })?;
+        let mut reader = ipc_file_to_batches(buffer.to_vec())?;
+        let result = reader.next().ok_or(Error::Runtime {
+            message: "reranker result deserialization failed".to_string(),
+        })??;
+
+        return Ok(result);
+    }
+}
+
+impl std::fmt::Debug for Reranker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("NodeJSRerankerWrapper")
+    }
+}
+
+#[napi(object)]
+pub struct RerankerCallbacks {
+    pub rerank_hybrid: JsFunction,
+}
+
+#[napi(object)]
+pub struct RerankHybridCallbackArgs {
+    pub query: String,
+    pub vec_results: Vec<u8>,
+    pub fts_results: Vec<u8>,
+}
+
+fn buffer_to_record_batch(buffer: Buffer) -> Result<RecordBatch> {
+    let mut reader = ipc_file_to_batches(buffer.to_vec()).default_error()?;
+    reader
+        .next()
+        .ok_or(Error::InvalidInput {
+            message: "expected buffer containing record batch".to_string(),
+        })
+        .default_error()?
+        .map_err(Error::from)
+        .default_error()
+}
+
+/// Wrapper around rust RRFReranker
+#[napi]
+pub struct RRFReranker {
+    inner: lancedb::rerankers::rrf::RRFReranker,
+}
+
+#[napi]
+impl RRFReranker {
+    #[napi]
+    pub async fn try_new(k: &[f32]) -> Result<Self> {
+        let k = k
+            .first()
+            .copied()
+            .ok_or(Error::InvalidInput {
+                message: "must supply RRF Reranker constructor arg 'k'".to_string(),
+            })
+            .default_error()?;
+
+        Ok(Self {
+            inner: lancedb::rerankers::rrf::RRFReranker::new(k),
+        })
+    }
+
+    #[napi]
+    pub async fn rerank_hybrid(
+        &self,
+        query: String,
+        vec_results: Buffer,
+        fts_results: Buffer,
+    ) -> Result<Buffer> {
+        let vec_results = buffer_to_record_batch(vec_results)?;
+        let fts_results = buffer_to_record_batch(fts_results)?;
+
+        let result = self
+            .inner
+            .rerank_hybrid(&query, vec_results, fts_results)
+            .await
+            .unwrap();
+
+        let result_buff = batches_to_ipc_file(&[result]).default_error()?;
+
+        Ok(Buffer::from(result_buff.as_ref()))
+    }
+}

--- a/nodejs/src/rerankers.rs
+++ b/nodejs/src/rerankers.rs
@@ -27,11 +27,13 @@ use lancedb::{error::Error, ipc::ipc_file_to_batches};
 use crate::error::NapiErrorExt;
 
 /// Reranker implementation that "wraps" a NodeJS Reranker implementation.
-/// This contains closures over the callbacks that can be used to invoke the
+/// This contains references to the callbacks that can be used to invoke the
 /// reranking methods on the NodeJS implementation and handles serializing the
 /// record batches to Arrow IPC buffers.
 #[napi]
 pub struct Reranker {
+    /// callback to the Javascript which will call the rerankHybrid method of
+    /// some Reranker implementation
     rerank_hybrid: ThreadsafeFunction<RerankHybridCallbackArgs, ErrorStrategy::CalleeHandled>,
 }
 

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -214,6 +214,7 @@ mod polars_arrow_convertors;
 pub mod query;
 #[cfg(feature = "remote")]
 pub mod remote;
+pub mod rerankers;
 pub mod table;
 pub mod utils;
 

--- a/rust/lancedb/src/query/hybrid.rs
+++ b/rust/lancedb/src/query/hybrid.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 Lance Developers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use arrow::compute::{
     kernels::numeric::{div, sub},

--- a/rust/lancedb/src/query/hybrid.rs
+++ b/rust/lancedb/src/query/hybrid.rs
@@ -1,0 +1,355 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow::compute::{
+    kernels::numeric::{div, sub},
+    max, min, sort_to_indices, take,
+};
+use arrow_array::{cast::downcast_array, Float32Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema, SortOptions};
+use lance::dataset::ROW_ID;
+use lance_index::{scalar::inverted::SCORE_COL, vector::DIST_COL};
+use std::sync::Arc;
+
+use crate::error::{Error, Result};
+
+/// Converts results's score column to a rank.
+///
+/// Expects the `column` argument to be type Float32 and will panic if it's not
+pub fn rank(results: RecordBatch, column: &str, ascending: Option<bool>) -> Result<RecordBatch> {
+    let scores = results.column_by_name(column).ok_or(Error::InvalidInput {
+        message: format!(
+            "expected column {} not found in rank. found columns {:?}",
+            column,
+            results
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name())
+                .collect::<Vec<_>>(),
+        ),
+    })?;
+
+    if results.num_rows() == 0 {
+        return Ok(results);
+    }
+
+    let scores: Float32Array = downcast_array(scores);
+    let score_indices = sort_to_indices(
+        &scores,
+        Some(SortOptions {
+            descending: !ascending.unwrap_or(true),
+            ..Default::default()
+        }),
+        None,
+    )?;
+    let schema = results.schema();
+    let ranks = Float32Array::from_iter_values((1..results.num_rows() + 1).map(|i| i as f32));
+    let ranks = take(&ranks, &score_indices, None)?;
+    let (column_idx, _) = schema.column_with_name(column).unwrap();
+    let mut columns = results.columns().to_vec();
+    columns[column_idx] = ranks;
+
+    let results = RecordBatch::try_new(results.schema(), columns)?;
+
+    Ok(results)
+}
+
+/// Get the query schemas needed when combining the search results.
+///
+/// If either of the record batches are empty, then we create a schema from the
+/// other record batch, and replace the score/distance column. If both record
+/// batches are empty, create empty schemas.
+pub fn query_schemas(
+    fts_results: &[RecordBatch],
+    vec_results: &[RecordBatch],
+) -> (Arc<Schema>, Arc<Schema>) {
+    let (fts_schema, vec_schema) = match (
+        fts_results.first().map(|r| r.schema()),
+        vec_results.first().map(|r| r.schema()),
+    ) {
+        (Some(fts_schema), Some(vec_schema)) => (fts_schema, vec_schema),
+        (None, Some(vec_schema)) => {
+            let fts_schema = with_field_name_replaced(&vec_schema, DIST_COL, SCORE_COL);
+            (Arc::new(fts_schema), vec_schema)
+        }
+        (Some(fts_schema), None) => {
+            let vec_schema = with_field_name_replaced(&fts_schema, DIST_COL, SCORE_COL);
+            (fts_schema, Arc::new(vec_schema))
+        }
+        (None, None) => (Arc::new(empty_fts_schema()), Arc::new(empty_vec_schema())),
+    };
+
+    (fts_schema, vec_schema)
+}
+
+pub fn empty_fts_schema() -> Schema {
+    Schema::new(vec![
+        Arc::new(Field::new(SCORE_COL, DataType::Float32, false)),
+        Arc::new(Field::new(ROW_ID, DataType::UInt64, false)),
+    ])
+}
+
+pub fn empty_vec_schema() -> Schema {
+    Schema::new(vec![
+        Arc::new(Field::new(DIST_COL, DataType::Float32, false)),
+        Arc::new(Field::new(ROW_ID, DataType::UInt64, false)),
+    ])
+}
+
+pub fn with_field_name_replaced(schema: &Schema, target: &str, replacement: &str) -> Schema {
+    let field_idx = schema.fields().iter().enumerate().find_map(|(i, field)| {
+        if field.name() == target {
+            Some(i)
+        } else {
+            None
+        }
+    });
+
+    let mut fields = schema.fields().to_vec();
+    if let Some(idx) = field_idx {
+        let new_field = (*fields[idx]).clone().with_name(replacement);
+        fields[idx] = Arc::new(new_field);
+    }
+
+    Schema::new(fields)
+}
+
+/// Normalize the scores column to have values between 0 and 1.
+///
+/// Expects the `column` argument to be type Float32 and will panic if it's not
+pub fn normalize_scores(
+    results: RecordBatch,
+    column: &str,
+    invert: Option<bool>,
+) -> Result<RecordBatch> {
+    let scores = results.column_by_name(column).ok_or(Error::InvalidInput {
+        message: format!(
+            "expected column {} not found in rank. found columns {:?}",
+            column,
+            results
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name())
+                .collect::<Vec<_>>(),
+        ),
+    })?;
+
+    if results.num_rows() == 0 {
+        return Ok(results);
+    }
+    let mut scores: Float32Array = downcast_array(scores);
+
+    let max = max(&scores).unwrap_or(0.0);
+    let min = min(&scores).unwrap_or(0.0);
+
+    // this is equivalent to np.isclose which is used in python
+    let rng = if max - min < 10e-5 { max } else { max - min };
+
+    // if rng is 0, then min and max are both 0 so we just leave the scores as is
+    if rng != 0.0 {
+        let tmp = div(
+            &sub(&scores, &Float32Array::new_scalar(min))?,
+            &Float32Array::new_scalar(rng),
+        )?;
+        scores = downcast_array(&tmp);
+    }
+
+    if invert.unwrap_or(false) {
+        let tmp = sub(&Float32Array::new_scalar(1.0), &scores)?;
+        scores = downcast_array(&tmp);
+    }
+
+    let schema = results.schema();
+    let (column_idx, _) = schema.column_with_name(column).unwrap();
+    let mut columns = results.columns().to_vec();
+    columns[column_idx] = Arc::new(scores);
+
+    let results = RecordBatch::try_new(results.schema(), columns).unwrap();
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow_array::StringArray;
+    use arrow_schema::{DataType, Field, Schema};
+
+    #[test]
+    fn test_rank() {
+        let schema = Arc::new(Schema::new(vec![
+            Arc::new(Field::new("name", DataType::Utf8, false)),
+            Arc::new(Field::new("score", DataType::Float32, false)),
+        ]));
+
+        let names = StringArray::from(vec!["foo", "bar", "baz", "bean", "dog"]);
+        let scores = Float32Array::from(vec![0.2, 0.4, 0.1, 0.6, -0.4]);
+
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(names), Arc::new(scores)]).unwrap();
+
+        let result = rank(batch.clone(), "score", Some(false)).unwrap();
+        assert_eq!(2, result.schema().fields().len());
+        assert_eq!("name", result.schema().field(0).name());
+        assert_eq!("score", result.schema().field(1).name());
+
+        let names: StringArray = downcast_array(result.column(0));
+        assert_eq!(
+            names.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec!["bean", "bar", "foo", "baz", "dog"]
+        );
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0]
+        );
+
+        // check sort ascending
+        let result = rank(batch.clone(), "score", Some(true)).unwrap();
+        let names: StringArray = downcast_array(result.column(0));
+        assert_eq!(
+            names.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec!["dog", "baz", "foo", "bar", "bean"]
+        );
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0]
+        );
+
+        // ensure default sort is ascending
+        let result = rank(batch.clone(), "score", None).unwrap();
+        let names: StringArray = downcast_array(result.column(0));
+        assert_eq!(
+            names.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec!["dog", "baz", "foo", "bar", "bean"]
+        );
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0]
+        );
+
+        // check it can handle an empty batch
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(Vec::<&str>::new())),
+                Arc::new(Float32Array::from(Vec::<f32>::new())),
+            ],
+        )
+        .unwrap();
+        let result = rank(batch.clone(), "score", None).unwrap();
+        assert_eq!(0, result.num_rows());
+        assert_eq!(2, result.schema().fields().len());
+        assert_eq!("name", result.schema().field(0).name());
+        assert_eq!("score", result.schema().field(1).name());
+
+        // check it returns the expected error when there's no column
+        let result = rank(batch.clone(), "bad_col", None);
+        match result {
+            Err(Error::InvalidInput { message }) => {
+                assert_eq!("expected column bad_col not found in rank. found columns [\"name\", \"score\"]", message);
+            }
+            _ => {
+                panic!("expected invalid input error, received {:?}", result)
+            }
+        }
+    }
+
+    #[test]
+    fn test_normalize_scores() {
+        let schema = Arc::new(Schema::new(vec![
+            Arc::new(Field::new("name", DataType::Utf8, false)),
+            Arc::new(Field::new("score", DataType::Float32, false)),
+        ]));
+
+        let names = Arc::new(StringArray::from(vec!["foo", "bar", "baz", "bean", "dog"]));
+        let scores = Arc::new(Float32Array::from(vec![-4.0, 2.0, 0.0, 3.0, 6.0]));
+
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![names.clone(), scores.clone()]).unwrap();
+
+        let result = normalize_scores(batch.clone(), "score", Some(false)).unwrap();
+        let names: StringArray = downcast_array(result.column(0));
+        assert_eq!(
+            names.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec!["foo", "bar", "baz", "bean", "dog"]
+        );
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![0.0, 0.6, 0.4, 0.7, 1.0]
+        );
+
+        // check it can invert the normalization
+        let result = normalize_scores(batch.clone(), "score", Some(true)).unwrap();
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![1.0, 1.0 - 0.6, 0.6, 0.3, 0.0]
+        );
+
+        // check that the default is not inverted
+        let result = normalize_scores(batch.clone(), "score", None).unwrap();
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![0.0, 0.6, 0.4, 0.7, 1.0]
+        );
+
+        // check that it will function correctly if all the values are the same
+        let names = Arc::new(StringArray::from(vec!["foo", "bar", "baz", "bean", "dog"]));
+        let scores = Arc::new(Float32Array::from(vec![2.1, 2.1, 2.1, 2.1, 2.1]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![names.clone(), scores.clone()]).unwrap();
+        let result = normalize_scores(batch.clone(), "score", None).unwrap();
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+
+        // check it keeps floating point rounding errors for same score normalized the same
+        // e.g., the behaviour is consistent with python
+        let scores = Arc::new(Float32Array::from(vec![1.0, 1.0, 1.0, 1.0, 0.9999999]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![names.clone(), scores.clone()]).unwrap();
+        let result = normalize_scores(batch.clone(), "score", None).unwrap();
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![
+                1.0 - 0.9999999,
+                1.0 - 0.9999999,
+                1.0 - 0.9999999,
+                1.0 - 0.9999999,
+                0.0
+            ]
+        );
+
+        // check that it can handle if all the scores are 0
+        let scores = Arc::new(Float32Array::from(vec![0.0, 0.0, 0.0, 0.0, 0.0]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![names.clone(), scores.clone()]).unwrap();
+        let result = normalize_scores(batch.clone(), "score", None).unwrap();
+        let scores: Float32Array = downcast_array(result.column(1));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+    }
+}

--- a/rust/lancedb/src/query/hybrid.rs
+++ b/rust/lancedb/src/query/hybrid.rs
@@ -62,11 +62,12 @@ pub fn rank(results: RecordBatch, column: &str, ascending: Option<bool>) -> Resu
     // should be in the list.
     let score_indices = sort_to_indices(
         &score_indices,
-        Some(SortOptions{
+        Some(SortOptions {
             descending: false,
             ..Default::default()
         }),
-        None)?;
+        None,
+    )?;
 
     let schema = results.schema();
     let ranks = Float32Array::from_iter_values((1..results.num_rows() + 1).map(|i| i as f32));
@@ -208,7 +209,6 @@ mod test {
             Arc::new(Field::new("name", DataType::Utf8, false)),
             Arc::new(Field::new("score", DataType::Float32, false)),
         ]));
-
 
         let names = StringArray::from(vec!["foo", "bar", "baz", "bean", "dog"]);
         let scores = Float32Array::from(vec![0.2, 0.4, 0.1, 0.6, 0.45]);

--- a/rust/lancedb/src/rerankers.rs
+++ b/rust/lancedb/src/rerankers.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 Lance Developers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use std::collections::BTreeSet;
 

--- a/rust/lancedb/src/rerankers.rs
+++ b/rust/lancedb/src/rerankers.rs
@@ -1,0 +1,98 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+
+use arrow::{
+    array::downcast_array,
+    compute::{concat_batches, filter_record_batch},
+};
+use arrow_array::{BooleanArray, RecordBatch, UInt64Array};
+use async_trait::async_trait;
+use lance::dataset::ROW_ID;
+
+use crate::error::{Error, Result};
+
+pub mod rrf;
+
+/// column name for reranker relevance score
+const RELEVANCE_SCORE: &str = "_relevance_score";
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum NormalizeMethod {
+    Score,
+    Rank,
+}
+
+/// Interface for a reranker. A reranker is used to rerank the results from a
+/// vector and FTS search. This is useful for combining the results from both
+/// search methods.
+#[async_trait]
+pub trait Reranker: std::fmt::Debug + Sync + Send {
+    // TODO support vector reranking and FTS reranking. Currently only hybrid reranking is supported.
+
+    /// Rerank function receives the individual results from the vector and FTS search
+    /// results. You can choose to use any of the results to generate the final results,
+    /// allowing maximum flexibility.
+    async fn rerank_hybrid(
+        &self,
+        query: &str,
+        vector_results: RecordBatch,
+        fts_results: RecordBatch,
+    ) -> Result<RecordBatch>;
+
+    fn merge_results(
+        &self,
+        vector_results: RecordBatch,
+        fts_results: RecordBatch,
+    ) -> Result<RecordBatch> {
+        let combined = concat_batches(&fts_results.schema(), [vector_results, fts_results].iter())?;
+
+        let mut mask = BooleanArray::builder(combined.num_rows());
+        let mut unique_ids = BTreeSet::new();
+        let row_ids = combined.column_by_name(ROW_ID).ok_or(Error::InvalidInput {
+            message: format!(
+                "could not find expected column {} while merging results. found columns {:?}",
+                ROW_ID,
+                combined
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|f| f.name())
+                    .collect::<Vec<_>>()
+            ),
+        })?;
+        let row_ids: UInt64Array = downcast_array(row_ids);
+        row_ids.values().iter().for_each(|id| {
+            mask.append_value(unique_ids.insert(id));
+        });
+
+        let combined = filter_record_batch(&combined, &mask.finish())?;
+
+        Ok(combined)
+    }
+}
+
+pub fn check_reranker_result(result: &RecordBatch) -> Result<()> {
+    if result.schema().column_with_name(RELEVANCE_SCORE).is_none() {
+        return Err(Error::Schema {
+            message: format!(
+                "rerank_hybrid must return a RecordBatch with a column named {}",
+                RELEVANCE_SCORE
+            ),
+        });
+    }
+
+    Ok(())
+}

--- a/rust/lancedb/src/rerankers/rrf.rs
+++ b/rust/lancedb/src/rerankers/rrf.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 Lance Developers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -32,14 +21,16 @@ use crate::rerankers::{Reranker, RELEVANCE_SCORE};
 ///
 #[derive(Debug)]
 pub struct RRFReranker {
-    /// A constant used in the RRF formula (default is 60). Experiments
-    /// indicate that k = 60 was near-optimal, but that the choice is
-    /// not critical. See paper:
-    /// https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
     k: f32,
 }
 
 impl RRFReranker {
+    /// Create a new RRFReranker
+    ///
+    /// The parameter k is a constant used in the RRF formula (default is 60).
+    /// Experiments indicate that k = 60 was near-optimal, but that the choice
+    /// is not critical. See paper:
+    /// https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
     pub fn new(k: f32) -> Self {
         Self { k }
     }

--- a/rust/lancedb/src/rerankers/rrf.rs
+++ b/rust/lancedb/src/rerankers/rrf.rs
@@ -204,7 +204,7 @@ pub mod test {
             .unwrap();
 
         assert_eq!(3, result.schema().fields().len());
-        assert_eq!("name", result.schema().fields().get(0).unwrap().name());
+        assert_eq!("name", result.schema().fields().first().unwrap().name());
         assert_eq!(ROW_ID, result.schema().fields().get(1).unwrap().name());
         assert_eq!(
             RELEVANCE_SCORE,

--- a/rust/lancedb/src/rerankers/rrf.rs
+++ b/rust/lancedb/src/rerankers/rrf.rs
@@ -1,0 +1,232 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use arrow::{
+    array::downcast_array,
+    compute::{sort_to_indices, take},
+};
+use arrow_array::{Float32Array, RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Field, Schema, SortOptions};
+use async_trait::async_trait;
+use lance::dataset::ROW_ID;
+
+use crate::error::{Error, Result};
+use crate::rerankers::{Reranker, RELEVANCE_SCORE};
+
+/// Reranks the results using Reciprocal Rank Fusion(RRF) algorithm based
+/// on the scores of vector and FTS search.
+///
+#[derive(Debug)]
+pub struct RRFReranker {
+    /// A constant used in the RRF formula (default is 60). Experiments
+    /// indicate that k = 60 was near-optimal, but that the choice is
+    /// not critical. See paper:
+    /// https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
+    k: f32,
+}
+
+impl RRFReranker {
+    pub fn new(k: f32) -> Self {
+        Self { k }
+    }
+}
+
+impl Default for RRFReranker {
+    fn default() -> Self {
+        Self { k: 60.0 }
+    }
+}
+
+#[async_trait]
+impl Reranker for RRFReranker {
+    async fn rerank_hybrid(
+        &self,
+        _query: &str,
+        vector_results: RecordBatch,
+        fts_results: RecordBatch,
+    ) -> Result<RecordBatch> {
+        let vector_ids = vector_results
+            .column_by_name(ROW_ID)
+            .ok_or(Error::InvalidInput {
+                message: format!(
+                    "expected column {} not found in vector_results. found columns {:?}",
+                    ROW_ID,
+                    vector_results
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|f| f.name())
+                        .collect::<Vec<_>>()
+                ),
+            })?;
+        let fts_ids = fts_results
+            .column_by_name(ROW_ID)
+            .ok_or(Error::InvalidInput {
+                message: format!(
+                    "expected column {} not found in fts_results. found columns {:?}",
+                    ROW_ID,
+                    fts_results
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|f| f.name())
+                        .collect::<Vec<_>>()
+                ),
+            })?;
+
+        let vector_ids: UInt64Array = downcast_array(&vector_ids);
+        let fts_ids: UInt64Array = downcast_array(&fts_ids);
+
+        let mut rrf_score_map = BTreeMap::new();
+        let mut update_score_map = |(i, result_id)| {
+            let score = 1.0 / (i as f32 + self.k);
+            rrf_score_map
+                .entry(result_id)
+                .and_modify(|e| *e += score)
+                .or_insert(score);
+        };
+        vector_ids
+            .values()
+            .iter()
+            .enumerate()
+            .for_each(&mut update_score_map);
+        fts_ids
+            .values()
+            .iter()
+            .enumerate()
+            .for_each(&mut update_score_map);
+
+        let combined_results = self.merge_results(vector_results, fts_results)?;
+
+        let combined_row_ids: UInt64Array =
+            downcast_array(combined_results.column_by_name(ROW_ID).unwrap());
+        let relevance_scores = Float32Array::from_iter_values(
+            combined_row_ids
+                .values()
+                .iter()
+                .map(|row_id| rrf_score_map.get(row_id).unwrap())
+                .copied(),
+        );
+
+        // keep track of indices sorted by the relevance column
+        let sort_indices = sort_to_indices(
+            &relevance_scores,
+            Some(SortOptions {
+                descending: true,
+                ..Default::default()
+            }),
+            None,
+        )
+        .unwrap();
+
+        // add relevance scores to columns
+        let mut columns = combined_results.columns().to_vec();
+        columns.push(Arc::new(relevance_scores));
+
+        // sort by the relevance scores
+        let columns = columns
+            .iter()
+            .map(|c| take(c, &sort_indices, None).unwrap())
+            .collect();
+
+        // add relevance score to schema
+        let mut fields = combined_results.schema().fields().to_vec();
+        fields.push(Arc::new(Field::new(
+            RELEVANCE_SCORE,
+            DataType::Float32,
+            false,
+        )));
+        let schema = Schema::new(fields);
+
+        let combined_results = RecordBatch::try_new(Arc::new(schema), columns)?;
+
+        Ok(combined_results)
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use arrow_array::StringArray;
+
+    #[tokio::test]
+    async fn test_rrf_reranker() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+
+        let vec_results = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["foo", "bar", "baz", "bean", "dog"])),
+                Arc::new(UInt64Array::from(vec![1, 4, 2, 5, 3])),
+            ],
+        )
+        .unwrap();
+
+        let fts_results = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["bar", "bean", "dog"])),
+                Arc::new(UInt64Array::from(vec![4, 5, 3])),
+            ],
+        )
+        .unwrap();
+
+        // scores should be calculated as:
+        // - foo = 1/1        = 1.0
+        // - bar = 1/2 + 1/1  = 1.5
+        // - baz = 1/3        = 0.333
+        // - bean = 1/4 + 1/2 = 0.75
+        // - dog = 1/5 + 1/3  = 0.533
+        // then we should get the result ranked in descending order
+
+        let reranker = RRFReranker::new(1.0);
+
+        let result = reranker
+            .rerank_hybrid("", vec_results, fts_results)
+            .await
+            .unwrap();
+
+        assert_eq!(3, result.schema().fields().len());
+        assert_eq!("name", result.schema().fields().get(0).unwrap().name());
+        assert_eq!(ROW_ID, result.schema().fields().get(1).unwrap().name());
+        assert_eq!(
+            RELEVANCE_SCORE,
+            result.schema().fields().get(2).unwrap().name()
+        );
+
+        let names: StringArray = downcast_array(result.column(0));
+        assert_eq!(
+            names.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec!["bar", "foo", "bean", "dog", "baz"]
+        );
+
+        let ids: UInt64Array = downcast_array(result.column(1));
+        assert_eq!(
+            ids.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![4, 1, 5, 3, 2]
+        );
+
+        let scores: Float32Array = downcast_array(result.column(2));
+        assert_eq!(
+            scores.iter().map(|e| e.unwrap()).collect::<Vec<_>>(),
+            vec![1.5, 1.0, 0.75, 1.0 / 5.0 + 1.0 / 3.0, 1.0 / 3.0]
+        );
+    }
+}


### PR DESCRIPTION
Support hybrid search in both rust and node SDKs.

- Adds a new rerankers package to rust LanceDB, with the implementation of the default RRF reranker
- Adds a new hybrid package to lancedb, with some helper methods related to hybrid search such as normalizing scores and converting score column to rank columns
- Adds capability to LanceDB VectorQuery to perform hybrid search if it has both a nearest vector and full text search parameters.
- Adds wrappers for reranker implementations to nodejs SDK.

Additional rerankers will be added in followup PRs

https://github.com/lancedb/lancedb/issues/1921

---
Notes about how the rust rerankers are wrapped for calling from JS:

I wanted to keep the core reranker logic, and the invocation of the reranker by the query code, in Rust. This aligns with the philosophy of the new node SDK where it's just a thin wrapper around Rust. However, I also wanted to have support for users who want to add custom rerankers written in Javascript.

When we add a reranker to the query from Javascript, it adds a special Rust reranker that has a callback to the Javascript code (which could then turn around and call an underlying Rust reranker implementation if desired). This adds a bit of complexity, but overall I think it moves us in the right direction of having the majority of the query logic in the underlying Rust SDK while keeping the option open to support custom Javascript Rerankers.