### PR TITLE
refactor: rename drop_db / drop_database to drop_all_tables, expose database from connection

### DIFF
--- a/docs/src/js/classes/Connection.md
+++ b/docs/src/js/classes/Connection.md
@@ -131,6 +131,20 @@ Return a brief description of the connection
 
 ***
 
+### dropAllTables()
+
+```ts
+abstract dropAllTables(): Promise<void>
+```
+
+Drop all tables in the database.
+
+#### Returns
+
+`Promise`&lt;`void`&gt;
+
+***
+
 ### dropTable()
 
 ```ts

--- a/nodejs/__test__/connection.test.ts
+++ b/nodejs/__test__/connection.test.ts
@@ -17,14 +17,14 @@ describe("when connecting", () => {
   it("should connect", async () => {
     const db = await connect(tmpDir.name);
     expect(db.display()).toBe(
-      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=None)`
+      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=None)`,
     );
   });
 
   it("should allow read consistency interval to be specified", async () => {
     const db = await connect(tmpDir.name, { readConsistencyInterval: 5 });
     expect(db.display()).toBe(
-      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=5s)`
+      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=5s)`,
     );
   });
 });
@@ -85,7 +85,7 @@ describe("given a connection", () => {
     let tbl = await db.createTable("test", [{ id: 1 }, { id: 2 }]);
     await expect(tbl.countRows()).resolves.toBe(2);
     await expect(
-      db.createTable("test", [{ id: 1 }, { id: 2 }])
+      db.createTable("test", [{ id: 1 }, { id: 2 }]),
     ).rejects.toThrow();
     tbl = await db.createTable("test", [{ id: 3 }], { mode: "overwrite" });
     await expect(tbl.countRows()).resolves.toBe(1);
@@ -157,7 +157,7 @@ describe("given a connection", () => {
       new Schema([new Field("id", new Float64(), true)]),
       {
         enableV2ManifestPaths: true,
-      }
+      },
     )) as LocalTable;
     expect(await table.usesV2ManifestPaths()).toBe(true);
 
@@ -184,7 +184,7 @@ describe("given a connection", () => {
       new Schema([new Field("id", new Float64(), true)]),
       {
         enableV2ManifestPaths: false,
-      }
+      },
     )) as LocalTable;
 
     expect(await table.usesV2ManifestPaths()).toBe(false);

--- a/nodejs/__test__/connection.test.ts
+++ b/nodejs/__test__/connection.test.ts
@@ -17,14 +17,14 @@ describe("when connecting", () => {
   it("should connect", async () => {
     const db = await connect(tmpDir.name);
     expect(db.display()).toBe(
-      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=None)`,
+      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=None)`
     );
   });
 
   it("should allow read consistency interval to be specified", async () => {
     const db = await connect(tmpDir.name, { readConsistencyInterval: 5 });
     expect(db.display()).toBe(
-      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=5s)`,
+      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=5s)`
     );
   });
 });
@@ -61,11 +61,31 @@ describe("given a connection", () => {
     await expect(tbl.countRows()).resolves.toBe(1);
   });
 
+  it("should be able to drop tables`", async () => {
+    await db.createTable("test", [{ id: 1 }, { id: 2 }]);
+    await db.createTable("test2", [{ id: 1 }, { id: 2 }]);
+    await db.createTable("test3", [{ id: 1 }, { id: 2 }]);
+
+    await expect(db.tableNames()).resolves.toEqual(["test", "test2", "test3"]);
+
+    await db.dropTable("test2");
+
+    await expect(db.tableNames()).resolves.toEqual(["test", "test3"]);
+
+    await db.dropAllTables();
+
+    await expect(db.tableNames()).resolves.toEqual([]);
+
+    // Make sure we can still create more tables after dropping all
+
+    await db.createTable("test4", [{ id: 1 }, { id: 2 }]);
+  });
+
   it("should fail if creating table twice, unless overwrite is true", async () => {
     let tbl = await db.createTable("test", [{ id: 1 }, { id: 2 }]);
     await expect(tbl.countRows()).resolves.toBe(2);
     await expect(
-      db.createTable("test", [{ id: 1 }, { id: 2 }]),
+      db.createTable("test", [{ id: 1 }, { id: 2 }])
     ).rejects.toThrow();
     tbl = await db.createTable("test", [{ id: 3 }], { mode: "overwrite" });
     await expect(tbl.countRows()).resolves.toBe(1);
@@ -137,7 +157,7 @@ describe("given a connection", () => {
       new Schema([new Field("id", new Float64(), true)]),
       {
         enableV2ManifestPaths: true,
-      },
+      }
     )) as LocalTable;
     expect(await table.usesV2ManifestPaths()).toBe(true);
 
@@ -164,7 +184,7 @@ describe("given a connection", () => {
       new Schema([new Field("id", new Float64(), true)]),
       {
         enableV2ManifestPaths: false,
-      },
+      }
     )) as LocalTable;
 
     expect(await table.usesV2ManifestPaths()).toBe(false);

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -167,7 +167,7 @@ export abstract class Connection {
    */
   abstract openTable(
     name: string,
-    options?: Partial<OpenTableOptions>
+    options?: Partial<OpenTableOptions>,
   ): Promise<Table>;
 
   /**
@@ -181,7 +181,7 @@ export abstract class Connection {
     options: {
       name: string;
       data: Data;
-    } & Partial<CreateTableOptions>
+    } & Partial<CreateTableOptions>,
   ): Promise<Table>;
   /**
    * Creates a new Table and initialize it with new data.
@@ -192,7 +192,7 @@ export abstract class Connection {
   abstract createTable(
     name: string,
     data: Record<string, unknown>[] | TableLike,
-    options?: Partial<CreateTableOptions>
+    options?: Partial<CreateTableOptions>,
   ): Promise<Table>;
 
   /**
@@ -203,7 +203,7 @@ export abstract class Connection {
   abstract createEmptyTable(
     name: string,
     schema: import("./arrow").SchemaLike,
-    options?: Partial<CreateTableOptions>
+    options?: Partial<CreateTableOptions>,
   ): Promise<Table>;
 
   /**
@@ -246,19 +246,19 @@ export class LocalConnection extends Connection {
 
   async openTable(
     name: string,
-    options?: Partial<OpenTableOptions>
+    options?: Partial<OpenTableOptions>,
   ): Promise<Table> {
     const innerTable = await this.inner.openTable(
       name,
       cleanseStorageOptions(options?.storageOptions),
-      options?.indexCacheSize
+      options?.indexCacheSize,
     );
 
     return new LocalTable(innerTable);
   }
 
   private getStorageOptions(
-    options?: Partial<CreateTableOptions>
+    options?: Partial<CreateTableOptions>,
   ): Record<string, string> | undefined {
     if (options?.dataStorageVersion !== undefined) {
       if (options.storageOptions === undefined) {
@@ -284,7 +284,7 @@ export class LocalConnection extends Connection {
       | string
       | ({ name: string; data: Data } & Partial<CreateTableOptions>),
     data?: Record<string, unknown>[] | TableLike,
-    options?: Partial<CreateTableOptions>
+    options?: Partial<CreateTableOptions>,
   ): Promise<Table> {
     if (typeof nameOrOptions !== "string" && "name" in nameOrOptions) {
       const { name, data, ...options } = nameOrOptions;
@@ -302,7 +302,7 @@ export class LocalConnection extends Connection {
       nameOrOptions,
       buf,
       mode,
-      storageOptions
+      storageOptions,
     );
 
     return new LocalTable(innerTable);
@@ -311,7 +311,7 @@ export class LocalConnection extends Connection {
   async createEmptyTable(
     name: string,
     schema: import("./arrow").SchemaLike,
-    options?: Partial<CreateTableOptions>
+    options?: Partial<CreateTableOptions>,
   ): Promise<Table> {
     let mode: string = options?.mode ?? "create";
     const existOk = options?.existOk ?? false;
@@ -333,7 +333,7 @@ export class LocalConnection extends Connection {
       name,
       buf,
       mode,
-      storageOptions
+      storageOptions,
     );
     return new LocalTable(innerTable);
   }
@@ -351,7 +351,7 @@ export class LocalConnection extends Connection {
  * Takes storage options and makes all the keys snake case.
  */
 export function cleanseStorageOptions(
-  options?: Record<string, string>
+  options?: Record<string, string>,
 ): Record<string, string> | undefined {
   if (options === undefined) {
     return undefined;
@@ -390,7 +390,7 @@ function camelToSnakeCase(camel: string): string {
 async function parseTableData(
   data: Record<string, unknown>[] | TableLike,
   options?: Partial<CreateTableOptions>,
-  streaming = false
+  streaming = false,
 ) {
   let mode: string = options?.mode ?? "create";
   const existOk = options?.existOk ?? false;
@@ -409,14 +409,14 @@ async function parseTableData(
     const buf = await fromTableToStreamBuffer(
       table,
       options?.embeddingFunction,
-      options?.schema
+      options?.schema,
     );
     return { buf, mode };
   } else {
     const buf = await fromTableToBuffer(
       table,
       options?.embeddingFunction,
-      options?.schema
+      options?.schema,
     );
     return { buf, mode };
   }

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -167,7 +167,7 @@ export abstract class Connection {
    */
   abstract openTable(
     name: string,
-    options?: Partial<OpenTableOptions>,
+    options?: Partial<OpenTableOptions>
   ): Promise<Table>;
 
   /**
@@ -181,7 +181,7 @@ export abstract class Connection {
     options: {
       name: string;
       data: Data;
-    } & Partial<CreateTableOptions>,
+    } & Partial<CreateTableOptions>
   ): Promise<Table>;
   /**
    * Creates a new Table and initialize it with new data.
@@ -192,7 +192,7 @@ export abstract class Connection {
   abstract createTable(
     name: string,
     data: Record<string, unknown>[] | TableLike,
-    options?: Partial<CreateTableOptions>,
+    options?: Partial<CreateTableOptions>
   ): Promise<Table>;
 
   /**
@@ -203,7 +203,7 @@ export abstract class Connection {
   abstract createEmptyTable(
     name: string,
     schema: import("./arrow").SchemaLike,
-    options?: Partial<CreateTableOptions>,
+    options?: Partial<CreateTableOptions>
   ): Promise<Table>;
 
   /**
@@ -211,6 +211,11 @@ export abstract class Connection {
    * @param {string} name The name of the table to drop.
    */
   abstract dropTable(name: string): Promise<void>;
+
+  /**
+   * Drop all tables in the database.
+   */
+  abstract dropAllTables(): Promise<void>;
 }
 
 /** @hideconstructor */
@@ -241,19 +246,19 @@ export class LocalConnection extends Connection {
 
   async openTable(
     name: string,
-    options?: Partial<OpenTableOptions>,
+    options?: Partial<OpenTableOptions>
   ): Promise<Table> {
     const innerTable = await this.inner.openTable(
       name,
       cleanseStorageOptions(options?.storageOptions),
-      options?.indexCacheSize,
+      options?.indexCacheSize
     );
 
     return new LocalTable(innerTable);
   }
 
   private getStorageOptions(
-    options?: Partial<CreateTableOptions>,
+    options?: Partial<CreateTableOptions>
   ): Record<string, string> | undefined {
     if (options?.dataStorageVersion !== undefined) {
       if (options.storageOptions === undefined) {
@@ -279,7 +284,7 @@ export class LocalConnection extends Connection {
       | string
       | ({ name: string; data: Data } & Partial<CreateTableOptions>),
     data?: Record<string, unknown>[] | TableLike,
-    options?: Partial<CreateTableOptions>,
+    options?: Partial<CreateTableOptions>
   ): Promise<Table> {
     if (typeof nameOrOptions !== "string" && "name" in nameOrOptions) {
       const { name, data, ...options } = nameOrOptions;
@@ -297,7 +302,7 @@ export class LocalConnection extends Connection {
       nameOrOptions,
       buf,
       mode,
-      storageOptions,
+      storageOptions
     );
 
     return new LocalTable(innerTable);
@@ -306,7 +311,7 @@ export class LocalConnection extends Connection {
   async createEmptyTable(
     name: string,
     schema: import("./arrow").SchemaLike,
-    options?: Partial<CreateTableOptions>,
+    options?: Partial<CreateTableOptions>
   ): Promise<Table> {
     let mode: string = options?.mode ?? "create";
     const existOk = options?.existOk ?? false;
@@ -328,7 +333,7 @@ export class LocalConnection extends Connection {
       name,
       buf,
       mode,
-      storageOptions,
+      storageOptions
     );
     return new LocalTable(innerTable);
   }
@@ -336,13 +341,17 @@ export class LocalConnection extends Connection {
   async dropTable(name: string): Promise<void> {
     return this.inner.dropTable(name);
   }
+
+  async dropAllTables(): Promise<void> {
+    return this.inner.dropAllTables();
+  }
 }
 
 /**
  * Takes storage options and makes all the keys snake case.
  */
 export function cleanseStorageOptions(
-  options?: Record<string, string>,
+  options?: Record<string, string>
 ): Record<string, string> | undefined {
   if (options === undefined) {
     return undefined;
@@ -381,7 +390,7 @@ function camelToSnakeCase(camel: string): string {
 async function parseTableData(
   data: Record<string, unknown>[] | TableLike,
   options?: Partial<CreateTableOptions>,
-  streaming = false,
+  streaming = false
 ) {
   let mode: string = options?.mode ?? "create";
   const existOk = options?.existOk ?? false;
@@ -400,14 +409,14 @@ async function parseTableData(
     const buf = await fromTableToStreamBuffer(
       table,
       options?.embeddingFunction,
-      options?.schema,
+      options?.schema
     );
     return { buf, mode };
   } else {
     const buf = await fromTableToBuffer(
       table,
       options?.embeddingFunction,
-      options?.schema,
+      options?.schema
     );
     return { buf, mode };
   }

--- a/nodejs/src/connection.rs
+++ b/nodejs/src/connection.rs
@@ -187,4 +187,9 @@ impl Connection {
     pub async fn drop_table(&self, name: String) -> napi::Result<()> {
         self.get_inner()?.drop_table(&name).await.default_error()
     }
+
+    #[napi(catch_unwind)]
+    pub async fn drop_all_tables(&self) -> napi::Result<()> {
+        self.get_inner()?.drop_all_tables().await.default_error()
+    }
 }

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -501,7 +501,7 @@ class LanceDBConnection(DBConnection):
 
     @deprecation.deprecated(
         deprecated_in="0.15.1",
-        removed_in="0.16",
+        removed_in="0.17",
         current_version=__version__,
         details="Use drop_all_tables() instead",
     )
@@ -873,7 +873,7 @@ class AsyncConnection(object):
 
     @deprecation.deprecated(
         deprecated_in="0.15.1",
-        removed_in="0.16",
+        removed_in="0.17",
         current_version=__version__,
         details="Use drop_all_tables() instead",
     )

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -14,6 +14,7 @@ from overrides import EnforceOverrides, override  # type: ignore
 from lancedb.common import data_to_reader, sanitize_uri, validate_schema
 from lancedb.background_loop import LOOP
 
+from . import __version__
 from ._lancedb import connect as lancedb_connect  # type: ignore
 from .table import (
     AsyncTable,
@@ -25,6 +26,8 @@ from .util import (
     get_uri_scheme,
     validate_table_name,
 )
+
+import deprecation
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -294,6 +297,12 @@ class DBConnection(EnforceOverrides):
         """
         raise NotImplementedError
 
+    def drop_all_tables(self):
+        """
+        Drop all tables from the database
+        """
+        raise NotImplementedError
+
     @property
     def uri(self) -> str:
         return self._uri
@@ -487,8 +496,18 @@ class LanceDBConnection(DBConnection):
         LOOP.run(self._conn.drop_table(name, ignore_missing=ignore_missing))
 
     @override
+    def drop_all_tables(self):
+        LOOP.run(self._conn.drop_all_tables())
+
+    @deprecation.deprecated(
+        deprecated_in="0.15.1",
+        removed_in="0.16",
+        current_version=__version__,
+        details="Use drop_all_tables() instead",
+    )
+    @override
     def drop_database(self):
-        LOOP.run(self._conn.drop_database())
+        LOOP.run(self._conn.drop_all_tables())
 
 
 class AsyncConnection(object):
@@ -848,9 +867,19 @@ class AsyncConnection(object):
             if f"Table '{name}' was not found" not in str(e):
                 raise e
 
+    async def drop_all_tables(self):
+        """Drop all tables from the database."""
+        await self._inner.drop_all_tables()
+
+    @deprecation.deprecated(
+        deprecated_in="0.15.1",
+        removed_in="0.16",
+        current_version=__version__,
+        details="Use drop_all_tables() instead",
+    )
     async def drop_database(self):
         """
         Drop database
         This is the same thing as dropping all the tables
         """
-        await self._inner.drop_db()
+        await self._inner.drop_all_tables()

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -499,6 +499,10 @@ def test_delete_table(tmp_db: lancedb.DBConnection):
     # if ignore_missing=True
     tmp_db.drop_table("does_not_exist", ignore_missing=True)
 
+    tmp_db.drop_all_tables()
+
+    assert tmp_db.table_names() == []
+
 
 @pytest.mark.asyncio
 async def test_delete_table_async(tmp_db: lancedb.DBConnection):

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -170,12 +170,11 @@ impl Connection {
         })
     }
 
-    pub fn drop_db(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyAny>> {
+    pub fn drop_all_tables(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyAny>> {
         let inner = self_.get_inner()?.clone();
-        future_into_py(
-            self_.py(),
-            async move { inner.drop_db().await.infer_error() },
-        )
+        future_into_py(self_.py(), async move {
+            inner.drop_all_tables().await.infer_error()
+        })
     }
 }
 

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -418,6 +418,11 @@ impl Connection {
         self.uri.as_str()
     }
 
+    /// Get access to the underlying database
+    pub fn database(&self) -> &Arc<dyn Database> {
+        &self.internal
+    }
+
     /// Get the names of all tables in the database
     ///
     /// The names will be returned in lexicographical order (ascending)
@@ -504,8 +509,14 @@ impl Connection {
     /// Drop the database
     ///
     /// This is the same as dropping all of the tables
+    #[deprecated(since = "0.15.1", note = "Use `drop_all_tables` instead")]
     pub async fn drop_db(&self) -> Result<()> {
-        self.internal.drop_db().await
+        self.internal.drop_all_tables().await
+    }
+
+    /// Drops all tables in the database
+    pub async fn drop_all_tables(&self) -> Result<()> {
+        self.internal.drop_all_tables().await
     }
 
     /// Get the in-memory embedding registry.

--- a/rust/lancedb/src/database.rs
+++ b/rust/lancedb/src/database.rs
@@ -128,6 +128,6 @@ pub trait Database:
     /// Drop a table in the database
     async fn drop_table(&self, name: &str) -> Result<()>;
     /// Drop all tables in the database
-    async fn drop_db(&self) -> Result<()>;
+    async fn drop_all_tables(&self) -> Result<()>;
     fn as_any(&self) -> &dyn std::any::Any;
 }

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -529,7 +529,7 @@ impl Database for ListingDatabase {
         Ok(())
     }
 
-    async fn drop_db(&self) -> Result<()> {
+    async fn drop_all_tables(&self) -> Result<()> {
         self.object_store
             .remove_dir_all(self.base_path.clone())
             .await?;

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -237,7 +237,7 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
         Ok(())
     }
 
-    async fn drop_db(&self) -> Result<()> {
+    async fn drop_all_tables(&self) -> Result<()> {
         Err(crate::Error::NotSupported {
             message: "Dropping databases is not supported in the remote API".to_string(),
         })


### PR DESCRIPTION
If we start supporting external catalogs then "drop database" may be misleading (and not possible).  We should be more clear that this is a utility method to drop all tables.  This is also a nice chance for some consistency cleanup as it was `drop_db` in rust, `drop_database` in python, and non-existent in typescript.

This PR also adds a public accessor to get the database trait from a connection.

BREAKING CHANGE: the `drop_database` / `drop_db` methods are now deprecated.