### PR TITLE
feat!: add variable store to embeddings registry

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
                   - Imagebind embeddings: embeddings/available_embedding_models/multimodal_embedding_functions/imagebind_embedding.md
                   - Jina Embeddings: embeddings/available_embedding_models/multimodal_embedding_functions/jina_multimodal_embedding.md
           - User-defined embedding functions: embeddings/custom_embedding_function.md
+          - Variables and secrets: embeddings/variables_and_secrets.md
           - "Example: Multi-lingual semantic search": notebooks/multi_lingual_example.ipynb
           - "Example: MultiModal CLIP Embeddings": notebooks/DisappearingEmbeddingFunction.ipynb
       - 🔌 Integrations:
@@ -315,6 +316,7 @@ nav:
               - Imagebind embeddings: embeddings/available_embedding_models/multimodal_embedding_functions/imagebind_embedding.md
               - Jina Embeddings: embeddings/available_embedding_models/multimodal_embedding_functions/jina_multimodal_embedding.md
       - User-defined embedding functions: embeddings/custom_embedding_function.md
+      - Variables and secrets: embeddings/variables_and_secrets.md
       - "Example: Multi-lingual semantic search": notebooks/multi_lingual_example.ipynb
       - "Example: MultiModal CLIP Embeddings": notebooks/DisappearingEmbeddingFunction.ipynb
   - Integrations:

--- a/docs/src/embeddings/custom_embedding_function.md
+++ b/docs/src/embeddings/custom_embedding_function.md
@@ -56,8 +56,8 @@ Let's implement `SentenceTransformerEmbeddings` class. All you need to do is imp
 This is a stripped down version of our implementation of `SentenceTransformerEmbeddings` that removes certain optimizations and default settings.
 
 !!! danger "Use sensitive keys to prevent leaking secrets"
-    To prevent leaking secrets, such as API keys, you should add an configuration
-    parameteres of embedding function to the output of the
+    To prevent leaking secrets, such as API keys, you should add any sensitive
+    parameters of an embedding function to the output of the
     [sensitive_keys()][lancedb.embeddings.base.EmbeddingFunction.sensitive_keys] /
     [getSensitiveKeys()](../../js/namespaces/embedding/classes/EmbeddingFunction/#getsensitivekeys)
     method. This prevents users from accidentally instantiating the embedding

--- a/docs/src/embeddings/custom_embedding_function.md
+++ b/docs/src/embeddings/custom_embedding_function.md
@@ -55,6 +55,14 @@ Let's implement `SentenceTransformerEmbeddings` class. All you need to do is imp
 
 This is a stripped down version of our implementation of `SentenceTransformerEmbeddings` that removes certain optimizations and default settings.
 
+!!! danger "Use sensitive keys to prevent leaking secrets"
+    To prevent leaking secrets, such as API keys, you should add an configuration
+    parameteres of embedding function to the output of the
+    [sensitive_keys()][lancedb.embeddings.base.EmbeddingFunction.sensitive_keys] /
+    [getSensitiveKeys()](../../js/namespaces/embedding/classes/EmbeddingFunction/#getsensitivekeys)
+    method. This prevents users from accidentally instantiating the embedding
+    function with hard-coded secrets.
+
 Now you can use this embedding function to create your table schema and that's it! you can then ingest data and run queries without manually vectorizing the inputs.
 
 === "Python"

--- a/docs/src/embeddings/variables_and_secrets.md
+++ b/docs/src/embeddings/variables_and_secrets.md
@@ -1,0 +1,58 @@
+# Variable and Secrets
+
+Most embedding configuration options are saved in the table's metadata. However,
+this isn't always appropriate. For example, API keys should never be stored in the
+metadata. Additionally, other configuration options might be best set at runtime,
+such as the `device` configuration that controls whether to use GPU or CPU for
+inference. If you hardcoded this to GPU, you wouldn't be able to run the code on
+server without one.
+
+To handle these cases, you can set variables on the embedding registry and
+reference them in the embedding configuration. These variables will be available
+during the runtime of your program, but not saved in the table's metadata. When
+the table is loaded from a different process, the variables must be set again
+for the embedding functions to be able to be loaded.
+
+To set a variable, use the `set_var()` / `setVar()` method on the embedding registry.
+To reference a variable, use the syntax `$env:VARIABLE_NAME`. If there is a default
+value, you can use the syntax `$env:VARIABLE_NAME:DEFAULT_VALUE`.
+
+## Using variables to set secrets
+
+Sensitive configuration, such as API keys, must either be set as environment
+variables or using variables on the embedding registry. If you pass in a hardcoded
+value, LanceDB will raise an error.
+
+=== "Python"
+
+    ```shell
+    --8<-- "python/python/tests/docs/test_embeddings_optional.py:register_secret"
+    ```
+
+=== "Typescript"
+
+    ```shell
+    --8<-- "docs/src/basic_legacy.ts:create_table"
+    ```
+
+## Using variables to set device
+
+Because not all computers have a GPU, it's helpful to be able to set the `device`
+parameter at runtime, rather than have it hard coded in the embedding configuration.
+To make it work even if the variable isn't set, you could provide a default value
+of `cpu` in the embedding configuration.
+
+Some embedding libraries have a method to detect which devices are available,
+which could also be used to dynamically set the device at runtime. For example, in Python you can check if a CUDA GPU is available using `torch.cuda.is_available()`.
+
+=== "Python"
+
+    ```shell
+    --8<-- "python/python/tests/docs/test_embeddings_optional.py:register_device"
+    ```
+
+=== "Typescript"
+
+    ```shell
+    --8<-- "docs/src/basic_legacy.ts:create_table"
+    ```

--- a/docs/src/embeddings/variables_and_secrets.md
+++ b/docs/src/embeddings/variables_and_secrets.md
@@ -5,13 +5,12 @@ this isn't always appropriate. For example, API keys should never be stored in t
 metadata. Additionally, other configuration options might be best set at runtime,
 such as the `device` configuration that controls whether to use GPU or CPU for
 inference. If you hardcoded this to GPU, you wouldn't be able to run the code on
-server without one.
+a server without one.
 
 To handle these cases, you can set variables on the embedding registry and
 reference them in the embedding configuration. These variables will be available
 during the runtime of your program, but not saved in the table's metadata. When
-the table is loaded from a different process, the variables must be set again
-for the embedding functions to be able to be loaded.
+the table is loaded from a different process, the variables must be set again.
 
 To set a variable, use the `set_var()` / `setVar()` method on the embedding registry.
 To reference a variable, use the syntax `$env:VARIABLE_NAME`. If there is a default
@@ -21,38 +20,34 @@ value, you can use the syntax `$env:VARIABLE_NAME:DEFAULT_VALUE`.
 
 Sensitive configuration, such as API keys, must either be set as environment
 variables or using variables on the embedding registry. If you pass in a hardcoded
-value, LanceDB will raise an error.
+value, LanceDB will raise an error. Instead, if you want to set an API key via
+configuration, use a variable:
 
 === "Python"
 
-    ```shell
+    ```python
     --8<-- "python/python/tests/docs/test_embeddings_optional.py:register_secret"
     ```
 
 === "Typescript"
 
-    ```shell
-    --8<-- "docs/src/basic_legacy.ts:create_table"
+    ```typescript
+    --8<-- "nodejs/examples/embedding.test.ts:register_secret"
     ```
 
-## Using variables to set device
+## Using variables to set the device parameter
 
-Because not all computers have a GPU, it's helpful to be able to set the `device`
-parameter at runtime, rather than have it hard coded in the embedding configuration.
-To make it work even if the variable isn't set, you could provide a default value
-of `cpu` in the embedding configuration.
+Many embedding functions that run locally have a `device` parameter that controls
+whether to use GPU or CPU for inference. Because not all computers have a GPU,
+it's helpful to be able to set the `device` parameter at runtime, rather than
+have it hard coded in the embedding configuration. To make it work even if the
+variable isn't set, you could provide a default value of `cpu` in the embedding
+configuration.
 
-Some embedding libraries have a method to detect which devices are available,
-which could also be used to dynamically set the device at runtime. For example, in Python you can check if a CUDA GPU is available using `torch.cuda.is_available()`.
+Some embedding libraries even have a method to detect which devices are available,
+which could be used to dynamically set the device at runtime. For example, in Python
+you can check if a CUDA GPU is available using `torch.cuda.is_available()`.
 
-=== "Python"
-
-    ```shell
-    --8<-- "python/python/tests/docs/test_embeddings_optional.py:register_device"
-    ```
-
-=== "Typescript"
-
-    ```shell
-    --8<-- "docs/src/basic_legacy.ts:create_table"
-    ```
+```python
+--8<-- "python/python/tests/docs/test_embeddings_optional.py:register_device"
+```

--- a/docs/src/js/namespaces/embedding/classes/EmbeddingFunction.md
+++ b/docs/src/js/namespaces/embedding/classes/EmbeddingFunction.md
@@ -9,7 +9,7 @@
 An embedding function that automatically creates vector representation for a given column.
 
 It's important subclasses pass the **original** options to the super constructor
-and then pass those options to `resolveConfig` to resolve any variables before
+and then pass those options to `resolveVariables` to resolve any variables before
 using them.
 
 ## Example
@@ -18,7 +18,7 @@ using them.
 class MyEmbeddingFunction extends EmbeddingFunction {
   constructor(options: {model: string, timeout: number}) {
     super(optionsRaw);
-    const options = this.resolveConfig(optionsRaw);
+    const options = this.resolveVariables(optionsRaw);
     this.model = options.model;
     this.timeout = options.timeout;
   }
@@ -106,7 +106,7 @@ The datatype of the embeddings
 ### getSensitiveKeys()
 
 ```ts
-abstract protected getSensitiveKeys(): string[]
+protected getSensitiveKeys(): string[]
 ```
 
 Provide a list of keys in the function options that should be treated as

--- a/docs/src/js/namespaces/embedding/classes/EmbeddingFunction.md
+++ b/docs/src/js/namespaces/embedding/classes/EmbeddingFunction.md
@@ -8,6 +8,23 @@
 
 An embedding function that automatically creates vector representation for a given column.
 
+It's important subclasses pass the **original** options to the super constructor
+and then pass those options to `resolveConfig` to resolve any variables before
+using them.
+
+## Example
+
+```ts
+class MyEmbeddingFunction extends EmbeddingFunction {
+  constructor(options: {model: string, timeout: number}) {
+    super(optionsRaw);
+    const options = this.resolveConfig(optionsRaw);
+    this.model = options.model;
+    this.timeout = options.timeout;
+  }
+}
+```
+
 ## Extended by
 
 - [`TextEmbeddingFunction`](TextEmbeddingFunction.md)
@@ -23,8 +40,12 @@ An embedding function that automatically creates vector representation for a giv
 ### new EmbeddingFunction()
 
 ```ts
-new EmbeddingFunction<T, M>(): EmbeddingFunction<T, M>
+new EmbeddingFunction<T, M>(args): EmbeddingFunction<T, M>
 ```
+
+#### Parameters
+
+* **args**: `Partial`&lt;`M`&gt; = `{}`
 
 #### Returns
 
@@ -82,11 +103,32 @@ The datatype of the embeddings
 
 ***
 
+### getSensitiveKeys()
+
+```ts
+abstract protected getSensitiveKeys(): string[]
+```
+
+Provide a list of keys in the function options that should be treated as
+sensitive. If users pass raw values for these keys, they will be rejected.
+
+#### Returns
+
+`string`[]
+
+***
+
 ### init()?
 
 ```ts
 optional init(): Promise<void>
 ```
+
+Optionally load any resources needed for the embedding function.
+
+This method is called after the embedding function has been initialized
+but before any embeddings are computed. It is useful for loading local models
+or other resources that are needed for the embedding function to work.
 
 #### Returns
 
@@ -105,6 +147,28 @@ The number of dimensions of the embeddings
 #### Returns
 
 `undefined` \| `number`
+
+***
+
+### resolveVariables()
+
+```ts
+protected resolveVariables<T>(config): Partial<T>
+```
+
+Apply variables to the config.
+
+#### Type Parameters
+
+• **T** *extends* [`FunctionOptions`](../interfaces/FunctionOptions.md)
+
+#### Parameters
+
+* **config**: `Partial`&lt;`T`&gt;
+
+#### Returns
+
+`Partial`&lt;`T`&gt;
 
 ***
 
@@ -134,37 +198,15 @@ sourceField is used in combination with `LanceSchema` to provide a declarative d
 ### toJSON()
 
 ```ts
-abstract toJSON(): Partial<M>
+toJSON(): Record<string, any>
 ```
 
-Convert the embedding function to a JSON object
-It is used to serialize the embedding function to the schema
-It's important that any object returned by this method contains all the necessary
-information to recreate the embedding function
-
-It should return the same object that was passed to the constructor
-If it does not, the embedding function will not be able to be recreated, or could be recreated incorrectly
+Get the original arguments to the constructor, to serialize them so they
+can be used to recreate the embedding function later.
 
 #### Returns
 
-`Partial`&lt;`M`&gt;
-
-#### Example
-
-```ts
-class MyEmbeddingFunction extends EmbeddingFunction {
-  constructor(options: {model: string, timeout: number}) {
-    super();
-    this.model = options.model;
-    this.timeout = options.timeout;
-  }
-  toJSON() {
-    return {
-      model: this.model,
-      timeout: this.timeout,
-    };
-}
-```
+`Record`&lt;`string`, `any`&gt;
 
 ***
 

--- a/docs/src/js/namespaces/embedding/classes/EmbeddingFunction.md
+++ b/docs/src/js/namespaces/embedding/classes/EmbeddingFunction.md
@@ -40,12 +40,8 @@ class MyEmbeddingFunction extends EmbeddingFunction {
 ### new EmbeddingFunction()
 
 ```ts
-new EmbeddingFunction<T, M>(args): EmbeddingFunction<T, M>
+new EmbeddingFunction<T, M>(): EmbeddingFunction<T, M>
 ```
-
-#### Parameters
-
-* **args**: `Partial`&lt;`M`&gt; = `{}`
 
 #### Returns
 
@@ -153,22 +149,18 @@ The number of dimensions of the embeddings
 ### resolveVariables()
 
 ```ts
-protected resolveVariables<T>(config): Partial<T>
+protected resolveVariables(config): Partial<M>
 ```
 
 Apply variables to the config.
 
-#### Type Parameters
-
-• **T** *extends* [`FunctionOptions`](../interfaces/FunctionOptions.md)
-
 #### Parameters
 
-* **config**: `Partial`&lt;`T`&gt;
+* **config**: `Partial`&lt;`M`&gt;
 
 #### Returns
 
-`Partial`&lt;`T`&gt;
+`Partial`&lt;`M`&gt;
 
 ***
 

--- a/docs/src/js/namespaces/embedding/classes/EmbeddingFunctionRegistry.md
+++ b/docs/src/js/namespaces/embedding/classes/EmbeddingFunctionRegistry.md
@@ -80,6 +80,28 @@ getTableMetadata(functions): Map<string, string>
 
 ***
 
+### getVar()
+
+```ts
+getVar(name): undefined | string
+```
+
+Get a variable.
+
+#### Parameters
+
+* **name**: `string`
+
+#### Returns
+
+`undefined` \| `string`
+
+#### See
+
+[setVar](EmbeddingFunctionRegistry.md#setvar)
+
+***
+
 ### length()
 
 ```ts
@@ -141,6 +163,30 @@ reset the registry to the initial state
 #### Parameters
 
 * **this**: [`EmbeddingFunctionRegistry`](EmbeddingFunctionRegistry.md)
+
+#### Returns
+
+`void`
+
+***
+
+### setVar()
+
+```ts
+setVar(name, value): void
+```
+
+Set a variable. These can be accessed in the embedding function
+configuration using the syntax `$var:variable_name`. If they are not
+set, an error will be thrown letting you know which key is unset. If you
+want to supply a default value, you can add an additional part in the
+configuration like so: `$var:variable_name:default_value`.
+
+#### Parameters
+
+* **name**: `string`
+
+* **value**: `string`
 
 #### Returns
 

--- a/docs/src/js/namespaces/embedding/classes/EmbeddingFunctionRegistry.md
+++ b/docs/src/js/namespaces/embedding/classes/EmbeddingFunctionRegistry.md
@@ -184,6 +184,8 @@ configuration like so: `$var:variable_name:default_value`. Default values
 can be used for runtime configurations that are not sensitive, such as
 whether to use a GPU for inference.
 
+The name must not contain colons. The default value can contain colons.
+
 #### Parameters
 
 * **name**: `string`

--- a/docs/src/js/namespaces/embedding/classes/EmbeddingFunctionRegistry.md
+++ b/docs/src/js/namespaces/embedding/classes/EmbeddingFunctionRegistry.md
@@ -180,7 +180,9 @@ Set a variable. These can be accessed in the embedding function
 configuration using the syntax `$var:variable_name`. If they are not
 set, an error will be thrown letting you know which key is unset. If you
 want to supply a default value, you can add an additional part in the
-configuration like so: `$var:variable_name:default_value`.
+configuration like so: `$var:variable_name:default_value`. Default values
+can be used for runtime configurations that are not sensitive, such as
+whether to use a GPU for inference.
 
 #### Parameters
 

--- a/docs/src/js/namespaces/embedding/classes/TextEmbeddingFunction.md
+++ b/docs/src/js/namespaces/embedding/classes/TextEmbeddingFunction.md
@@ -21,8 +21,12 @@ an abstract class for implementing embedding functions that take text as input
 ### new TextEmbeddingFunction()
 
 ```ts
-new TextEmbeddingFunction<M>(): TextEmbeddingFunction<M>
+new TextEmbeddingFunction<M>(args): TextEmbeddingFunction<M>
 ```
+
+#### Parameters
+
+* **args**: `Partial`&lt;`M`&gt; = `{}`
 
 #### Returns
 
@@ -114,11 +118,36 @@ abstract generateEmbeddings(texts, ...args): Promise<number[][] | Float32Array[]
 
 ***
 
+### getSensitiveKeys()
+
+```ts
+abstract protected getSensitiveKeys(): string[]
+```
+
+Provide a list of keys in the function options that should be treated as
+sensitive. If users pass raw values for these keys, they will be rejected.
+
+#### Returns
+
+`string`[]
+
+#### Inherited from
+
+[`EmbeddingFunction`](EmbeddingFunction.md).[`getSensitiveKeys`](EmbeddingFunction.md#getsensitivekeys)
+
+***
+
 ### init()?
 
 ```ts
 optional init(): Promise<void>
 ```
+
+Optionally load any resources needed for the embedding function.
+
+This method is called after the embedding function has been initialized
+but before any embeddings are computed. It is useful for loading local models
+or other resources that are needed for the embedding function to work.
 
 #### Returns
 
@@ -148,6 +177,32 @@ The number of dimensions of the embeddings
 
 ***
 
+### resolveVariables()
+
+```ts
+protected resolveVariables<T>(config): Partial<T>
+```
+
+Apply variables to the config.
+
+#### Type Parameters
+
+• **T** *extends* [`FunctionOptions`](../interfaces/FunctionOptions.md)
+
+#### Parameters
+
+* **config**: `Partial`&lt;`T`&gt;
+
+#### Returns
+
+`Partial`&lt;`T`&gt;
+
+#### Inherited from
+
+[`EmbeddingFunction`](EmbeddingFunction.md).[`resolveVariables`](EmbeddingFunction.md#resolvevariables)
+
+***
+
 ### sourceField()
 
 ```ts
@@ -173,37 +228,15 @@ sourceField is used in combination with `LanceSchema` to provide a declarative d
 ### toJSON()
 
 ```ts
-abstract toJSON(): Partial<M>
+toJSON(): Record<string, any>
 ```
 
-Convert the embedding function to a JSON object
-It is used to serialize the embedding function to the schema
-It's important that any object returned by this method contains all the necessary
-information to recreate the embedding function
-
-It should return the same object that was passed to the constructor
-If it does not, the embedding function will not be able to be recreated, or could be recreated incorrectly
+Get the original arguments to the constructor, to serialize them so they
+can be used to recreate the embedding function later.
 
 #### Returns
 
-`Partial`&lt;`M`&gt;
-
-#### Example
-
-```ts
-class MyEmbeddingFunction extends EmbeddingFunction {
-  constructor(options: {model: string, timeout: number}) {
-    super();
-    this.model = options.model;
-    this.timeout = options.timeout;
-  }
-  toJSON() {
-    return {
-      model: this.model,
-      timeout: this.timeout,
-    };
-}
-```
+`Record`&lt;`string`, `any`&gt;
 
 #### Inherited from
 

--- a/docs/src/js/namespaces/embedding/classes/TextEmbeddingFunction.md
+++ b/docs/src/js/namespaces/embedding/classes/TextEmbeddingFunction.md
@@ -21,12 +21,8 @@ an abstract class for implementing embedding functions that take text as input
 ### new TextEmbeddingFunction()
 
 ```ts
-new TextEmbeddingFunction<M>(args): TextEmbeddingFunction<M>
+new TextEmbeddingFunction<M>(): TextEmbeddingFunction<M>
 ```
-
-#### Parameters
-
-* **args**: `Partial`&lt;`M`&gt; = `{}`
 
 #### Returns
 
@@ -180,22 +176,18 @@ The number of dimensions of the embeddings
 ### resolveVariables()
 
 ```ts
-protected resolveVariables<T>(config): Partial<T>
+protected resolveVariables(config): Partial<M>
 ```
 
 Apply variables to the config.
 
-#### Type Parameters
-
-• **T** *extends* [`FunctionOptions`](../interfaces/FunctionOptions.md)
-
 #### Parameters
 
-* **config**: `Partial`&lt;`T`&gt;
+* **config**: `Partial`&lt;`M`&gt;
 
 #### Returns
 
-`Partial`&lt;`T`&gt;
+`Partial`&lt;`M`&gt;
 
 #### Inherited from
 

--- a/docs/src/js/namespaces/embedding/classes/TextEmbeddingFunction.md
+++ b/docs/src/js/namespaces/embedding/classes/TextEmbeddingFunction.md
@@ -121,7 +121,7 @@ abstract generateEmbeddings(texts, ...args): Promise<number[][] | Float32Array[]
 ### getSensitiveKeys()
 
 ```ts
-abstract protected getSensitiveKeys(): string[]
+protected getSensitiveKeys(): string[]
 ```
 
 Provide a list of keys in the function options that should be treated as

--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -17,6 +17,8 @@ import {
 import { EmbeddingFunction, LanceSchema } from "../lancedb/embedding";
 import { getRegistry, register } from "../lancedb/embedding/registry";
 
+const testOpenAIInteg = process.env.OPENAI_API_KEY == null ? test.skip : test;
+
 describe("embedding functions", () => {
   let tmpDir: tmp.DirResult;
   beforeEach(() => {
@@ -230,10 +232,7 @@ describe("embedding functions", () => {
     );
   });
 
-  it("propagates variables through all methods", async () => {
-    if (!process.env.OPENAI_API_KEY) {
-      test.skip("OPENAI_API_KEY not set");
-    }
+  testOpenAIInteg("propagates variables through all methods", async () => {
     delete process.env.OPENAI_API_KEY;
     const registry = getRegistry();
     registry.setVar("openai_api_key", "sk-...");

--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -29,11 +29,11 @@ describe("embedding functions", () => {
 
   it("should be able to create a table with an embedding function", async () => {
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      toJSON(): object {
-        return {};
-      }
       ndims() {
         return 3;
+      }
+      getSensitiveKeys() {
+        return [];
       }
       embeddingDataType(): Float {
         return new Float32();
@@ -75,11 +75,11 @@ describe("embedding functions", () => {
   it("should be able to append and upsert using embedding function", async () => {
     @register()
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      toJSON(): object {
-        return {};
-      }
       ndims() {
         return 3;
+      }
+      getSensitiveKeys() {
+        return [];
       }
       embeddingDataType(): Float {
         return new Float32();
@@ -143,11 +143,11 @@ describe("embedding functions", () => {
   it("should be able to create an empty table with an embedding function", async () => {
     @register()
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      toJSON(): object {
-        return {};
-      }
       ndims() {
         return 3;
+      }
+      getSensitiveKeys() {
+        return [];
       }
       embeddingDataType(): Float {
         return new Float32();
@@ -194,11 +194,11 @@ describe("embedding functions", () => {
   it("should error when appending to a table with an unregistered embedding function", async () => {
     @register("mock")
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      toJSON(): object {
-        return {};
-      }
       ndims() {
         return 3;
+      }
+      getSensitiveKeys() {
+        return [];
       }
       embeddingDataType(): Float {
         return new Float32();
@@ -245,11 +245,11 @@ describe("embedding functions", () => {
     "should be able to provide manual embeddings with multiple float datatype",
     async (floatType) => {
       class MockEmbeddingFunction extends EmbeddingFunction<string> {
-        toJSON(): object {
-          return {};
-        }
         ndims() {
           return 3;
+        }
+        getSensitiveKeys() {
+          return [];
         }
         embeddingDataType(): Float {
           return floatType;
@@ -292,10 +292,9 @@ describe("embedding functions", () => {
     async (floatType) => {
       @register("test1")
       class MockEmbeddingFunctionWithoutNDims extends EmbeddingFunction<string> {
-        toJSON(): object {
-          return {};
+        getSensitiveKeys() {
+          return [];
         }
-
         embeddingDataType(): Float {
           return floatType;
         }
@@ -310,11 +309,11 @@ describe("embedding functions", () => {
       }
       @register("test")
       class MockEmbeddingFunction extends EmbeddingFunction<string> {
-        toJSON(): object {
-          return {};
-        }
         ndims() {
           return 3;
+        }
+        getSensitiveKeys() {
+          return [];
         }
         embeddingDataType(): Float {
           return floatType;

--- a/nodejs/__test__/registry.test.ts
+++ b/nodejs/__test__/registry.test.ts
@@ -39,11 +39,6 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
   it("should register a new item to the registry", async () => {
     @register("mock-embedding")
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      toJSON(): object {
-        return {
-          someText: "hello",
-        };
-      }
       constructor() {
         super();
       }
@@ -92,11 +87,6 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
   });
   test("should error if registering with the same name", async () => {
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      toJSON(): object {
-        return {
-          someText: "hello",
-        };
-      }
       constructor() {
         super();
       }
@@ -120,11 +110,6 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
   });
   test("schema should contain correct metadata", async () => {
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      toJSON(): object {
-        return {
-          someText: "hello",
-        };
-      }
       constructor() {
         super();
       }

--- a/nodejs/__test__/registry.test.ts
+++ b/nodejs/__test__/registry.test.ts
@@ -11,7 +11,11 @@ import * as arrow18 from "apache-arrow-18";
 import * as tmp from "tmp";
 
 import { connect } from "../lancedb";
-import { EmbeddingFunction, LanceSchema } from "../lancedb/embedding";
+import {
+  EmbeddingFunction,
+  FunctionOptions,
+  LanceSchema,
+} from "../lancedb/embedding";
 import { getRegistry, register } from "../lancedb/embedding/registry";
 
 describe.each([arrow15, arrow16, arrow17, arrow18])("LanceSchema", (arrow) => {
@@ -104,8 +108,8 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
   });
   test("schema should contain correct metadata", async () => {
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      constructor() {
-        super();
+      constructor(args: FunctionOptions = {}) {
+        super(args);
       }
       ndims() {
         return 3;
@@ -117,7 +121,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
         return data.map(() => [1, 2, 3]);
       }
     }
-    const func = new MockEmbeddingFunction();
+    const func = new MockEmbeddingFunction({ someText: "hello" });
 
     const schema = LanceSchema({
       id: new arrow.Int32(),
@@ -148,9 +152,9 @@ describe("Registry.setVar", () => {
     @register("mock-embedding")
     // biome-ignore lint/correctness/noUnusedVariables :
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
-      constructor(optionsRaw: { someKey: string; secretKey?: string }) {
+      constructor(optionsRaw: FunctionOptions = {}) {
         super(optionsRaw);
-        const options = this.resolveConfig(optionsRaw);
+        const options = this.resolveVariables(optionsRaw);
 
         expect(optionsRaw["someKey"].startsWith("$var:someName")).toBe(true);
         expect(options["someKey"]).toBe("someValue");

--- a/nodejs/__test__/registry.test.ts
+++ b/nodejs/__test__/registry.test.ts
@@ -109,7 +109,8 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
   test("schema should contain correct metadata", async () => {
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
       constructor(args: FunctionOptions = {}) {
-        super(args);
+        super();
+        this.resolveVariables(args);
       }
       ndims() {
         return 3;
@@ -153,7 +154,7 @@ describe("Registry.setVar", () => {
     // biome-ignore lint/correctness/noUnusedVariables :
     class MockEmbeddingFunction extends EmbeddingFunction<string> {
       constructor(optionsRaw: FunctionOptions = {}) {
-        super(optionsRaw);
+        super();
         const options = this.resolveVariables(optionsRaw);
 
         expect(optionsRaw["someKey"].startsWith("$var:someName")).toBe(true);

--- a/nodejs/__test__/registry.test.ts
+++ b/nodejs/__test__/registry.test.ts
@@ -48,9 +48,6 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
       embeddingDataType() {
         return new arrow.Float32() as apiArrow.Float;
       }
-      protected getSensitiveKeys() {
-        return [];
-      }
       async computeSourceEmbeddings(data: string[]) {
         return data.map(() => [1, 2, 3]);
       }
@@ -90,9 +87,6 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
       constructor() {
         super();
       }
-      protected getSensitiveKeys() {
-        return [];
-      }
       ndims() {
         return 3;
       }
@@ -115,9 +109,6 @@ describe.each([arrow15, arrow16, arrow17, arrow18])("Registry", (arrow) => {
       }
       ndims() {
         return 3;
-      }
-      protected getSensitiveKeys() {
-        return [];
       }
       embeddingDataType() {
         return new arrow.Float32() as apiArrow.Float;

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -1041,9 +1041,6 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
         ndims() {
           return 1;
         }
-        protected getSensitiveKeys(): string[] {
-          return [];
-        }
         embeddingDataType() {
           return new Float32();
         }

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -1038,11 +1038,11 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
     test("can search using a string", async () => {
       @register()
       class MockEmbeddingFunction extends EmbeddingFunction<string> {
-        toJSON(): object {
-          return {};
-        }
         ndims() {
           return 1;
+        }
+        protected getSensitiveKeys(): string[] {
+          return [];
         }
         embeddingDataType() {
           return new Float32();

--- a/nodejs/examples/embedding.test.ts
+++ b/nodejs/examples/embedding.test.ts
@@ -45,7 +45,7 @@ test("custom embedding function", async () => {
     class MyEmbeddingFunction extends EmbeddingFunction<string> {
       constructor(optionsRaw = {}) {
         super(optionsRaw);
-        const options = this.resolveConfig(optionsRaw);
+        const options = this.resolveVariables(optionsRaw);
         // Initialize using options
       }
       ndims() {
@@ -98,15 +98,15 @@ test("custom embedding function", async () => {
     expect(await table.countRows()).toBe(2);
     expect(await table2.countRows()).toBe(2);
   });
+});
 
-  test("embedding function api_key", async () => {
-    // --8<-- [start:register_secret]
-    const registry = getRegistry();
-    registry.setVar("api_key", "sk-...");
+test("embedding function api_key", async () => {
+  // --8<-- [start:register_secret]
+  const registry = getRegistry();
+  registry.setVar("api_key", "sk-...");
 
-    const func = registry.get("openai").create({
-      apiKey: "$var:api_key",
-    });
-    // --8<-- [end:register_secret]
+  const func = registry.get("openai")!.create({
+    apiKey: "$var:api_key",
   });
+  // --8<-- [end:register_secret]
 });

--- a/nodejs/examples/embedding.test.ts
+++ b/nodejs/examples/embedding.test.ts
@@ -44,7 +44,7 @@ test("custom embedding function", async () => {
     @register("my_embedding")
     class MyEmbeddingFunction extends EmbeddingFunction<string> {
       constructor(optionsRaw = {}) {
-        super(optionsRaw);
+        super();
         const options = this.resolveVariables(optionsRaw);
         // Initialize using options
       }

--- a/nodejs/examples/embedding.test.ts
+++ b/nodejs/examples/embedding.test.ts
@@ -17,8 +17,8 @@ openAiTest("openai embeddings", async () => {
     // --8<-- [start:openai_embeddings]
     const db = await lancedb.connect(databaseDir);
     const func = getRegistry()
-    .get("openai")
-    ?.create({ model: "text-embedding-ada-002" }) as EmbeddingFunction;
+      .get("openai")
+      ?.create({ model: "text-embedding-ada-002" }) as EmbeddingFunction;
 
     const wordsSchema = LanceSchema({
       text: func.sourceField(new Utf8()),

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -73,8 +73,8 @@ export abstract class EmbeddingFunction<
     return JSON.parse(JSON.stringify(this.#config));
   }
 
-  constructor(args: Partial<M> = {}) {
-    this.#config = args;
+  constructor() {
+    this.#config = {};
   }
 
   /**
@@ -88,9 +88,8 @@ export abstract class EmbeddingFunction<
   /**
    * Apply variables to the config.
    */
-  protected resolveVariables<T extends FunctionOptions>(
-    config: Partial<T>,
-  ): Partial<T> {
+  protected resolveVariables(config: Partial<M>): Partial<M> {
+    this.#config = config;
     const registry = getRegistry();
     const newConfig = { ...config };
     for (const [key_, value] of Object.entries(newConfig)) {
@@ -103,7 +102,7 @@ export abstract class EmbeddingFunction<
         );
       }
       // Makes TS happy (https://stackoverflow.com/a/78391854)
-      const key = key_ as keyof T;
+      const key = key_ as keyof M;
       if (typeof value === "string" && value.startsWith("$var:")) {
         const [name, defaultValue] = value.slice(5).split(":", 2);
         const variableValue = registry.getVar(name);

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -15,6 +15,7 @@ import {
   newVectorType,
 } from "../arrow";
 import { sanitizeType } from "../sanitize";
+import { getRegistry } from "./registry";
 
 /**
  * Options for a given embedding function
@@ -32,6 +33,22 @@ export interface EmbeddingFunctionConstructor<
 
 /**
  * An embedding function that automatically creates vector representation for a given column.
+ *
+ * It's important subclasses pass the **original** options to the super constructor
+ * and then pass those options to `resolveConfig` to resolve any variables before
+ * using them.
+ *
+ * @example
+ * ```ts
+ * class MyEmbeddingFunction extends EmbeddingFunction {
+ *   constructor(options: {model: string, timeout: number}) {
+ *     super(optionsRaw);
+ *     const options = this.resolveConfig(optionsRaw);
+ *     this.model = options.model;
+ *     this.timeout = options.timeout;
+ *   }
+ * }
+ * ```
  */
 export abstract class EmbeddingFunction<
   // biome-ignore lint/suspicious/noExplicitAny: we don't know what the implementor will do
@@ -44,33 +61,73 @@ export abstract class EmbeddingFunction<
    */
   // biome-ignore lint/style/useNamingConvention: we want to keep the name as it is
   readonly TOptions!: M;
-  /**
-   * Convert the embedding function to a JSON object
-   * It is used to serialize the embedding function to the schema
-   * It's important that any object returned by this method contains all the necessary
-   * information to recreate the embedding function
-   *
-   * It should return the same object that was passed to the constructor
-   * If it does not, the embedding function will not be able to be recreated, or could be recreated incorrectly
-   *
-   * @example
-   * ```ts
-   * class MyEmbeddingFunction extends EmbeddingFunction {
-   *   constructor(options: {model: string, timeout: number}) {
-   *     super();
-   *     this.model = options.model;
-   *     this.timeout = options.timeout;
-   *   }
-   *   toJSON() {
-   *     return {
-   *       model: this.model,
-   *       timeout: this.timeout,
-   *     };
-   * }
-   * ```
-   */
-  abstract toJSON(): Partial<M>;
 
+  #config: Partial<M>;
+
+  /**
+   * Get the original arguments to the constructor, to serialize them so they
+   * can be used to recreate the embedding function later.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny :
+  toJSON(): Record<string, any> {
+    return JSON.parse(JSON.stringify(this.#config));
+  }
+
+  constructor(args: Partial<M> = {}) {
+    this.#config = args;
+  }
+
+  /**
+   * Provide a list of keys in the function options that should be treated as
+   * sensitive. If users pass raw values for these keys, they will be rejected.
+   */
+  protected abstract getSensitiveKeys(): string[];
+
+  /**
+   * Apply variables to the config.
+   */
+  protected resolveConfig<T extends FunctionOptions>(
+    config: Partial<T>,
+  ): Partial<T> {
+    const registry = getRegistry();
+    const newConfig = { ...config };
+    for (const [key_, value] of Object.entries(newConfig)) {
+      if (
+        this.getSensitiveKeys().includes(key_) &&
+        !value.startsWith("$var:")
+      ) {
+        throw new Error(
+          `The key "${key_}" is sensitive and cannot be set directly. Please use the $var: syntax to set it.`,
+        );
+      }
+      // Makes TS happy (https://stackoverflow.com/a/78391854)
+      const key = key_ as keyof T;
+      if (typeof value === "string" && value.startsWith("$var:")) {
+        const [name, defaultValue] = value.slice(5).split(":", 2);
+        const variableValue = registry.getVar(name);
+        if (!variableValue) {
+          if (defaultValue) {
+            // biome-ignore lint/suspicious/noExplicitAny:
+            newConfig[key] = defaultValue as any;
+          } else {
+            throw new Error(`Variable "${name}" not found`);
+          }
+        } else {
+          // biome-ignore lint/suspicious/noExplicitAny:
+          newConfig[key] = variableValue as any;
+        }
+      }
+    }
+    return newConfig;
+  }
+
+  /**
+   * Optionally load any resources needed for the embedding function.
+   *
+   * This method is called after the embedding function has been initialized
+   * but before any embeddings are computed. It is useful for loading local models
+   * or other resources that are needed for the embedding function to work.
+   */
   async init?(): Promise<void>;
 
   /**

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -86,7 +86,7 @@ export abstract class EmbeddingFunction<
   /**
    * Apply variables to the config.
    */
-  protected resolveConfig<T extends FunctionOptions>(
+  protected resolveVariables<T extends FunctionOptions>(
     config: Partial<T>,
   ): Partial<T> {
     const registry = getRegistry();

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -35,7 +35,7 @@ export interface EmbeddingFunctionConstructor<
  * An embedding function that automatically creates vector representation for a given column.
  *
  * It's important subclasses pass the **original** options to the super constructor
- * and then pass those options to `resolveConfig` to resolve any variables before
+ * and then pass those options to `resolveVariables` to resolve any variables before
  * using them.
  *
  * @example
@@ -43,7 +43,7 @@ export interface EmbeddingFunctionConstructor<
  * class MyEmbeddingFunction extends EmbeddingFunction {
  *   constructor(options: {model: string, timeout: number}) {
  *     super(optionsRaw);
- *     const options = this.resolveConfig(optionsRaw);
+ *     const options = this.resolveVariables(optionsRaw);
  *     this.model = options.model;
  *     this.timeout = options.timeout;
  *   }

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -81,7 +81,9 @@ export abstract class EmbeddingFunction<
    * Provide a list of keys in the function options that should be treated as
    * sensitive. If users pass raw values for these keys, they will be rejected.
    */
-  protected abstract getSensitiveKeys(): string[];
+  protected getSensitiveKeys(): string[] {
+    return [];
+  }
 
   /**
    * Apply variables to the config.

--- a/nodejs/lancedb/embedding/openai.ts
+++ b/nodejs/lancedb/embedding/openai.ts
@@ -25,7 +25,7 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
       model: "text-embedding-ada-002",
     },
   ) {
-    super(optionsRaw);
+    super();
     const options = this.resolveVariables(optionsRaw);
 
     const openAIKey = options?.apiKey ?? process.env.OPENAI_API_KEY;

--- a/nodejs/lancedb/embedding/openai.ts
+++ b/nodejs/lancedb/embedding/openai.ts
@@ -26,7 +26,7 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
     },
   ) {
     super(optionsRaw);
-    const options = this.resolveConfig(optionsRaw);
+    const options = this.resolveVariables(optionsRaw);
 
     const openAIKey = options?.apiKey ?? process.env.OPENAI_API_KEY;
     if (!openAIKey) {

--- a/nodejs/lancedb/embedding/openai.ts
+++ b/nodejs/lancedb/embedding/openai.ts
@@ -21,11 +21,13 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
   #modelName: OpenAIOptions["model"];
 
   constructor(
-    options: Partial<OpenAIOptions> = {
+    optionsRaw: Partial<OpenAIOptions> = {
       model: "text-embedding-ada-002",
     },
   ) {
-    super();
+    super(optionsRaw);
+    const options = this.resolveConfig(optionsRaw);
+
     const openAIKey = options?.apiKey ?? process.env.OPENAI_API_KEY;
     if (!openAIKey) {
       throw new Error("OpenAI API key is required");
@@ -52,10 +54,8 @@ export class OpenAIEmbeddingFunction extends EmbeddingFunction<
     this.#modelName = modelName;
   }
 
-  toJSON() {
-    return {
-      model: this.#modelName,
-    };
+  protected getSensitiveKeys(): string[] {
+    return ["apiKey"];
   }
 
   ndims(): number {

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -4,7 +4,6 @@
 import {
   type EmbeddingFunction,
   type EmbeddingFunctionConstructor,
-  FunctionOptions,
 } from "./embedding_function";
 import "reflect-metadata";
 

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -172,6 +172,8 @@ export class EmbeddingFunctionRegistry {
    * can be used for runtime configurations that are not sensitive, such as
    * whether to use a GPU for inference.
    *
+   * The name must not contain colons. The default value can contain colons.
+   *
    * @param name
    * @param value
    */

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -168,7 +168,9 @@ export class EmbeddingFunctionRegistry {
    * configuration using the syntax `$var:variable_name`. If they are not
    * set, an error will be thrown letting you know which key is unset. If you
    * want to supply a default value, you can add an additional part in the
-   * configuration like so: `$var:variable_name:default_value`.
+   * configuration like so: `$var:variable_name:default_value`. Default values
+   * can be used for runtime configurations that are not sensitive, such as
+   * whether to use a GPU for inference.
    *
    * @param name
    * @param value

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -4,6 +4,7 @@
 import {
   type EmbeddingFunction,
   type EmbeddingFunctionConstructor,
+  FunctionOptions,
 } from "./embedding_function";
 import "reflect-metadata";
 
@@ -23,6 +24,7 @@ export interface EmbeddingFunctionCreate<T extends EmbeddingFunction> {
  */
 export class EmbeddingFunctionRegistry {
   #functions = new Map<string, EmbeddingFunctionConstructor>();
+  #variables = new Map<string, string>();
 
   /**
    * Get the number of registered functions
@@ -82,10 +84,7 @@ export class EmbeddingFunctionRegistry {
       };
     } else {
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-      create = function (options?: any) {
-        const instance = new factory(options);
-        return instance;
-      };
+      create = (options?: any) => new factory(options);
     }
 
     return {
@@ -163,6 +162,58 @@ export class EmbeddingFunctionRegistry {
     metadata.set("embedding_functions", JSON.stringify(jsonData));
 
     return metadata;
+  }
+
+  /**
+   * Set a variable. These can be accessed in the embedding function
+   * configuration using the syntax `$var:variable_name`. If they are not
+   * set, an error will be thrown letting you know which key is unset. If you
+   * want to supply a default value, you can add an additional part in the
+   * configuration like so: `$var:variable_name:default_value`.
+   *
+   * Secrets
+   *
+   * @param name
+   * @param value
+   */
+  setVar(name: string, value: string): void {
+    if (name.includes(":")) {
+      throw new Error("Variable names cannot contain colons");
+    }
+    this.#variables.set(name, value);
+  }
+
+  /**
+   * Get a variable.
+   * @param name
+   * @returns
+   * @see {@link setVar}
+   */
+  getVar(name: string): string | undefined {
+    return this.#variables.get(name);
+  }
+
+  /**
+   * @ignore
+   */
+  resolveConfig(config: Partial<FunctionOptions>): Partial<FunctionOptions> {
+    const newConfig = { ...config };
+    for (const [key, value] of Object.entries(newConfig)) {
+      if (typeof value === "string" && value.startsWith("$var:")) {
+        const [name, defaultValue] = value.slice(5).split(":", 1);
+        const variableValue = this.getVar(name);
+        if (!variableValue) {
+          if (defaultValue) {
+            newConfig[key] = defaultValue;
+          } else {
+            throw new Error(`Variable "${name}" not found`);
+          }
+        } else {
+          newConfig[key] = variableValue;
+        }
+      }
+    }
+    return newConfig;
   }
 }
 

--- a/nodejs/lancedb/embedding/registry.ts
+++ b/nodejs/lancedb/embedding/registry.ts
@@ -171,8 +171,6 @@ export class EmbeddingFunctionRegistry {
    * want to supply a default value, you can add an additional part in the
    * configuration like so: `$var:variable_name:default_value`.
    *
-   * Secrets
-   *
    * @param name
    * @param value
    */
@@ -191,29 +189,6 @@ export class EmbeddingFunctionRegistry {
    */
   getVar(name: string): string | undefined {
     return this.#variables.get(name);
-  }
-
-  /**
-   * @ignore
-   */
-  resolveConfig(config: Partial<FunctionOptions>): Partial<FunctionOptions> {
-    const newConfig = { ...config };
-    for (const [key, value] of Object.entries(newConfig)) {
-      if (typeof value === "string" && value.startsWith("$var:")) {
-        const [name, defaultValue] = value.slice(5).split(":", 1);
-        const variableValue = this.getVar(name);
-        if (!variableValue) {
-          if (defaultValue) {
-            newConfig[key] = defaultValue;
-          } else {
-            throw new Error(`Variable "${name}" not found`);
-          }
-        } else {
-          newConfig[key] = variableValue;
-        }
-      }
-    }
-    return newConfig;
   }
 }
 

--- a/nodejs/lancedb/embedding/transformers.ts
+++ b/nodejs/lancedb/embedding/transformers.ts
@@ -44,11 +44,12 @@ export class TransformersEmbeddingFunction extends EmbeddingFunction<
   #ndims?: number;
 
   constructor(
-    options: Partial<XenovaTransformerOptions> = {
+    optionsRaw: Partial<XenovaTransformerOptions> = {
       model: "Xenova/all-MiniLM-L6-v2",
     },
   ) {
-    super();
+    super(optionsRaw);
+    const options = this.resolveConfig(optionsRaw);
 
     const modelName = options?.model ?? "Xenova/all-MiniLM-L6-v2";
     this.#tokenizerOptions = {
@@ -59,21 +60,9 @@ export class TransformersEmbeddingFunction extends EmbeddingFunction<
     this.#ndims = options.ndims;
     this.#modelName = modelName;
   }
-  toJSON() {
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-    const obj: Record<string, any> = {
-      model: this.#modelName,
-    };
-    if (this.#ndims) {
-      obj["ndims"] = this.#ndims;
-    }
-    if (this.#tokenizerOptions) {
-      obj["tokenizerOptions"] = this.#tokenizerOptions;
-    }
-    if (this.#tokenizer) {
-      obj["tokenizer"] = this.#tokenizer.name;
-    }
-    return obj;
+
+  protected getSensitiveKeys(): string[] {
+    return [];
   }
 
   async init() {

--- a/nodejs/lancedb/embedding/transformers.ts
+++ b/nodejs/lancedb/embedding/transformers.ts
@@ -49,7 +49,7 @@ export class TransformersEmbeddingFunction extends EmbeddingFunction<
     },
   ) {
     super(optionsRaw);
-    const options = this.resolveConfig(optionsRaw);
+    const options = this.resolveVariables(optionsRaw);
 
     const modelName = options?.model ?? "Xenova/all-MiniLM-L6-v2";
     this.#tokenizerOptions = {

--- a/nodejs/lancedb/embedding/transformers.ts
+++ b/nodejs/lancedb/embedding/transformers.ts
@@ -61,10 +61,6 @@ export class TransformersEmbeddingFunction extends EmbeddingFunction<
     this.#modelName = modelName;
   }
 
-  protected getSensitiveKeys(): string[] {
-    return [];
-  }
-
   async init() {
     let transformers;
     try {

--- a/nodejs/lancedb/embedding/transformers.ts
+++ b/nodejs/lancedb/embedding/transformers.ts
@@ -48,7 +48,7 @@ export class TransformersEmbeddingFunction extends EmbeddingFunction<
       model: "Xenova/all-MiniLM-L6-v2",
     },
   ) {
-    super(optionsRaw);
+    super();
     const options = this.resolveVariables(optionsRaw);
 
     const modelName = options?.model ?? "Xenova/all-MiniLM-L6-v2";

--- a/python/python/lancedb/embeddings/base.py
+++ b/python/python/lancedb/embeddings/base.py
@@ -159,6 +159,10 @@ class EmbeddingFunction(BaseModel, ABC):
         return texts
 
     def safe_model_dump(self):
+        if not hasattr(self, "_original_args"):
+            raise ValueError(
+                "EmbeddingFunction was not created with EmbeddingFunction.create()"
+            )
         return self._original_args
 
     @abstractmethod

--- a/python/python/lancedb/embeddings/jinaai.py
+++ b/python/python/lancedb/embeddings/jinaai.py
@@ -57,6 +57,10 @@ class JinaEmbeddings(EmbeddingFunction):
         # TODO: fix hardcoding
         return 768
 
+    @staticmethod
+    def sensitive_keys() -> List[str]:
+        return ["api_key"]
+
     def sanitize_input(
         self, inputs: Union[TEXT, IMAGES]
     ) -> Union[List[Any], np.ndarray]:

--- a/python/python/lancedb/embeddings/openai.py
+++ b/python/python/lancedb/embeddings/openai.py
@@ -55,6 +55,10 @@ class OpenAIEmbeddings(TextEmbeddingFunction):
         return self._ndims
 
     @staticmethod
+    def sensitive_keys():
+        return ["api_key"]
+
+    @staticmethod
     def model_names():
         return [
             "text-embedding-ada-002",

--- a/python/python/lancedb/embeddings/registry.py
+++ b/python/python/lancedb/embeddings/registry.py
@@ -163,7 +163,9 @@ class EmbeddingFunctionRegistry:
         the syntax `$var:variable_name`. If they are not set, an error will be
         thrown letting you know which variable is missing. If you want to supply
         a default value, you can add an additional part in the configuration
-        like so: `$var:variable_name:default_value`.
+        like so: `$var:variable_name:default_value`. Default values can be
+        used for runtime configurations that are not sensitive, such as
+        whether to use a GPU for inference.
         """
         if ":" in name:
             raise ValueError("Variable names cannot contain colons")

--- a/python/python/lancedb/embeddings/registry.py
+++ b/python/python/lancedb/embeddings/registry.py
@@ -166,6 +166,8 @@ class EmbeddingFunctionRegistry:
         like so: `$var:variable_name:default_value`. Default values can be
         used for runtime configurations that are not sensitive, such as
         whether to use a GPU for inference.
+
+        The name must not contain a colon. Default values can contain colons.
         """
         if ":" in name:
             raise ValueError("Variable names cannot contain colons")

--- a/python/python/lancedb/embeddings/registry.py
+++ b/python/python/lancedb/embeddings/registry.py
@@ -41,6 +41,7 @@ class EmbeddingFunctionRegistry:
 
     def __init__(self):
         self._functions = {}
+        self._variables = {}
 
     def register(self, alias: str = None):
         """
@@ -155,6 +156,24 @@ class EmbeddingFunctionRegistry:
         # so we need to json dump then utf8 encode
         metadata = json.dumps(json_data, indent=2).encode("utf-8")
         return {"embedding_functions": metadata}
+
+    def set_var(self, name: str, value: str) -> None:
+        """
+        Set a variable. These can be accessed in embedding configuration using
+        the syntax `$var:variable_name`. If they are not set, an error will be
+        thrown letting you know which variable is missing. If you want to supply
+        a default value, you can add an additional part in the configuration
+        like so: `$var:variable_name:default_value`.
+        """
+        if ":" in name:
+            raise ValueError("Variable names cannot contain colons")
+        self._variables[name] = value
+
+    def get_var(self, name: str) -> str:
+        """
+        Get a variable.
+        """
+        return self._variables[name]
 
 
 # Global instance

--- a/python/python/lancedb/embeddings/watsonx.py
+++ b/python/python/lancedb/embeddings/watsonx.py
@@ -41,6 +41,10 @@ class WatsonxEmbeddings(TextEmbeddingFunction):
     params: Optional[Dict] = None
 
     @staticmethod
+    def sensitive_keys():
+        return ["api_key"]
+
+    @staticmethod
     def model_names():
         return [
             "ibm/slate-125m-english-rtrvr",

--- a/python/python/tests/docs/test_embeddings_optional.py
+++ b/python/python/tests/docs/test_embeddings_optional.py
@@ -59,6 +59,11 @@ def test_embeddings_secret():
     func = registry.get("openai").create(api_key="$var:api_key")
     # --8<-- [end:register_secret]
 
+    try:
+        import torch
+    except ImportError:
+        pytest.skip("torch not installed")
+
     # --8<-- [start:register_device]
     import torch
 

--- a/python/python/tests/docs/test_embeddings_optional.py
+++ b/python/python/tests/docs/test_embeddings_optional.py
@@ -13,20 +13,14 @@ import pytest
 
 @pytest.mark.slow
 def test_embeddings_openai():
-    uri = "memory://"
     # --8<-- [start:openai_embeddings]
-    registry = get_registry()
-    registry.set_var("open_api_key", "sk-...")
-    func = registry.get("openai").create(
-        name="text-embedding-ada-002",
-        api_key="$var:open_api_key",
-    )
+    db = lancedb.connect("/tmp/db")
+    func = get_registry().get("openai").create(name="text-embedding-ada-002")
 
     class Words(LanceModel):
         text: str = func.SourceField()
         vector: Vector(func.ndims()) = func.VectorField()
 
-    db = lancedb.connect(uri)
     table = db.create_table("words", schema=Words, mode="overwrite")
     table.add([{"text": "hello world"}, {"text": "goodbye world"}])
 

--- a/python/python/tests/docs/test_embeddings_optional.py
+++ b/python/python/tests/docs/test_embeddings_optional.py
@@ -13,14 +13,20 @@ import pytest
 
 @pytest.mark.slow
 def test_embeddings_openai():
+    uri = "memory://"
     # --8<-- [start:openai_embeddings]
-    db = lancedb.connect("/tmp/db")
-    func = get_registry().get("openai").create(name="text-embedding-ada-002")
+    registry = get_registry()
+    registry.set_var("open_api_key", "sk-...")
+    func = registry.get("openai").create(
+        name="text-embedding-ada-002",
+        api_key="$var:open_api_key",
+    )
 
     class Words(LanceModel):
         text: str = func.SourceField()
         vector: Vector(func.ndims()) = func.VectorField()
 
+    db = lancedb.connect(uri)
     table = db.create_table("words", schema=Words, mode="overwrite")
     table.add([{"text": "hello world"}, {"text": "goodbye world"}])
 

--- a/python/python/tests/docs/test_embeddings_optional.py
+++ b/python/python/tests/docs/test_embeddings_optional.py
@@ -55,3 +55,23 @@ async def test_embeddings_openai_async():
     actual = await (await table.search(query)).limit(1).to_pydantic(Words)[0]
     print(actual.text)
     # --8<-- [end:async_openai_embeddings]
+
+
+def test_embeddings_secret():
+    # --8<-- [start:register_secret]
+    registry = get_registry()
+    registry.set_var("api_key", "sk-...")
+
+    func = registry.get("openai").create(api_key="$var:api_key")
+    # --8<-- [end:register_secret]
+
+    # --8<-- [start:register_device]
+    import torch
+
+    registry = get_registry()
+    if torch.cuda.is_available():
+        registry.set_var("device", "cuda")
+
+    func = registry.get("huggingface").create(device="$var:device:cpu")
+    # --8<-- [end:register_device]
+    assert func.device == "cuda" if torch.cuda.is_available() else "cpu"

--- a/python/python/tests/test_rerankers.py
+++ b/python/python/tests/test_rerankers.py
@@ -32,8 +32,8 @@ pytest.importorskip("lancedb.fts")
 def get_test_table(tmp_path, use_tantivy):
     db = lancedb.connect(tmp_path)
     # Create a LanceDB table schema with a vector and a text column
-    emb = EmbeddingFunctionRegistry.get_instance().get("test")()
-    meta_emb = EmbeddingFunctionRegistry.get_instance().get("test")()
+    emb = EmbeddingFunctionRegistry.get_instance().get("test").create()
+    meta_emb = EmbeddingFunctionRegistry.get_instance().get("test").create()
 
     class MyTable(LanceModel):
         text: str = emb.SourceField()
@@ -405,7 +405,9 @@ def test_answerdotai_reranker(tmp_path, use_tantivy):
 
 
 @pytest.mark.skipif(
-    os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY not set"
+    os.environ.get("OPENAI_API_KEY") is None
+    or os.environ.get("OPENAI_BASE_URL") is not None,
+    reason="OPENAI_API_KEY not set",
 )
 @pytest.mark.parametrize("use_tantivy", [True, False])
 def test_openai_reranker(tmp_path, use_tantivy):

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -887,7 +887,7 @@ def test_create_with_embedding_function(mem_db: DBConnection):
         text: str
         vector: Vector(10)
 
-    func = MockTextEmbeddingFunction()
+    func = MockTextEmbeddingFunction.create()
     texts = ["hello world", "goodbye world", "foo bar baz fizz buzz"]
     df = pd.DataFrame({"text": texts, "vector": func.compute_source_embeddings(texts)})
 
@@ -934,7 +934,7 @@ def test_create_f16_table(mem_db: DBConnection):
 
 
 def test_add_with_embedding_function(mem_db: DBConnection):
-    emb = EmbeddingFunctionRegistry.get_instance().get("test")()
+    emb = EmbeddingFunctionRegistry.get_instance().get("test").create()
 
     class MyTable(LanceModel):
         text: str = emb.SourceField()
@@ -1128,7 +1128,7 @@ def test_count_rows(mem_db: DBConnection):
 
 def setup_hybrid_search_table(db: DBConnection, embedding_func):
     # Create a LanceDB table schema with a vector and a text column
-    emb = EmbeddingFunctionRegistry.get_instance().get(embedding_func)()
+    emb = EmbeddingFunctionRegistry.get_instance().get(embedding_func).create()
 
     class MyTable(LanceModel):
         text: str = emb.SourceField()

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -127,7 +127,7 @@ def test_append_vector_columns():
     conf = EmbeddingFunctionConfig(
         source_column="text",
         vector_column="vector",
-        function=MockTextEmbeddingFunction(),
+        function=MockTextEmbeddingFunction.create(),
     )
     metadata = registry.get_table_metadata([conf])
 
@@ -434,7 +434,7 @@ def test_sanitize_data(
         conf = EmbeddingFunctionConfig(
             source_column="text",
             vector_column="vector",
-            function=MockTextEmbeddingFunction(),
+            function=MockTextEmbeddingFunction.create(),
         )
         metadata = registry.get_table_metadata([conf])
     else:


### PR DESCRIPTION
BREAKING CHANGE: embedding function implementations in Node need to now call `resolveVariables()` in their constructors and should **not** implement `toJSON()`.

This tries to address the handling of secrets. In Node, they are currently lost. In Python, they are currently leaked into the table schema metadata.

This PR introduces an in-memory variable store on the function registry. It also allows embedding function definitions to label certain config values as "sensitive", and the preprocessing logic will raise an error if users try to pass in hard-coded values.

Closes #2110
Closes #521 