### PR TITLE
feat: add get dataset method on NativeTable

### DIFF
--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -1,11 +1,11 @@
 use std::io::Cursor;
 use std::sync::{Arc, Mutex};
 
-use crate::index::Index;
 use crate::index::IndexStatistics;
 use crate::query::Select;
 use crate::table::AddDataMode;
 use crate::utils::{supported_btree_data_type, supported_vector_data_type};
+use crate::{index::Index, table::dataset};
 use crate::{Error, Table};
 use arrow_array::RecordBatchReader;
 use arrow_ipc::reader::FileReader;
@@ -331,6 +331,9 @@ impl<S: HttpSend> TableInternal for RemoteTable<S> {
     }
     fn name(&self) -> &str {
         &self.name
+    }
+    fn dataset(&self) -> &dataset::DatasetConsistencyWrapper {
+        unimplemented!()
     }
     async fn version(&self) -> Result<u64> {
         self.describe().await.map(|desc| desc.version)

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -381,6 +381,8 @@ pub(crate) trait TableInternal: std::fmt::Display + std::fmt::Debug + Send + Syn
     fn as_native(&self) -> Option<&NativeTable>;
     /// Get the name of the table.
     fn name(&self) -> &str;
+    /// Get the dataset of the table.
+    fn dataset(&self) -> &dataset::DatasetConsistencyWrapper;
     /// Get the arrow [Schema] of the table.
     async fn schema(&self) -> Result<SchemaRef>;
     /// Count the number of rows in this table.
@@ -502,6 +504,11 @@ impl Table {
     /// Get the name of the table.
     pub fn name(&self) -> &str {
         self.inner.name()
+    }
+
+    /// Get the dataset of the table.
+    pub fn dataset(&self) -> &dataset::DatasetConsistencyWrapper {
+        self.inner.dataset()
     }
 
     /// Get the arrow [Schema] of the table.
@@ -1756,6 +1763,10 @@ impl TableInternal for NativeTable {
 
     fn name(&self) -> &str {
         self.name.as_str()
+    }
+
+    fn dataset(&self) -> &dataset::DatasetConsistencyWrapper {
+        &self.dataset
     }
 
     async fn version(&self) -> Result<u64> {


### PR DESCRIPTION
I want to public the dataset method from native table, then I can use more lance method like order_by which is not exposed in the lancedb crate.