### PR TITLE
docs: fix full-text search (Native FTS) TypeScript doc error

### DIFF
--- a/docs/src/fts.md
+++ b/docs/src/fts.md
@@ -50,7 +50,7 @@ Consider that we have a LanceDB table named `my_table`, whose string column `tex
     });
 
     await tbl
-        .search("puppy", queryType="fts")
+        .search("puppy", "fts")
         .select(["text"])
         .limit(10)
         .toArray();


### PR DESCRIPTION
Fix

```
Cannot find name 'queryType'.ts(2304)
any
```