### PR TITLE
feat: add index version to list_indices

### DIFF
--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -445,6 +445,7 @@ describe("When creating an index", () => {
       name: "vec_idx",
       indexType: "IvfPq",
       columns: ["vec"],
+      version: 1,
     });
 
     // Search without specifying the column
@@ -545,6 +546,7 @@ describe("When creating an index", () => {
       name: "vec_idx",
       indexType: "IvfHnswSq",
       columns: ["vec"],
+      version: 1,
     });
 
     // Search without specifying the column

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -376,6 +376,7 @@ pub struct IndexConfig {
     /// Currently this is always an array of size 1. In the future there may
     /// be more columns to represent composite indices.
     pub columns: Vec<String>,
+    pub version: i64,
 }
 
 impl From<lancedb::index::IndexConfig> for IndexConfig {
@@ -385,6 +386,7 @@ impl From<lancedb::index::IndexConfig> for IndexConfig {
             index_type,
             columns: value.columns,
             name: value.name,
+            version: value.version as i64,
         }
     }
 }

--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -68,6 +68,8 @@ class Table:
 class IndexConfig:
     index_type: str
     columns: List[str]
+    name: str
+    version: int
 
 async def connect(
     uri: str,

--- a/python/python/tests/test_index.py
+++ b/python/python/tests/test_index.py
@@ -86,7 +86,7 @@ async def test_create_scalar_index(some_table: AsyncTable):
 async def test_create_bitmap_index(some_table: AsyncTable):
     await some_table.create_index("id", config=Bitmap())
     indices = await some_table.list_indices()
-    assert str(indices) == '[Index(Bitmap, columns=["id"], name="id_idx")]'
+    assert str(indices) == '[Index(Bitmap, columns=["id"], name="id_idx", version=1)]'
     indices = await some_table.list_indices()
     assert len(indices) == 1
     index_name = indices[0].name
@@ -102,7 +102,9 @@ async def test_create_bitmap_index(some_table: AsyncTable):
 async def test_create_label_list_index(some_table: AsyncTable):
     await some_table.create_index("tags", config=LabelList())
     indices = await some_table.list_indices()
-    assert str(indices) == '[Index(LabelList, columns=["tags"], name="tags_idx")]'
+    assert str(indices) == (
+        '[Index(LabelList, columns=["tags"], name="tags_idx", version=1)]'
+    )
 
 
 @pytest.mark.asyncio

--- a/python/python/tests/test_index.py
+++ b/python/python/tests/test_index.py
@@ -70,7 +70,8 @@ async def test_create_scalar_index(some_table: AsyncTable):
     # Can recreate if replace=True
     await some_table.create_index("id", replace=True)
     indices = await some_table.list_indices()
-    assert str(indices) == '[Index(BTree, columns=["id"], name="id_idx")]'
+    assert indices[0].version == 2
+    assert str(indices) == '[Index(BTree, columns=["id"], name="id_idx", version=2)]'
     assert len(indices) == 1
     assert indices[0].index_type == "BTree"
     assert indices[0].columns == ["id"]

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -999,6 +999,8 @@ def test_create_scalar_index(mem_db: DBConnection):
     assert len(indices) == 1
     scalar_index = indices[0]
     assert scalar_index.index_type == "BTree"
+    assert scalar_index.columns == ["x"]
+    assert scalar_index.version == 1
 
     # Confirm that prefiltering still works with the scalar index column
     results = table.search().where("x = 'c'").to_arrow()

--- a/python/src/index.rs
+++ b/python/src/index.rs
@@ -194,14 +194,16 @@ pub struct IndexConfig {
     pub columns: Vec<String>,
     /// Name of the index.
     pub name: String,
+    /// The version of the index
+    pub version: u64,
 }
 
 #[pymethods]
 impl IndexConfig {
     pub fn __repr__(&self) -> String {
         format!(
-            "Index({}, columns={:?}, name=\"{}\")",
-            self.index_type, self.columns, self.name
+            "Index({}, columns={:?}, name=\"{}\", version={})",
+            self.index_type, self.columns, self.name, self.version
         )
     }
 
@@ -224,6 +226,7 @@ impl From<lancedb::index::IndexConfig> for IndexConfig {
             index_type,
             columns: value.columns,
             name: value.name,
+            version: value.version,
         }
     }
 }

--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -177,6 +177,8 @@ pub struct IndexConfig {
     /// Currently this is always a Vec of size 1.  In the future there may
     /// be more columns to represent composite indices.
     pub columns: Vec<String>,
+    /// The version of the index
+    pub version: u64,
 }
 
 #[skip_serializing_none]

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -753,6 +753,8 @@ impl<S: HttpSend> TableInternal for RemoteTable<S> {
         struct IndexConfigResponse {
             index_name: String,
             columns: Vec<String>,
+            #[serde(default)]
+            version: u64,
         }
 
         let body = response.text().await.err_to_http(request_id.clone())?;
@@ -776,6 +778,7 @@ impl<S: HttpSend> TableInternal for RemoteTable<S> {
                         name: index.index_name,
                         index_type: stats.index_type,
                         columns: index.columns,
+                        version: index.version,
                     })),
                     Ok(None) => Ok(None), // The index must have been deleted since we listed it.
                     Err(e) => Err(e),
@@ -1572,12 +1575,14 @@ mod tests {
                                 "index_uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
                                 "columns": ["vector"],
                                 "index_status": "done",
+                                "index_version": 1
                             },
                             {
                                 "index_name": "my_idx",
                                 "index_uuid": "34255f64-5717-4562-b3fc-2c963f66afa6",
                                 "columns": ["my_column"],
                                 "index_status": "done",
+                                "index_version": 2
                             },
                         ]
                     })
@@ -1611,11 +1616,13 @@ mod tests {
                 name: "vector_idx".into(),
                 index_type: IndexType::IvfPq,
                 columns: vec!["vector".into()],
+                version: 1,
             },
             IndexConfig {
                 name: "my_idx".into(),
                 index_type: IndexType::LabelList,
                 columns: vec!["my_column".into()],
+                version: 2,
             },
         ];
         assert_eq!(indices, expected);

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -754,7 +754,7 @@ impl<S: HttpSend> TableInternal for RemoteTable<S> {
             index_name: String,
             columns: Vec<String>,
             #[serde(default)]
-            version: u64,
+            index_version: u64,
         }
 
         let body = response.text().await.err_to_http(request_id.clone())?;
@@ -778,7 +778,7 @@ impl<S: HttpSend> TableInternal for RemoteTable<S> {
                         name: index.index_name,
                         index_type: stats.index_type,
                         columns: index.columns,
-                        version: index.version,
+                        version: index.index_version,
                     })),
                     Ok(None) => Ok(None), // The index must have been deleted since we listed it.
                     Err(e) => Err(e),
@@ -1575,7 +1575,6 @@ mod tests {
                                 "index_uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
                                 "columns": ["vector"],
                                 "index_status": "done",
-                                "index_version": 1
                             },
                             {
                                 "index_name": "my_idx",
@@ -1616,7 +1615,8 @@ mod tests {
                 name: "vector_idx".into(),
                 index_type: IndexType::IvfPq,
                 columns: vec!["vector".into()],
-                version: 1,
+                // default value when version is not present in response for backward compatibility
+                version: 0,
             },
             IndexConfig {
                 name: "my_idx".into(),

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -2199,7 +2199,8 @@ impl TableInternal for NativeTable {
             }
 
             let name = idx.name.clone();
-            Ok(IndexConfig { index_type, columns, name })
+            let version = idx.dataset_version;
+            Ok(IndexConfig { index_type, columns, name, version })
         }).try_collect::<Vec<_>>().await
     }
 


### PR DESCRIPTION
Solve the case that list_indices show three exactly same index and confuse users