### PR TITLE
fix: fix index out of bound in load indices

### DIFF
--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1380,10 +1380,11 @@ impl NativeTable {
 
     pub async fn load_indices(&self) -> Result<Vec<VectorIndex>> {
         let dataset = self.dataset.get().await?;
-        let (indices, mf) = futures::try_join!(dataset.load_indices(), dataset.latest_manifest())?;
+        let mf = dataset.manifest();
+        let indices = dataset.load_indices().await?;
         Ok(indices
             .iter()
-            .map(|i| VectorIndex::new_from_format(&(mf.0), i))
+            .map(|i| VectorIndex::new_from_format(&mf, i))
             .collect())
     }
 

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1384,7 +1384,7 @@ impl NativeTable {
         let indices = dataset.load_indices().await?;
         Ok(indices
             .iter()
-            .map(|i| VectorIndex::new_from_format(&mf, i))
+            .map(|i| VectorIndex::new_from_format(mf, i))
             .collect())
     }
 


### PR DESCRIPTION
panicked at 'index out of bounds: the len is 24 but the index is 25':Lancedb/rust/lancedb/src/index/vector.rs:26\n

load_indices() on the old manifest while use the newer manifest to get column names could result in index out of bound if some columns are removed from the new version.
This change reduce the possibility of index out of bound operation but does not fully remove it.
Better that lance can directly provide column name info so no need extra calls to get column name but that require modify the public APIs