### PR TITLE
feat: extra headers parameter in client options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.18.1-beta.3"
+version = "0.18.1-beta.4"
 dependencies = [
  "arrow",
  "env_logger 0.10.2",

--- a/docs/src/js/interfaces/ClientConfig.md
+++ b/docs/src/js/interfaces/ClientConfig.md
@@ -8,6 +8,14 @@
 
 ## Properties
 
+### extraHeaders?
+
+```ts
+optional extraHeaders: Record<string, string>;
+```
+
+***
+
 ### retryConfig?
 
 ```ts

--- a/nodejs/__test__/remote.test.ts
+++ b/nodejs/__test__/remote.test.ts
@@ -104,4 +104,26 @@ describe("remote connection", () => {
       },
     );
   });
+
+  it("should pass on requested extra headers", async () => {
+    await withMockDatabase(
+      (req, res) => {
+        expect(req.headers["x-my-header"]).toEqual("my-value");
+
+        const body = JSON.stringify({ tables: [] });
+        res.writeHead(200, { "Content-Type": "application/json" }).end(body);
+      },
+      async (db) => {
+        const tableNames = await db.tableNames();
+        expect(tableNames).toEqual([]);
+      },
+      {
+        clientConfig: {
+          extraHeaders: {
+            "x-my-header": "my-value",
+          },
+        },
+      },
+    );
+  });
 });

--- a/nodejs/src/remote.rs
+++ b/nodejs/src/remote.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
+use std::collections::HashMap;
+
 use napi_derive::*;
 
 /// Timeout configuration for remote HTTP client.
@@ -67,6 +69,7 @@ pub struct ClientConfig {
     pub user_agent: Option<String>,
     pub retry_config: Option<RetryConfig>,
     pub timeout_config: Option<TimeoutConfig>,
+    pub extra_headers: Option<HashMap<String, String>>,
 }
 
 impl From<TimeoutConfig> for lancedb::remote::TimeoutConfig {
@@ -104,6 +107,7 @@ impl From<ClientConfig> for lancedb::remote::ClientConfig {
                 .unwrap_or(concat!("LanceDB-Node-Client/", env!("CARGO_PKG_VERSION")).to_string()),
             retry_config: config.retry_config.map(Into::into).unwrap_or_default(),
             timeout_config: config.timeout_config.map(Into::into).unwrap_or_default(),
+            extra_headers: config.extra_headers.unwrap_or_default(),
         }
     }
 }

--- a/python/python/lancedb/remote/__init__.py
+++ b/python/python/lancedb/remote/__init__.py
@@ -109,6 +109,7 @@ class ClientConfig:
     user_agent: str = f"LanceDB-Python-Client/{__version__}"
     retry_config: RetryConfig = field(default_factory=RetryConfig)
     timeout_config: Optional[TimeoutConfig] = field(default_factory=TimeoutConfig)
+    extra_headers: Optional[dict] = None
 
     def __post_init__(self):
         if isinstance(self.retry_config, dict):

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -249,6 +249,7 @@ pub struct PyClientConfig {
     user_agent: String,
     retry_config: Option<PyClientRetryConfig>,
     timeout_config: Option<PyClientTimeoutConfig>,
+    extra_headers: Option<HashMap<String, String>>,
 }
 
 #[derive(FromPyObject)]
@@ -300,6 +301,7 @@ impl From<PyClientConfig> for lancedb::remote::ClientConfig {
             user_agent: value.user_agent,
             retry_config: value.retry_config.map(Into::into).unwrap_or_default(),
             timeout_config: value.timeout_config.map(Into::into).unwrap_or_default(),
+            extra_headers: value.extra_headers.unwrap_or_default(),
         }
     }
 }

--- a/rust/lancedb/src/remote/client.rs
+++ b/rust/lancedb/src/remote/client.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-use std::{future::Future, time::Duration};
+use std::{collections::HashMap, future::Future, str::FromStr, time::Duration};
 
+use http::HeaderName;
 use log::debug;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
@@ -23,6 +24,7 @@ pub struct ClientConfig {
     /// name and version.
     pub user_agent: String,
     // TODO: how to configure request ids?
+    pub extra_headers: HashMap<String, String>,
 }
 
 impl Default for ClientConfig {
@@ -31,6 +33,7 @@ impl Default for ClientConfig {
             timeout_config: TimeoutConfig::default(),
             retry_config: RetryConfig::default(),
             user_agent: concat!("LanceDB-Rust-Client/", env!("CARGO_PKG_VERSION")).into(),
+            extra_headers: HashMap::new(),
         }
     }
 }
@@ -256,6 +259,7 @@ impl RestfulLanceDbClient<Sender> {
                 host_override.is_some(),
                 options,
                 db_prefix,
+                &client_config,
             )?)
             .user_agent(client_config.user_agent)
             .build()
@@ -291,6 +295,7 @@ impl<S: HttpSend> RestfulLanceDbClient<S> {
         has_host_override: bool,
         options: &RemoteOptions,
         db_prefix: Option<&str>,
+        config: &ClientConfig,
     ) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -341,6 +346,18 @@ impl<S: HttpSend> RestfulLanceDbClient<S> {
                 "x-azure-storage-account-name",
                 HeaderValue::from_str(v).map_err(|_| Error::InvalidInput {
                     message: format!("non-ascii storage account name '{}' provided", db_name),
+                })?,
+            );
+        }
+
+        for (key, value) in &config.extra_headers {
+            let key_parsed = HeaderName::from_str(key).map_err(|_| Error::InvalidInput {
+                message: format!("non-ascii value for header '{}' provided", key),
+            })?;
+            headers.insert(
+                key_parsed,
+                HeaderValue::from_str(value).map_err(|_| Error::InvalidInput {
+                    message: format!("non-ascii value for header '{}' provided", key),
                 })?,
             );
         }


### PR DESCRIPTION
Closes #1106

Unfortunately, these need to be set at the connection level. I investigated whether if we let users provide a callback they could use `AsyncLocalStorage` to access their context. However, it doesn't seem like NAPI supports this right now. I filed an issue: https://github.com/napi-rs/napi-rs/issues/2456
