### PR TITLE
ci: fix arm64 windows cross compile build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -171,6 +171,30 @@ jobs:
           $env:VCPKG_ROOT = $env:VCPKG_INSTALLATION_ROOT
           cargo test --features remote --locked
 
+  windows-arm64-cross:
+    # We cross compile in Node releases, so we want to make sure
+    # this can run successfully.
+    runs-on: ubuntu-latest
+    container: alpine:edge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apk add protobuf-dev curl clang lld llvm19 grep npm bash msitools sed
+          curl --proto '=https' --tlsv1.3 -sSf https://raw.githubusercontent.com/rust-lang/rustup/refs/heads/master/rustup-init.sh | sh -s -- -y
+          echo "source $HOME/.cargo/env" >> $GITHUB_ENV
+          echo "export CC=clang" >> $GITHUB_ENV
+          echo "export AR=llvm-ar" >> $GITHUB_ENV
+          source "$HOME/.cargo/env"
+          rustup target add aarch64-pc-windows-msvc
+          (mkdir -p sysroot && cd sysroot && sh ../ci/sysroot-aarch64-pc-windows-msvc.sh)
+          echo "export C_INCLUDE_PATH=/usr/aarch64-pc-windows-msvc/usr/include" >> $GITHUB_ENV
+          echo "export CARGO_BUILD_TARGET=aarch64-pc-windows-msvc" >> $GITHUB_ENV
+          echo "export RUSTFLAGS='-Ctarget-feature=+crt-static,+neon,+fp16,+fhm,+dotprod -Clinker=lld -Clink-arg=/LIBPATH:/usr/aarch64-pc-windows-msvc/usr/lib -Clink-arg=arm64rt.lib'" >> $GITHUB_ENV
+      - name: Check
+        run: cargo check --target aarch64-pc-windows-msvc --features remote --locked
+
   windows-arm64:
     runs-on: windows-4x-arm
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -181,19 +181,26 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies
         run: |
+          set -e
           apk add protobuf-dev curl clang lld llvm19 grep npm bash msitools sed
+
           curl --proto '=https' --tlsv1.3 -sSf https://raw.githubusercontent.com/rust-lang/rustup/refs/heads/master/rustup-init.sh | sh -s -- -y
-          echo "source $HOME/.cargo/env" >> $GITHUB_ENV
-          echo "export CC=clang" >> $GITHUB_ENV
-          echo "export AR=llvm-ar" >> $GITHUB_ENV
-          source "$HOME/.cargo/env"
+          source $HOME/.cargo/env
           rustup target add aarch64-pc-windows-msvc
-          (mkdir -p sysroot && cd sysroot && sh ../ci/sysroot-aarch64-pc-windows-msvc.sh)
-          echo "export C_INCLUDE_PATH=/usr/aarch64-pc-windows-msvc/usr/include" >> $GITHUB_ENV
-          echo "export CARGO_BUILD_TARGET=aarch64-pc-windows-msvc" >> $GITHUB_ENV
-          echo "export RUSTFLAGS='-Ctarget-feature=+crt-static,+neon,+fp16,+fhm,+dotprod -Clinker=lld -Clink-arg=/LIBPATH:/usr/aarch64-pc-windows-msvc/usr/lib -Clink-arg=arm64rt.lib'" >> $GITHUB_ENV
+
+          mkdir -p sysroot
+          cd sysroot
+          sh ../ci/sysroot-aarch64-pc-windows-msvc.sh
       - name: Check
-        run: cargo check --target aarch64-pc-windows-msvc --features remote --locked
+        env:
+          CC: clang
+          AR: llvm-ar
+          C_INCLUDE_PATH: /usr/aarch64-pc-windows-msvc/usr/include
+          CARGO_BUILD_TARGET: aarch64-pc-windows-msvc
+          RUSTFLAGS: -Ctarget-feature=+crt-static,+neon,+fp16,+fhm,+dotprod -Clinker=lld -Clink-arg=/LIBPATH:/usr/aarch64-pc-windows-msvc/usr/lib -Clink-arg=arm64rt.lib
+        run: |
+          source $HOME/.cargo/env
+          cargo check --features remote --locked
 
   windows-arm64:
     runs-on: windows-4x-arm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -4111,6 +4111,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "chrono",
+ "crunchy",
  "datafusion-common",
  "datafusion-physical-plan",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ num-traits = "0.2"
 rand = "0.8"
 regex = "1.10"
 lazy_static = "1"
+
+# Workaround for: https://github.com/eira-fransham/crunchy/issues/13
+crunchy = "=0.2.2"

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -68,6 +68,9 @@ candle-transformers = { version = "0.6.0", optional = true }
 candle-nn = { version = "0.6.0", optional = true }
 tokenizers = { version = "0.19.1", optional = true }
 
+# For a workaround, see workspace Cargo.toml
+crunchy.workspace = true
+
 [dev-dependencies]
 tempfile = "3.5.0"
 rand = { version = "0.8.3", features = ["small_rng"] }


### PR DESCRIPTION
* Adds a CI job to check the cross compiled Windows ARM build.
   * Didn't replace the test build because we need native build to run tests. But for some reason (I forget why) we need cross compiled for nodejs.
* Pinned crunchy to workaround https://github.com/eira-fransham/crunchy/issues/13

This is needed to fix failure from https://github.com/lancedb/lancedb/actions/runs/13020773184/job/36320719331