### PR TITLE
fix: answerdotai rerankers argument passing

### DIFF
--- a/python/python/lancedb/rerankers/answerdotai.py
+++ b/python/python/lancedb/rerankers/answerdotai.py
@@ -28,6 +28,7 @@ class AnswerdotaiRerankers(Reranker):
         Additional keyword arguments to pass to the model. For example, 'device'.
         See AnswerDotAI/rerankers for more information.
     """
+
     def __init__(
         self,
         model_type="colbert",
@@ -41,7 +42,9 @@ class AnswerdotaiRerankers(Reranker):
         rerankers = attempt_import_or_raise(
             "rerankers"
         )  # import here for faster ops later
-        self.reranker = rerankers.Reranker(model_name=model_name, model_type=model_type, **kwargs)
+        self.reranker = rerankers.Reranker(
+            model_name=model_name, model_type=model_type, **kwargs
+        )
 
     def _rerank(self, result_set: pa.Table, query: str):
         docs = result_set[self.column].to_pylist()

--- a/python/python/lancedb/rerankers/answerdotai.py
+++ b/python/python/lancedb/rerankers/answerdotai.py
@@ -28,7 +28,6 @@ class AnswerdotaiRerankers(Reranker):
         Additional keyword arguments to pass to the model. For example, 'device'.
         See AnswerDotAI/rerankers for more information.
     """
-
     def __init__(
         self,
         model_type="colbert",
@@ -42,7 +41,7 @@ class AnswerdotaiRerankers(Reranker):
         rerankers = attempt_import_or_raise(
             "rerankers"
         )  # import here for faster ops later
-        self.reranker = rerankers.Reranker(model_name, model_type, **kwargs)
+        self.reranker = rerankers.Reranker(model_name=model_name, model_type=model_type, **kwargs)
 
     def _rerank(self, result_set: pa.Table, query: str):
         docs = result_set[self.column].to_pylist()


### PR DESCRIPTION
This fixes an issue for people wishing to use different kinds of rerankers in lancedb via AnswerDotAI rerankers. Currently, the arguments are passed sequentially, but they don't match the[Reranker class implementation](https://github.com/AnswerDotAI/rerankers/blob/d604a8c47d7a9fce1b6ef0cec53f0e807d6cc0fa/rerankers/reranker.py#L179): the second argument is expected to be an optional "lang" for default models, while model_type should be passed explicitly. 

The one line changes in this PR fixes it and enables the use of other methods (eg LLMs-as-rerankers)