### PR TITLE
fix(rust): add embedding_registry on open_table

### DIFF
--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -1081,6 +1081,7 @@ impl ConnectionInternal for Database {
 
     async fn do_open_table(&self, mut options: OpenTableBuilder) -> Result<Table> {
         let table_uri = self.table_uri(&options.name)?;
+        let embedding_registry = self.embedding_registry.clone();
 
         // Inherit storage options from the connection
         let storage_options = options
@@ -1117,7 +1118,10 @@ impl ConnectionInternal for Database {
             )
             .await?,
         );
-        Ok(Table::new(native_table))
+        Ok(Table::new_with_embedding_registry(
+            native_table,
+            embedding_registry,
+        ))
     }
 
     async fn rename_table(&self, _old_name: &str, _new_name: &str) -> Result<()> {


### PR DESCRIPTION
# Description

Fix for: https://github.com/lancedb/lancedb/issues/1581

This is the same implementation as https://github.com/lancedb/lancedb/pull/1781 but with the addition of a unit test and rustfmt.