### PR TITLE
ci(rust): check MSRV and upgrade toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,7 @@ jobs:
     steps:
       - run: |
           rustc --version
+          cargo --version
           rustup toolchain list
       - uses: actions/checkout@v4
         with:
@@ -271,9 +272,11 @@ jobs:
           cargo update -p aws-sdk-bedrockruntime --precise 1.64.0
           cargo update -p aws-sdk-dynamodb --precise 1.55.0
           cargo update -p aws-config --precise 1.5.10
+          cargo update -p aws-sdk-kms --precise 1.51.0
+          cargo update -p aws-sdk-s3 --precise 1.65.0
           cargo update -p aws-sdk-sso --precise 1.50.0
           cargo update -p aws-sdk-ssooidc --precise 1.51.0
           cargo update -p aws-sdk-sts --precise 1.51.0
-          cargo update -p home --precise 0.5.11
+          cargo update -p home --precise 0.5.9
       - name: cargo +${{ matrix.msrv }} check
         run: cargo check --workspace --tests --benches --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,9 @@ jobs:
       CC: clang-18
       CXX: clang++-18
     steps:
+      - run: |
+          rustc --version
+          rustup toolchain list
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,11 +39,6 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
-      - run: |
-          cargo clean
-          rustc --version
-          cargo --version
-          rustup toolchain list
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -185,7 +185,7 @@ jobs:
           Add-Content $env:GITHUB_PATH "C:\BuildTools\VC\Tools\Llvm\x64\bin"
 
           # Add MSVC runtime libraries to LIB
-          $env:LIB = "C:\BuildTools\VC\Tools\MSVC\$latestVersion\lib\arm64;" + 
+          $env:LIB = "C:\BuildTools\VC\Tools\MSVC\$latestVersion\lib\arm64;" +
                      "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\arm64;" +
                      "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\arm64"
           Add-Content $env:GITHUB_ENV "LIB=$env:LIB"
@@ -238,3 +238,39 @@ jobs:
           $env:VCPKG_ROOT = $env:VCPKG_INSTALLATION_ROOT
           cargo build --target aarch64-pc-windows-msvc
           cargo test --target aarch64-pc-windows-msvc
+
+  msrv:
+    # Check the minimum supported Rust version
+    name: MSRV Check - Rust v${{ matrix.msrv }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        msrv: ["1.78.0"] # This should match up with rust-version in Cargo.toml
+    env:
+      # Need up-to-date compilers for kernels
+      CC: clang-18
+      CXX: clang++-18
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y protobuf-compiler libssl-dev
+      - name: Install ${{ matrix.msrv }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.msrv }}
+      - name: Downgrade  dependencies
+        # These packages have newer requirements for MSRV
+        run: |
+          cargo update -p aws-sdk-bedrockruntime --precise 1.64.0
+          cargo update -p aws-sdk-dynamodb --precise 1.55.0
+          cargo update -p aws-config --precise 1.5.10
+          cargo update -p aws-sdk-sso --precise 1.50.0
+          cargo update -p aws-sdk-ssooidc --precise 1.51.0
+          cargo update -p aws-sdk-sts --precise 1.51.0
+          cargo update -p home --precise 0.5.11
+      - name: cargo +${{ matrix.msrv }} check
+        run: cargo check --workspace --tests --benches --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,14 +35,15 @@ jobs:
       CC: clang-18
       CXX: clang++-18
     steps:
-      - run: |
-          rustc --version
-          cargo --version
-          rustup toolchain list
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
+      - run: |
+          cargo clean
+          rustc --version
+          cargo --version
+          rustup toolchain list
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/lancedb/lancedb"
 description = "Serverless, low-latency vector database for AI applications"
 keywords = ["lancedb", "lance", "database", "vector", "search"]
 categories = ["database-implementations"]
-rust-version = "1.80.0"                                                     # TODO: lower this once we upgrade Lance again.
+rust-version = "1.78.0"
 
 [workspace.dependencies]
 lance = { "version" = "=0.21.0", "features" = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.83.0"

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
-rust-version = "1.75"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -62,8 +62,6 @@ http = { version = "1", optional = true } # Matching what is in reqwest
 uuid = { version = "1.7.0", features = ["v4"], optional = true }
 polars-arrow = { version = ">=0.37,<0.40.0", optional = true }
 polars = { version = ">=0.37,<0.40.0", optional = true }
-# There was a big jump in MSRV for this package, and it's used by Polars.
-home = { version = "=0.5.9", optional = true }
 hf-hub = { version = "0.3.2", optional = true }
 candle-core = { version = "0.6.0", optional = true }
 candle-transformers = { version = "0.6.0", optional = true }
@@ -91,7 +89,7 @@ fp16kernels = ["lance-linalg/fp16kernels"]
 s3-test = []
 bedrock = ["dep:aws-sdk-bedrockruntime"]
 openai = ["dep:async-openai", "dep:reqwest"]
-polars = ["dep:polars-arrow", "dep:polars", "dep:home"]
+polars = ["dep:polars-arrow", "dep:polars"]
 sentence-transformers = [
     "dep:hf-hub",
     "dep:candle-core",

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -339,7 +339,7 @@ pub trait QueryBase {
     fn limit(self, limit: usize) -> Self;
 
     /// Set the offset of the query.
-
+    ///
     /// By default, it fetches starting with the first row.
     /// This method can be used to skip the first `offset` rows.
     fn offset(self, offset: usize) -> Self;


### PR DESCRIPTION
* Upgrades our toolchain file to v1.83.0, since many dependencies now have MSRV of 1.81.0
  * Reverts Rust changes from #1946 that were working around this in a dumb way
* Adding an MSRV check
* Reduce MSRV back to 1.78.0