### PR TITLE
feat!: revert query limit to be unbounded for scans

### DIFF
--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -666,11 +666,11 @@ describe("When creating an index", () => {
     expect(fs.readdirSync(indexDir)).toHaveLength(1);
 
     for await (const r of tbl.query().where("id > 1").select(["id"])) {
-      expect(r.numRows).toBe(10);
+      expect(r.numRows).toBe(298);
     }
     // should also work with 'filter' alias
     for await (const r of tbl.query().filter("id > 1").select(["id"])) {
-      expect(r.numRows).toBe(10);
+      expect(r.numRows).toBe(298);
     }
   });
 

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -3195,7 +3195,9 @@ class AsyncTable:
         # The sync remote table calls into this method, so we need to map the
         # query to the async version of the query and run that here. This is only
         # used for that code path right now.
-        async_query = self.query().limit(query.k)
+        async_query = self.query()
+        if query.k is not None:
+            async_query = async_query.limit(query.k)
         if query.offset > 0:
             async_query = async_query.offset(query.offset)
         if query.columns:

--- a/python/python/tests/test_fts.py
+++ b/python/python/tests/test_fts.py
@@ -174,6 +174,10 @@ def test_search_fts(table, use_tantivy):
     assert len(results) == 5
     assert len(results[0]) == 3  # id, text, _score
 
+    # Default limit of 10
+    results = table.search("puppy").select(["id", "text"]).to_list()
+    assert len(results) == 10
+
 
 @pytest.mark.asyncio
 async def test_fts_select_async(async_table):

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -1025,13 +1025,13 @@ def test_empty_query(mem_db: DBConnection):
 
     table = mem_db.create_table("my_table2", data=[{"id": i} for i in range(100)])
     df = table.search().select(["id"]).to_pandas()
-    assert len(df) == 10
+    assert len(df) == 100
     # None is the same as default
     df = table.search().select(["id"]).limit(None).to_pandas()
-    assert len(df) == 10
+    assert len(df) == 100
     # invalid limist is the same as None, wihch is the same as default
     df = table.search().select(["id"]).limit(-1).to_pandas()
-    assert len(df) == 10
+    assert len(df) == 100
     # valid limit should work
     df = table.search().select(["id"]).limit(42).to_pandas()
     assert len(df) == 42

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -469,6 +469,9 @@ impl<T: HasQuery> QueryBase for T {
     }
 
     fn full_text_search(mut self, query: FullTextSearchQuery) -> Self {
+        if self.mut_query().limit.is_none() {
+            self.mut_query().limit = Some(DEFAULT_TOP_K);
+        }
         self.mut_query().full_text_search = Some(query);
         self
     }
@@ -622,7 +625,7 @@ pub struct QueryRequest {
 impl Default for QueryRequest {
     fn default() -> Self {
         Self {
-            limit: Some(DEFAULT_TOP_K),
+            limit: None,
             offset: None,
             filter: None,
             full_text_search: None,
@@ -707,6 +710,11 @@ impl Query {
         let mut vector_query = self.into_vector();
         let query_vector = vector.to_query_vector(&DataType::Float32, "default")?;
         vector_query.request.query_vector.push(query_vector);
+
+        if vector_query.request.base.limit.is_none() {
+            vector_query.request.base.limit = Some(DEFAULT_TOP_K);
+        }
+
         Ok(vector_query)
     }
 

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -154,9 +154,9 @@ impl<S: HttpSend> RemoteTable<S> {
             body["offset"] = serde_json::Value::Number(serde_json::Number::from(offset));
         }
 
-        if let Some(limit) = params.limit {
-            body["k"] = serde_json::Value::Number(serde_json::Number::from(limit));
-        }
+        // Server requires k.
+        let limit = params.limit.unwrap_or(usize::MAX);
+        body["k"] = serde_json::Value::Number(serde_json::Number::from(limit));
 
         if let Some(filter) = &params.filter {
             body["filter"] = serde_json::Value::String(filter.clone());
@@ -1285,6 +1285,52 @@ mod tests {
         });
 
         table.delete("id in (1, 2, 3)").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_query_plain() {
+        let expected_data = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let expected_data_ref = expected_data.clone();
+
+        let table = Table::new_with_handler("my_table", move |request| {
+            assert_eq!(request.method(), "POST");
+            assert_eq!(request.url().path(), "/v1/table/my_table/query/");
+            assert_eq!(
+                request.headers().get("Content-Type").unwrap(),
+                JSON_CONTENT_TYPE
+            );
+
+            let body = request.body().unwrap().as_bytes().unwrap();
+            let body: serde_json::Value = serde_json::from_slice(body).unwrap();
+            let expected_body = serde_json::json!({
+                "k": usize::MAX,
+                "prefilter": true,
+                "vector": [], // Empty vector means no vector query.
+                "version": null,
+            });
+            assert_eq!(body, expected_body);
+
+            let response_body = write_ipc_file(&expected_data_ref);
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(response_body)
+                .unwrap()
+        });
+
+        let data = table
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].as_ref().unwrap(), &expected_data);
     }
 
     #[tokio::test]


### PR DESCRIPTION
In earlier PRs (#1886, #1191) we made the default limit 10 regardless of the query type. This was confusing for users and in many cases a breaking change. Users would have queries that used to return all results, but instead only returned the first 10, causing silent bugs.

Part of the cause was consistency: the Python sync API seems to have always had a limit of 10, while newer APIs (Python async and Nodejs) didn't.

This PR sets the default limit only for searches (vector search, FTS), while letting scans (even with filters) be unbounded. It does this consistently for all SDKs.

Fixes #1983
Fixes #1852
Fixes #2141
