### PR TITLE
docs: fix docstring of EmbeddingFunction

### DIFF
--- a/python/python/lancedb/embeddings/base.py
+++ b/python/python/lancedb/embeddings/base.py
@@ -17,7 +17,8 @@ class EmbeddingFunction(BaseModel, ABC):
 
     All concrete embedding functions must implement the following methods:
     1. compute_query_embeddings() which takes a query and returns a list of embeddings
-    2. compute_source_embeddings() which returns a list of embeddings for the source column
+    2. compute_source_embeddings() which returns a list of embeddings for
+       the source column
     For text data, the two will be the same. For multi-modal data, the source column
     might be images and the vector column might be text.
     3. ndims() which returns the number of dimensions of the vector column

--- a/python/python/lancedb/embeddings/base.py
+++ b/python/python/lancedb/embeddings/base.py
@@ -15,12 +15,12 @@ class EmbeddingFunction(BaseModel, ABC):
     """
     An ABC for embedding functions.
 
-    All concrete embedding functions must implement the following:
+    All concrete embedding functions must implement the following methods:
     1. compute_query_embeddings() which takes a query and returns a list of embeddings
-    2. get_source_embeddings() which returns a list of embeddings for the source column
+    2. compute_source_embeddings() which returns a list of embeddings for the source column
     For text data, the two will be the same. For multi-modal data, the source column
     might be images and the vector column might be text.
-    3. ndims method which returns the number of dimensions of the vector column
+    3. ndims() which returns the number of dimensions of the vector column
     """
 
     __slots__ = ("__weakref__",)  # pydantic 1.x compatibility


### PR DESCRIPTION
Hello LanceDB team,

---

I have fixed a discrepancy in the class docstring of `lancedb.embeddings.base:EmbeddingFunction` and made consistency alignments to that docstring.

### Changes made

1. The docstring referred to the abstract method `get_source_embeddings()`.
  This method does not exist in the repository at the current state.
  I have changed the mention to refer to the actual abstract method `compute_source_embeddings()`.
2. Also, I aligned the consistency within the ordered list which is describing the methods to be implemented by concrete embedding functions.

---

Thank you for developing this useful library. 👍

Best regards
Martin