### PR TITLE
feat(python): add `bypass_vector_index` to sync api

### DIFF
--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2798,6 +2798,8 @@ class AsyncTable:
                 async_query = async_query.column(query.vector_column)
             if query.ef:
                 async_query = async_query.ef(query.ef)
+            if not query.use_index:
+                async_query = async_query.bypass_vector_index()
 
         if not query.prefilter:
             async_query = async_query.postfilter()

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -684,10 +684,7 @@ def test_create_table_with_invalid_names(tmp_db: lancedb.DBConnection):
 
 
 def test_bypass_vector_index_sync(tmp_db: lancedb.DBConnection):
-    data = [
-        {"vector": np.random.rand(32)}
-        for _ in range(512)
-    ]
+    data = [{"vector": np.random.rand(32)} for _ in range(512)]
     sample_key = data[100]["vector"]
     table = tmp_db.create_table(
         "test",
@@ -699,17 +696,10 @@ def test_bypass_vector_index_sync(tmp_db: lancedb.DBConnection):
         num_sub_vectors=2,
     )
 
-    plan_with_index = (
-        table
-        .search(sample_key)
-        .explain_plan(verbose=True)
-    )
+    plan_with_index = table.search(sample_key).explain_plan(verbose=True)
     assert "ANN" in plan_with_index
 
     plan_without_index = (
-        table
-        .search(sample_key)
-        .bypass_vector_index()
-        .explain_plan(verbose=True)
+        table.search(sample_key).bypass_vector_index().explain_plan(verbose=True)
     )
     assert "KNN" in plan_without_index

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -681,3 +681,35 @@ def test_create_table_with_invalid_names(tmp_db: lancedb.DBConnection):
     with pytest.raises(ValueError):
         tmp_db.create_table("foo$$bar", data)
     tmp_db.create_table("foo.bar", data)
+
+
+def test_bypass_vector_index_sync(tmp_db: lancedb.DBConnection):
+    data = [
+        {"vector": np.random.rand(32)}
+        for _ in range(512)
+    ]
+    sample_key = data[100]["vector"]
+    table = tmp_db.create_table(
+        "test",
+        data,
+    )
+
+    table.create_index(
+        num_partitions=2,
+        num_sub_vectors=2,
+    )
+
+    plan_with_index = (
+        table
+        .search(sample_key)
+        .explain_plan(verbose=True)
+    )
+    assert "ANN" in plan_with_index
+
+    plan_without_index = (
+        table
+        .search(sample_key)
+        .bypass_vector_index()
+        .explain_plan(verbose=True)
+    )
+    assert "KNN" in plan_without_index


### PR DESCRIPTION
Hi lancedb team,

This PR adds the `bypass_vector_index` logic to the sync API, as described in [Issue #535](https://github.com/lancedb/lancedb/issues/535). (Closes #535).

Iv'e implemented it only for the regular vector search. If you think it should also be supported for FTS, Hybrid, or Empty queries and for the cloud solution, please let me know, and I’ll be happy to extend it.

Since there’s no `CONTRIBUTING.md` or contribution guidelines, I opted for the simplest implementation to get this started.

Looking forward to your feedback!

Thanks!