### PR TITLE
fix(node): `createTable()` should save embeddings, and `mergeInsert` should use them

### DIFF
--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -84,6 +84,7 @@ describe("embedding functions", () => {
   });
 
   it("should be able to append and upsert using embedding function", async () => {
+    @register()
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
       toJSON(): object {
         return {};
@@ -119,6 +120,9 @@ describe("embedding functions", () => {
       },
     );
 
+    const schema = await table.schema();
+    expect(schema.metadata.get("embedding_functions")).toBeDefined();
+
     // Append some new data
     const data1 = [
       { id: 3, text: "forest" },
@@ -128,7 +132,7 @@ describe("embedding functions", () => {
 
     // Upsert some data
     const data2 = [
-      { id: 5, test: "river" },
+      { id: 5, text: "river" },
       { id: 2, text: "canyon" },
     ];
     await table

--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -83,6 +83,70 @@ describe("embedding functions", () => {
     expect(vector0).toEqual([1, 2, 3]);
   });
 
+  it("should be able to append and upsert using embedding function", async () => {
+    class MockEmbeddingFunction extends EmbeddingFunction<string> {
+      toJSON(): object {
+        return {};
+      }
+      ndims() {
+        return 3;
+      }
+      embeddingDataType(): Float {
+        return new Float32();
+      }
+      async computeQueryEmbeddings(_data: string) {
+        return [1, 2, 3];
+      }
+      async computeSourceEmbeddings(data: string[]) {
+        return Array.from({ length: data.length }).fill([
+          1, 2, 3,
+        ]) as number[][];
+      }
+    }
+    const func = new MockEmbeddingFunction();
+    const db = await connect(tmpDir.name);
+    const table = await db.createTable(
+      "test",
+      [
+        { id: 1, text: "hello" },
+        { id: 2, text: "world" },
+      ],
+      {
+        embeddingFunction: {
+          function: func,
+          sourceColumn: "text",
+        },
+      },
+    );
+
+    // Append some new data
+    const data1 = [
+      { id: 3, text: "forest" },
+      { id: 4, text: "mountain" },
+    ];
+    await table.add(data1);
+
+    // Upsert some data
+    const data2 = [
+      { id: 5, test: "river" },
+      { id: 2, text: "canyon" },
+    ];
+    await table
+      .mergeInsert("id")
+      .whenMatchedUpdateAll()
+      .whenNotMatchedInsertAll()
+      .execute(data2);
+
+    const rows = await table.query().toArray();
+    rows.sort((a, b) => a.id - b.id);
+    const texts = rows.map((row) => row.text);
+    expect(texts).toEqual(["hello", "canyon", "forest", "mountain", "river"]);
+    const vectorsDefined = rows.map(
+      (row) => row.vector !== undefined && row.vector !== null,
+    );
+    expect(vectorsDefined).toEqual(new Array(5).fill(true));
+  });
+
   it("should be able to create an empty table with an embedding function", async () => {
     @register()
     class MockEmbeddingFunction extends EmbeddingFunction<string> {

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -540,7 +540,6 @@ async function applyEmbeddingsFromMetadata(
   table: ArrowTable,
   schema: Schema,
 ): Promise<ArrowTable> {
-  console.log(table.toString());
   const registry = getRegistry();
   const functions = await registry.parseFunctions(schema.metadata);
 

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -520,14 +520,8 @@ export class LocalTable extends Table {
   async add(data: Data, options?: Partial<AddDataOptions>): Promise<void> {
     const mode = options?.mode ?? "append";
     const schema = await this.schema();
-    const registry = getRegistry();
-    const functions = await registry.parseFunctions(schema.metadata);
 
-    const buffer = await fromDataToBuffer(
-      data,
-      functions.values().next().value,
-      schema,
-    );
+    const buffer = await fromDataToBuffer(data, undefined, schema);
     await this.inner.add(buffer, mode);
   }
 
@@ -733,7 +727,7 @@ export class LocalTable extends Table {
   }
   mergeInsert(on: string | string[]): MergeInsertBuilder {
     on = Array.isArray(on) ? on : [on];
-    return new MergeInsertBuilder(this.inner.mergeInsert(on));
+    return new MergeInsertBuilder(this.inner.mergeInsert(on), this.schema());
   }
 
   /**


### PR DESCRIPTION
* `createTable()` now saves embeddings in the schema metadata. Previously, it would drop them. (`createEmptyTable()` was already tested and worked.)
* `mergeInsert()` now uses embeddings.

Fixes #2066