### PR TITLE
test: query with dist range and new rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.16.1-beta.1"
+version = "0.16.1-beta.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.16.1-beta.1"
+version = "0.16.1-beta.2"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.16.1-beta.1"
+version = "0.16.1-beta.2"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.19.1-beta.1"
+version = "0.19.1-beta.2"
 dependencies = [
  "arrow",
  "env_logger",


### PR DESCRIPTION
we found a bug that flat KNN plan node's stats is not in right order as fields in schema, it would cause an error if querying with distance range and new unindexed rows.

we've fixed this in lance so add this test for verifying it works