### PR TITLE
feat!: change default from postfiltering to prefiltering for sync python

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -762,7 +762,7 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
 
         return result_set
 
-    def where(self, where: str, prefilter: bool = False) -> LanceVectorQueryBuilder:
+    def where(self, where: str, prefilter: bool = True) -> LanceVectorQueryBuilder:
         """Set the where clause.
 
         Parameters
@@ -771,7 +771,7 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
             The where clause which is a valid SQL where clause. See
             `Lance filter pushdown <https://lancedb.github.io/lance/read_and_write.html#filter-push-down>`_
             for valid SQL expressions.
-        prefilter: bool, default False
+        prefilter: bool, default True
             If True, apply the filter before vector search, otherwise the
             filter is applied on the result of vector search.
             This feature is **EXPERIMENTAL** and may be removed and modified

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -576,6 +576,7 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
     ...       .to_pandas())
        b      vector  _distance
     0  6  [0.4, 0.4]        0.0
+    1  2  [1.1, 1.2]   0.000944
     """
 
     def __init__(

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -575,7 +575,7 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
     ...       .limit(2)
     ...       .to_pandas())
        b      vector  _distance
-    0  6  [0.4, 0.4]        0.0
+    0  6  [0.4, 0.4]   0.000000
     1  2  [1.1, 1.2]   0.000944
     """
 

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -434,7 +434,7 @@ class LanceQueryBuilder(ABC):
             The where clause which is a valid SQL where clause. See
             `Lance filter pushdown <https://lancedb.github.io/lance/read_and_write.html#filter-push-down>`_
             for valid SQL expressions.
-        prefilter: bool, default True 
+        prefilter: bool, default True
             If True, apply the filter before vector search, otherwise the
             filter is applied on the result of vector search.
             This feature is **EXPERIMENTAL** and may be removed and modified

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -254,7 +254,7 @@ class LanceQueryBuilder(ABC):
         self._offset = 0
         self._columns = None
         self._where = None
-        self._prefilter = False
+        self._prefilter = True
         self._with_row_id = False
         self._vector = None
         self._text = None
@@ -425,7 +425,7 @@ class LanceQueryBuilder(ABC):
             raise ValueError("columns must be a list or a dictionary")
         return self
 
-    def where(self, where: str, prefilter: bool = False) -> LanceQueryBuilder:
+    def where(self, where: str, prefilter: bool = True) -> LanceQueryBuilder:
         """Set the where clause.
 
         Parameters
@@ -434,7 +434,7 @@ class LanceQueryBuilder(ABC):
             The where clause which is a valid SQL where clause. See
             `Lance filter pushdown <https://lancedb.github.io/lance/read_and_write.html#filter-push-down>`_
             for valid SQL expressions.
-        prefilter: bool, default False
+        prefilter: bool, default True 
             If True, apply the filter before vector search, otherwise the
             filter is applied on the result of vector search.
             This feature is **EXPERIMENTAL** and may be removed and modified

--- a/python/python/tests/test_query.py
+++ b/python/python/tests/test_query.py
@@ -291,6 +291,7 @@ def test_query_builder_with_different_vector_column():
         Query(
             vector=query,
             filter="b < 10",
+            prefilter=True,
             k=2,
             metric="cosine",
             columns=["b"],

--- a/python/python/tests/test_query.py
+++ b/python/python/tests/test_query.py
@@ -229,7 +229,7 @@ def test_query_builder_with_prefilter(table):
     )
     assert df["id"].values[0] == 2
     assert all(df["vector"].values[0] == [3, 4])
-    
+
     df = (
         LanceVectorQueryBuilder(table, [0, 0], "vector")
         .where("id = 2", prefilter=False)
@@ -247,10 +247,6 @@ def test_query_builder_with_prefilter(table):
     )
     assert df["id"].values[0] == 2
     assert all(df["vector"].values[0] == [3, 4])
-
-
-
-
 
 
 def test_query_builder_with_metric(table):

--- a/python/python/tests/test_query.py
+++ b/python/python/tests/test_query.py
@@ -223,20 +223,34 @@ def test_query_builder_with_filter(table):
 def test_query_builder_with_prefilter(table):
     df = (
         LanceVectorQueryBuilder(table, [0, 0], "vector")
-        .where("id = 2")
-        .limit(1)
-        .to_pandas()
-    )
-    assert len(df) == 0
-
-    df = (
-        LanceVectorQueryBuilder(table, [0, 0], "vector")
         .where("id = 2", prefilter=True)
         .limit(1)
         .to_pandas()
     )
     assert df["id"].values[0] == 2
     assert all(df["vector"].values[0] == [3, 4])
+    
+    df = (
+        LanceVectorQueryBuilder(table, [0, 0], "vector")
+        .where("id = 2", prefilter=False)
+        .limit(1)
+        .to_pandas()
+    )
+    assert len(df) == 0
+
+    # ensure the default prefilter = True
+    df = (
+        LanceVectorQueryBuilder(table, [0, 0], "vector")
+        .where("id = 2")
+        .limit(1)
+        .to_pandas()
+    )
+    assert df["id"].values[0] == 2
+    assert all(df["vector"].values[0] == [3, 4])
+
+
+
+
 
 
 def test_query_builder_with_metric(table):


### PR DESCRIPTION
BREAKING CHANGE: prefiltering is now the default in the synchronous python SDK

resolves: #1872 