### PR TITLE
feat: upgrade lance to 0.23.0-beta.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "fsst"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "rand",
 ]
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "lance"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "lance-core"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "lance-datafusion"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "lance-encoding"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "lance-file"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "lance-index"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "lance-io"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "lance-linalg"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "lance-table"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "lance-testing"
 version = "0.23.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.3#7aa7d94f7ccf2f0e930ea7994257937737d310d5"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.23.0-beta.4#c73d71706c22d499414ab31e06bd3ac3206e1fbe"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ rust-version = "1.78.0"
 [workspace.dependencies]
 lance = { "version" = "=0.23.0", "features" = [
     "dynamodb",
-], git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
-lance-io = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
-lance-index = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
-lance-linalg = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
-lance-table = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
-lance-testing = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
-lance-datafusion = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
-lance-encoding = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.3" }
+], git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
+lance-io = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
+lance-index = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
+lance-linalg = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
+lance-table = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
+lance-testing = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
+lance-datafusion = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
+lance-encoding = { version = "=0.23.0", git = "https://github.com/lancedb/lance.git", tag = "v0.23.0-beta.4" }
 # Note that this one does not include pyarrow
 arrow = { version = "53.2", optional = false }
 arrow-array = "53.2"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ name = "lancedb"
 dynamic = ["version"]
 dependencies = [
     "deprecation",
-    "pylance==0.23.0b3",
+    "pylance==0.23.0b4",
     "tqdm>=4.27.0",
     "pydantic>=1.10",
     "packaging",


### PR DESCRIPTION
Upstream changelog: https://github.com/lancedb/lance/releases/tag/v0.23.0-beta.4