### PR TITLE
feat(python)!: support inserting and upserting subschemas

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -784,10 +784,6 @@ class AsyncConnection(object):
             registry = EmbeddingFunctionRegistry.get_instance()
             metadata = registry.get_table_metadata(embedding_functions)
 
-        data, schema = sanitize_create_table(
-            data, schema, metadata, on_bad_vectors, fill_value
-        )
-
         # Defining defaults here and not in function prototype.  In the future
         # these defaults will move into rust so better to keep them as None.
         if on_bad_vectors is None:

--- a/python/python/lancedb/embeddings/registry.py
+++ b/python/python/lancedb/embeddings/registry.py
@@ -108,9 +108,13 @@ class EmbeddingFunctionRegistry:
             An empty dict is returned if input is None or does not
             contain b"embedding_functions".
         """
-        if metadata is None or b"embedding_functions" not in metadata:
+        if metadata is None:
             return {}
-        serialized = metadata[b"embedding_functions"]
+        serialized = metadata.get(
+            b"embedding_functions", metadata.get("embedding_functions")
+        )
+        if serialized is None:
+            return {}
         raw_list = json.loads(serialized.decode("utf-8"))
         return {
             obj["vector_column"]: EmbeddingFunctionConfig(

--- a/python/python/lancedb/embeddings/registry.py
+++ b/python/python/lancedb/embeddings/registry.py
@@ -110,6 +110,7 @@ class EmbeddingFunctionRegistry:
         """
         if metadata is None:
             return {}
+        # Look at both bytes and string keys, since we might use either
         serialized = metadata.get(
             b"embedding_functions", metadata.get("embedding_functions")
         )

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -472,7 +472,7 @@ class LanceQueryBuilder(ABC):
         --------
         >>> import lancedb
         >>> db = lancedb.connect("./.lancedb")
-        >>> table = db.create_table("my_table", [{"vector": [99, 99]}])
+        >>> table = db.create_table("my_table", [{"vector": [99.0, 99]}])
         >>> query = [100, 100]
         >>> plan = table.search(query).explain_plan(True)
         >>> print(plan) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2459,6 +2459,20 @@ def _infer_target_schema(table: pa.Table) -> pa.Schema:
             )
 
             schema = schema.set(i, new_field)
+        elif (
+            field.name == VECTOR_COLUMN_NAME
+            and (pa.types.is_list(field.type) or pa.types.is_large_list(field.type))
+            and pa.types.is_integer(field.type.value_type)
+        ):
+            # Use the most common length of the list as the dimensions
+            dim = _modal_list_size(table.column(i))
+            new_field = pa.field(
+                VECTOR_COLUMN_NAME,
+                pa.list_(pa.uint8(), dim),
+                nullable=field.nullable,
+            )
+
+            schema = schema.set(i, new_field)
 
     return schema
 

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -143,6 +143,11 @@ def _coerce_to_table(data, schema: Optional[pa.Schema] = None) -> pa.Table:
         and data.__class__.__name__ == "DataFrame"
     ):
         return data.to_arrow()
+    elif (
+        type(data).__module__.startswith("polars")
+        and data.__class__.__name__ == "LazyFrame"
+    ):
+        return data.collect().to_arrow()
     elif isinstance(data, Iterable):
         return _process_iterator(data, schema)
     else:

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2335,7 +2335,7 @@ def has_nan_values(arr: Union[pa.ListArray, pa.ChunkedArray]) -> pa.BooleanArray
     if pa.types.is_float16(values.type):
         # is_nan isn't yet implemented for f16, so we cast to f32
         # https://github.com/apache/arrow/issues/45083
-        values_has_nan = pc.is_nan(values).cast(pa.float32)
+        values_has_nan = pc.is_nan(values.cast(pa.float32()))
     else:
         values_has_nan = pc.is_nan(values)
     values_indices = pc.list_parent_indices(arr)

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -228,6 +228,8 @@ def sanitize_create_table(
 
     if metadata:
         schema = schema.with_metadata(metadata)
+        # Need to apply metadata to the data as well
+        data = data.replace_schema_metadata(metadata)
 
     return data, schema
 
@@ -2394,6 +2396,9 @@ def _process_iterator(data: Iterable, schema: Optional[pa.Schema] = None) -> pa.
                         f"does not match the expected schema.\nExpected:\n{schema}\n"
                         f"Got:\n{batch_table.schema}"
                     )
+        else:
+            # Use the first schema for the remainder of the batches
+            schema = batch_table.schema
         batches.append(batch_table)
 
     if batches:

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -206,7 +206,6 @@ def _sanitize_data(
     # 1. There might be embedding columns missing that will be added
     #    in the add_embeddings step.
     # 2. If `allow_subschemas` is True, there might be columns missing.
-    # TODO: What about empty list?
     table = _into_pyarrow_table(data)
 
     table = _append_vector_columns(table, target_schema, metadata=metadata)
@@ -2751,7 +2750,8 @@ class AsyncTable:
             allow_subschema=True,
         )
         if isinstance(data, pa.Table):
-            data = pa.RecordBatchReader.from_batches(schema, data.to_batches())
+            data = data.to_reader()
+
         await self._inner.add(data, mode or "append")
 
     def merge_insert(self, on: Union[str, Iterable[str]]) -> LanceMergeInsertBuilder:

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -933,9 +933,9 @@ class Table(ABC):
         --------
         >>> import lancedb
         >>> data = [
-        ...    {"x": 1, "vector": [1, 2]},
-        ...    {"x": 2, "vector": [3, 4]},
-        ...    {"x": 3, "vector": [5, 6]}
+        ...    {"x": 1, "vector": [1.0, 2]},
+        ...    {"x": 2, "vector": [3.0, 4]},
+        ...    {"x": 3, "vector": [5.0, 6]}
         ... ]
         >>> db = lancedb.connect("./.lancedb")
         >>> table = db.create_table("my_table", data)
@@ -997,7 +997,7 @@ class Table(ABC):
         --------
         >>> import lancedb
         >>> import pandas as pd
-        >>> data = pd.DataFrame({"x": [1, 2, 3], "vector": [[1, 2], [3, 4], [5, 6]]})
+        >>> data = pd.DataFrame({"x": [1, 2, 3], "vector": [[1.0, 2], [3, 4], [5, 6]]})
         >>> db = lancedb.connect("./.lancedb")
         >>> table = db.create_table("my_table", data)
         >>> table.to_pandas()
@@ -1005,7 +1005,7 @@ class Table(ABC):
         0  1  [1.0, 2.0]
         1  2  [3.0, 4.0]
         2  3  [5.0, 6.0]
-        >>> table.update(where="x = 2", values={"vector": [10, 10]})
+        >>> table.update(where="x = 2", values={"vector": [10.0, 10]})
         >>> table.to_pandas()
            x        vector
         0  1    [1.0, 2.0]
@@ -2023,9 +2023,9 @@ class LanceTable(Table):
         --------
         >>> import lancedb
         >>> data = [
-        ...    {"x": 1, "vector": [1, 2]},
-        ...    {"x": 2, "vector": [3, 4]},
-        ...    {"x": 3, "vector": [5, 6]}
+        ...    {"x": 1, "vector": [1.0, 2]},
+        ...    {"x": 2, "vector": [3.0, 4]},
+        ...    {"x": 3, "vector": [5.0, 6]}
         ... ]
         >>> db = lancedb.connect("./.lancedb")
         >>> table = db.create_table("my_table", data)
@@ -2114,7 +2114,7 @@ class LanceTable(Table):
         --------
         >>> import lancedb
         >>> import pandas as pd
-        >>> data = pd.DataFrame({"x": [1, 2, 3], "vector": [[1, 2], [3, 4], [5, 6]]})
+        >>> data = pd.DataFrame({"x": [1, 2, 3], "vector": [[1.0, 2], [3, 4], [5, 6]]})
         >>> db = lancedb.connect("./.lancedb")
         >>> table = db.create_table("my_table", data)
         >>> table.to_pandas()
@@ -2122,7 +2122,7 @@ class LanceTable(Table):
         0  1  [1.0, 2.0]
         1  2  [3.0, 4.0]
         2  3  [5.0, 6.0]
-        >>> table.update(where="x = 2", values={"vector": [10, 10]})
+        >>> table.update(where="x = 2", values={"vector": [10.0, 10]})
         >>> table.to_pandas()
            x        vector
         0  1    [1.0, 2.0]
@@ -2941,9 +2941,9 @@ class AsyncTable:
         --------
         >>> import lancedb
         >>> data = [
-        ...    {"x": 1, "vector": [1, 2]},
-        ...    {"x": 2, "vector": [3, 4]},
-        ...    {"x": 3, "vector": [5, 6]}
+        ...    {"x": 1, "vector": [1.0, 2]},
+        ...    {"x": 2, "vector": [3.0, 4]},
+        ...    {"x": 3, "vector": [5.0, 6]}
         ... ]
         >>> db = lancedb.connect("./.lancedb")
         >>> table = db.create_table("my_table", data)

--- a/python/python/lancedb/util.py
+++ b/python/python/lancedb/util.py
@@ -223,9 +223,7 @@ def inf_vector_column_query(schema: pa.Schema) -> str:
     vector_col_count = 0
     for field_name in schema.names:
         field = schema.field(field_name)
-        if pa.types.is_fixed_size_list(field.type) and pa.types.is_floating(
-            field.type.value_type
-        ):
+        if pa.types.is_fixed_size_list(field.type):
             vector_col_count += 1
             if vector_col_count > 1:
                 raise ValueError(

--- a/python/python/tests/docs/test_binary_vector.py
+++ b/python/python/tests/docs/test_binary_vector.py
@@ -21,7 +21,7 @@ def test_binary_vector():
     ]
     tbl = db.create_table("my_binary_vectors", data=data)
     query = np.random.randint(0, 256, size=16)
-    tbl.search(query).to_arrow()
+    tbl.search(query).metric("hamming").to_arrow()
     # --8<-- [end:sync_binary_vector]
     db.drop_table("my_binary_vectors")
 
@@ -39,6 +39,6 @@ async def test_binary_vector_async():
     ]
     tbl = await db.create_table("my_binary_vectors", data=data)
     query = np.random.randint(0, 256, size=16)
-    await tbl.query().nearest_to(query).to_arrow()
+    await tbl.query().nearest_to(query).distance_type("hamming").to_arrow()
     # --8<-- [end:async_binary_vector]
     await db.drop_table("my_binary_vectors")

--- a/python/python/tests/docs/test_guide_index.py
+++ b/python/python/tests/docs/test_guide_index.py
@@ -118,9 +118,9 @@ def test_scalar_index():
     # --8<-- [end:search_with_scalar_index]
     # --8<-- [start:vector_search_with_scalar_index]
     data = [
-        {"book_id": 1, "vector": [1, 2]},
-        {"book_id": 2, "vector": [3, 4]},
-        {"book_id": 3, "vector": [5, 6]},
+        {"book_id": 1, "vector": [1.0, 2]},
+        {"book_id": 2, "vector": [3.0, 4]},
+        {"book_id": 3, "vector": [5.0, 6]},
     ]
 
     table = db.create_table("book_with_embeddings", data)
@@ -156,9 +156,9 @@ async def test_scalar_index_async():
     # --8<-- [end:search_with_scalar_index_async]
     # --8<-- [start:vector_search_with_scalar_index_async]
     data = [
-        {"book_id": 1, "vector": [1, 2]},
-        {"book_id": 2, "vector": [3, 4]},
-        {"book_id": 3, "vector": [5, 6]},
+        {"book_id": 1, "vector": [1.0, 2]},
+        {"book_id": 2, "vector": [3.0, 4]},
+        {"book_id": 3, "vector": [5.0, 6]},
     ]
     async_tbl = await async_db.create_table("book_with_embeddings_async", data)
     (await async_tbl.query().where("book_id != 3").nearest_to([1, 2]).to_pandas())

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -198,7 +198,6 @@ def test_embedding_function_with_pandas(tmp_path):
         {
             "text": ["hello world", "goodbye world"],
             "val": [1, 2],
-            "not-used": ["s1", "s3"],
         }
     )
     db = lancedb.connect(tmp_path)
@@ -212,7 +211,6 @@ def test_embedding_function_with_pandas(tmp_path):
         {
             "text": ["extra", "more"],
             "val": [4, 5],
-            "misc-col": ["s1", "s3"],
         }
     )
     tbl.add(df)

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -242,8 +242,8 @@ def test_add_subschema(mem_db: DBConnection):
 
     data = {"price": 10.0, "item": "foo"}
     table.add([data])
-    data = {"price": 2.0, "vector": [3.1, 4.1]}
-    table.add([data])
+    data = pa.Table.from_pylist([{"price": 2.0, "vector": [3.1, 4.1]}])
+    table.add(data)
     data = {"price": 3.0, "vector": [5.9, 26.5], "item": "bar"}
     table.add([data])
 
@@ -777,30 +777,22 @@ def test_merge_insert(mem_db: DBConnection):
 
 
 def test_merge_insert_subschema(mem_db: DBConnection):
-    initial_data = pa.table({
-        "id": range(3),
-        "a": [1.0, 2.0, 3.0],
-        "c": ["x", "x", "x"]
-    })
+    initial_data = pa.table(
+        {"id": range(3), "a": [1.0, 2.0, 3.0], "c": ["x", "x", "x"]}
+    )
     table = mem_db.create_table("my_table", data=initial_data)
 
-    new_data = pa.table({
-        "id": [2, 3],
-        "c": ["y", "y"]
-    })
+    new_data = pa.table({"id": [2, 3], "c": ["y", "y"]})
     (
-        table
-        .merge_insert(on="id")
+        table.merge_insert(on="id")
         .when_matched_update_all()
         .when_not_matched_insert_all()
         .execute(new_data)
     )
 
-    expected = pa.table({
-        "id": [0, 1, 2, 3],
-        "a": [1.0, 2.0, 3.0, None],
-        "c": ["x", "x", "y", "y"]
-    })
+    expected = pa.table(
+        {"id": [0, 1, 2, 3], "a": [1.0, 2.0, 3.0, None], "c": ["x", "x", "y", "y"]}
+    )
     assert table.to_arrow().sort_by("id") == expected
 
 

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -776,6 +776,34 @@ def test_merge_insert(mem_db: DBConnection):
     assert table.to_arrow().sort_by("a") == expected
 
 
+def test_merge_insert_subschema(mem_db: DBConnection):
+    initial_data = pa.table({
+        "id": range(3),
+        "a": [1.0, 2.0, 3.0],
+        "c": ["x", "x", "x"]
+    })
+    table = mem_db.create_table("my_table", data=initial_data)
+
+    new_data = pa.table({
+        "id": [2, 3],
+        "c": ["y", "y"]
+    })
+    (
+        table
+        .merge_insert(on="id")
+        .when_matched_update_all()
+        .when_not_matched_insert_all()
+        .execute(new_data)
+    )
+
+    expected = pa.table({
+        "id": [0, 1, 2, 3],
+        "a": [1.0, 2.0, 3.0, None],
+        "c": ["x", "x", "y", "y"]
+    })
+    assert table.to_arrow().sort_by("id") == expected
+
+
 @pytest.mark.asyncio
 async def test_merge_insert_async(mem_db_async: AsyncConnection):
     data = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -233,7 +233,7 @@ def test_add(mem_db: DBConnection):
 def test_add_subschema(mem_db: DBConnection):
     schema = pa.schema(
         [
-            pa.field("vector", pa.list_(pa.float32(), 10), nullable=True),
+            pa.field("vector", pa.list_(pa.float32(), 2), nullable=True),
             pa.field("item", pa.string(), nullable=True),
             pa.field("price", pa.float64(), nullable=False),
         ]
@@ -242,14 +242,14 @@ def test_add_subschema(mem_db: DBConnection):
 
     data = {"price": 10.0, "item": "foo"}
     table.add([data])
-    data = pd.DataFrame({"price": [2.0], "vector": [[3.1] * 10]})
+    data = pd.DataFrame({"price": [2.0], "vector": [[3.1, 4.1]]})
     table.add(data)
-    data = {"price": 3.0, "vector": [5.9] * 10, "item": "bar"}
+    data = {"price": 3.0, "vector": [5.9, 26.5], "item": "bar"}
     table.add([data])
 
     expected = pa.table(
         {
-            "vector": [None, [3.1] * 10, [5.9] * 10],
+            "vector": [None, [3.1, 4.1], [5.9, 26.5]],
             "item": ["foo", None, "bar"],
             "price": [10.0, 2.0, 3.0],
         },
@@ -268,14 +268,14 @@ def test_add_subschema(mem_db: DBConnection):
 
     expected_schema = pa.schema(
         [
-            pa.field("vector", pa.list_(pa.float32(), 10), nullable=True),
+            pa.field("vector", pa.list_(pa.float32(), 2), nullable=True),
             pa.field("item", pa.string(), nullable=True),
             pa.field("price", pa.float64(), nullable=True),
         ]
     )
     expected = pa.table(
         {
-            "vector": [None, [3.1] * 10, [5.9] * 10, None],
+            "vector": [None, [3.1, 4.1], [5.9, 26.5], None],
             "item": ["foo", None, "bar", "foo"],
             "price": [10.0, 2.0, 3.0, None],
         },

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -292,6 +292,7 @@ def test_add_nullability(mem_db: DBConnection):
         ]
     )
     table = mem_db.create_table("test", schema=schema)
+    assert table.schema.field("vector").nullable is False
 
     nullable_schema = pa.schema(
         [
@@ -322,10 +323,7 @@ def test_add_nullability(mem_db: DBConnection):
     # We can't add nullable schema if it contains nulls
     with pytest.raises(
         Exception,
-        match=(
-            "The field `vector` contained null values even though the field "
-            "is marked non-null in the schema"
-        ),
+        match="Casting field 'vector' with null values to non-nullable",
     ):
         table.add(data)
 

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -558,7 +558,7 @@ def test_cast_to_target_schema():
             "extra": pa.int64(),
         }
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         _cast_to_target_schema(data, target)
     output = _cast_to_target_schema(data, target, allow_subschema=True)
     expected_schema = pa.schema(

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -363,8 +363,8 @@ def test_coerce_to_table(data):
     "schema",
     [
         None,
-        pa.schema({"a": pa.int64(), "b": pa.int64()}),
-        pa.schema({"a": pa.int64(), "b": pa.int64(), "c": pa.int64()}),
+        pa.schema({"a": pa.int64(), "b": pa.int32()}),
+        pa.schema({"a": pa.int64(), "b": pa.int32(), "c": pa.int64()}),
     ],
     ids=["infer", "explicit", "subschema"],
 )

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -466,6 +466,11 @@ def test_sanitize_data(
             }
         )
 
+    if not with_embedding:
+        to_remove = expected_schema.get_field_index("vector")
+        if to_remove >= 0:
+            expected_schema = expected_schema.remove(to_remove)
+
     expected = pa.table(
         {
             "id": [1],
@@ -497,7 +502,6 @@ def test_cast_to_target_schema():
             "vector": pa.list_(pa.float64()),
             "vec1": pa.list_(pa.float64(), 2),
             "vec2": pa.list_(pa.float32(), 2),
-            "vec3": pa.list_(pa.float16(), 2),
         }
     )
     data = pa.table(
@@ -507,7 +511,6 @@ def test_cast_to_target_schema():
             "vector": [[0.0] * 2],
             "vec1": [[0.0] * 2],
             "vec2": [[0.0] * 2],
-            "vec3": [[0.0] * 2],
         },
         schema=original_schema,
     )
@@ -523,7 +526,6 @@ def test_cast_to_target_schema():
             "vector": pa.list_(pa.float32(), 2),
             "vec1": pa.list_(pa.float32(), 2),
             "vec2": pa.list_(pa.float32(), 2),
-            "vec3": pa.list_(pa.float32(), 2),
         }
     )
     output = _cast_to_target_schema(data, target)
@@ -534,7 +536,6 @@ def test_cast_to_target_schema():
             "vector": [[0.0] * 2],
             "vec1": [[0.0] * 2],
             "vec2": [[0.0] * 2],
-            "vec3": [[0.0] * 2],
         },
         schema=target,
     )
@@ -553,7 +554,6 @@ def test_cast_to_target_schema():
             "vector": pa.list_(pa.float32(), 2),
             "vec1": pa.list_(pa.float32(), 2),
             "vec2": pa.list_(pa.float32(), 2),
-            "vec3": pa.list_(pa.float32(), 2),
             # Additional field
             "extra": pa.int64(),
         }
@@ -572,7 +572,6 @@ def test_cast_to_target_schema():
             "vector": pa.list_(pa.float32(), 2),
             "vec1": pa.list_(pa.float32(), 2),
             "vec2": pa.list_(pa.float32(), 2),
-            "vec3": pa.list_(pa.float32(), 2),
         }
     )
     expected = pa.table(
@@ -582,7 +581,6 @@ def test_cast_to_target_schema():
             "vector": [[0.0] * 2],
             "vec1": [[0.0] * 2],
             "vec2": [[0.0] * 2],
-            "vec3": [[0.0] * 2],
         },
         schema=expected_schema,
     )

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -373,6 +373,7 @@ def test_sanitize_data(
     schema: Optional[pa.Schema],
     with_embedding: bool,
 ):
+    # TODO: embeddings
     if with_embedding:
         metadata = {}  # TODO
     else:

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -27,7 +27,7 @@ import polars as pl
 import pytest
 import lancedb
 from lancedb.util import get_uri_scheme, join_uri, value_to_sql
-from tests.utils import exception_output
+from utils import exception_output
 
 
 def test_normalize_uri():

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -13,7 +13,12 @@
 
 import os
 import pathlib
+from typing import Optional
 
+from lancedb.table import _sanitize_data
+import pyarrow as pa
+import pandas as pd
+import polars as pl
 import pytest
 import lancedb
 from lancedb.util import get_uri_scheme, join_uri, value_to_sql
@@ -111,3 +116,71 @@ def test_value_to_sql_string(tmp_path):
     for value in values:
         table.update(where=f"search = {value_to_sql(value)}", values={"replace": value})
         assert table.to_pandas().query("search == @value")["replace"].item() == value
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [{"a": 1, "b": 2}],
+        pa.RecordBatch.from_pylist([{"a": 1, "b": 2}]),
+        pa.table({"a": [1], "b": [2]}),
+        pa.table({"a": [1], "b": [2]}).to_reader(),
+        pd.DataFrame({"a": [1], "b": [2]}),
+        pl.DataFrame({"a": [1], "b": [2]}),
+        pl.LazyFrame({"a": [1], "b": [2]}),
+    ],
+    ids=[
+        "rows",
+        "pa.RecordBatch",
+        "pa.Table",
+        "pa.RecordBatchReader",
+        "pd.DataFrame",
+        "pl.DataFrame",
+        "pl.LazyFrame",
+    ],
+)
+@pytest.mark.parametrize(
+    "schema",
+    [
+        None,
+        pa.schema({"a": pa.int64(), "b": pa.int64()}),
+        pa.schema({"a": pa.int64(), "b": pa.int64(), "c": pa.int64()}),
+    ],
+    ids=["infer", "explicit", "subschema"],
+)
+@pytest.mark.parametrize("with_embedding", [True, False])
+def test_sanitize_data(
+    data,
+    schema: Optional[pa.Schema],
+    with_embedding: bool,
+):
+    if with_embedding:
+        metadata = {}  # TODO
+    else:
+        metadata = None
+
+    if schema is not None:
+        to_remove = schema.get_field_index("c")
+        if to_remove >= 0:
+            expected_schema = schema.remove(to_remove)
+        else:
+            expected_schema = schema
+    else:
+        expected_schema = None
+    expected = pa.table(
+        {
+            "a": [1],
+            "b": [2],
+        },
+        schema=expected_schema,
+    )
+
+    output_data, output_schema = _sanitize_data(
+        data,
+        schema=schema,
+        metadata=metadata,
+    )
+
+    assert output_data == expected
+
+    # TODO: what does output schema do?

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -227,7 +227,6 @@ def test_sanitize_vectors_nan(on_bad_vectors):
     if on_bad_vectors == "drop":
         expected = pa.array([[3.0, 4.0]], type=output_type)
     elif on_bad_vectors == "fill":
-        # TODO: is this correct fill behavior?
         expected = pa.array([[42.0, 42.0], [3.0, 4.0]], type=output_type)
     elif on_bad_vectors == "null":
         expected = pa.array([None, [3.0, 4.0]], type=output_type)


### PR DESCRIPTION
BREAKING CHANGE: For a field "vector", list of integers will now be converted to binary (uint8) vectors instead of f32 vectors. Use float values instead for f32 vectors.

* Adds proper support for inserting and upserting subsets of the full schema. I thought I had previously implemented this in #1827, but it turns out I had not tested carefully enough.
* Refactors `_santize_data` and other utility functions to be simpler and not require `numpy` or `combine_chunks()`.
* Added a new suite of unit tests to validate sanitization utilities.

## Examples

```python
import pandas as pd
import lancedb

db = lancedb.connect("memory://demo")
intial_data = pd.DataFrame({
    "a": [1, 2, 3],
    "b": [4, 5, 6],
    "c": [7, 8, 9]
})
table = db.create_table("demo", intial_data)

# Insert a subschema
new_data = pd.DataFrame({"a": [10, 11]})
table.add(new_data)
table.to_pandas()
```
```
    a    b    c
0   1  4.0  7.0
1   2  5.0  8.0
2   3  6.0  9.0
3  10  NaN  NaN
4  11  NaN  NaN
```


```python
# Upsert a subschema
upsert_data = pd.DataFrame({
    "a": [3, 10, 15],
    "b": [6, 7, 8],
})
table.merge_insert(on="a").when_matched_update_all().when_not_matched_insert_all().execute(upsert_data)
table.to_pandas()
```
```
    a    b    c
0   1  4.0  7.0
1   2  5.0  8.0
2   3  6.0  9.0
3  10  7.0  NaN
4  11  NaN  NaN
5  15  8.0  NaN
```