### PR TITLE
feat: add support for streaming input to create_table

### DIFF
--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -1058,7 +1058,7 @@ mod tests {
         let schema = batches.first().unwrap().schema();
         let one_batch = concat_batches(&schema, batches.iter()).unwrap();
 
-        let ldb_stream = stream::iter(batches.clone().into_iter().map(|r| Result::Ok(r)));
+        let ldb_stream = stream::iter(batches.clone().into_iter().map(Result::Ok));
         let ldb_stream: SendableRecordBatchStream =
             Box::pin(SimpleRecordBatchStream::new(ldb_stream, schema.clone()));
 
@@ -1068,7 +1068,7 @@ mod tests {
             .await
             .unwrap();
 
-        let df_stream = stream::iter(batches.into_iter().map(|r| DataFusionResult::Ok(r)));
+        let df_stream = stream::iter(batches.into_iter().map(DataFusionResult::Ok));
         let df_stream: datafusion_physical_plan::SendableRecordBatchStream =
             Box::pin(RecordBatchStreamAdapter::new(schema.clone(), df_stream));
 

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -11,7 +11,7 @@ use arrow_schema::{Field, SchemaRef};
 use lance::dataset::ReadParams;
 use object_store::aws::AwsCredential;
 
-use crate::arrow::IntoArrow;
+use crate::arrow::{IntoArrow, IntoArrowStream, SendableRecordBatchStream};
 use crate::database::listing::{
     ListingDatabase, OPT_NEW_TABLE_STORAGE_VERSION, OPT_NEW_TABLE_V2_MANIFEST_PATHS,
 };
@@ -75,6 +75,14 @@ impl IntoArrow for NoData {
     }
 }
 
+// Stores the value given from the initial CreateTableBuilder::new call
+// and defers errors until `execute` is called
+enum CreateTableBuilderInitialData {
+    None,
+    Iterator(Result<Box<dyn RecordBatchReader + Send>>),
+    Stream(Result<SendableRecordBatchStream>),
+}
+
 /// A builder for configuring a [`Connection::create_table`] operation
 pub struct CreateTableBuilder<const HAS_DATA: bool> {
     parent: Arc<dyn Database>,
@@ -83,7 +91,7 @@ pub struct CreateTableBuilder<const HAS_DATA: bool> {
     request: CreateTableRequest,
     // This is a bit clumsy but we defer errors until `execute` is called
     // to maintain backwards compatibility
-    data: Option<Result<Box<dyn RecordBatchReader + Send>>>,
+    data: CreateTableBuilderInitialData,
 }
 
 // Builder methods that only apply when we have initial data
@@ -103,7 +111,26 @@ impl CreateTableBuilder<true> {
             ),
             embeddings: Vec::new(),
             embedding_registry,
-            data: Some(data.into_arrow()),
+            data: CreateTableBuilderInitialData::Iterator(data.into_arrow()),
+        }
+    }
+
+    fn new_streaming<T: IntoArrowStream>(
+        parent: Arc<dyn Database>,
+        name: String,
+        data: T,
+        embedding_registry: Arc<dyn EmbeddingRegistry>,
+    ) -> Self {
+        let dummy_schema = Arc::new(arrow_schema::Schema::new(Vec::<Field>::default()));
+        Self {
+            parent,
+            request: CreateTableRequest::new(
+                name,
+                CreateTableData::Empty(TableDefinition::new_from_schema(dummy_schema)),
+            ),
+            embeddings: Vec::new(),
+            embedding_registry,
+            data: CreateTableBuilderInitialData::Stream(data.into_arrow()),
         }
     }
 
@@ -125,17 +152,37 @@ impl CreateTableBuilder<true> {
     }
 
     fn into_request(self) -> Result<CreateTableRequest> {
-        let data = if self.embeddings.is_empty() {
-            self.data.unwrap()?
+        if self.embeddings.is_empty() {
+            match self.data {
+                CreateTableBuilderInitialData::Iterator(maybe_iter) => {
+                    let data = maybe_iter?;
+                    Ok(CreateTableRequest {
+                        data: CreateTableData::Data(data),
+                        ..self.request
+                    })
+                }
+                CreateTableBuilderInitialData::None => {
+                    unreachable!("No data provided for CreateTableBuilder<true>")
+                }
+                CreateTableBuilderInitialData::Stream(maybe_stream) => {
+                    let data = maybe_stream?;
+                    Ok(CreateTableRequest {
+                        data: CreateTableData::StreamingData(data),
+                        ..self.request
+                    })
+                }
+            }
         } else {
-            let data = self.data.unwrap()?;
-            Box::new(WithEmbeddings::new(data, self.embeddings))
-        };
-        let req = self.request;
-        Ok(CreateTableRequest {
-            data: CreateTableData::Data(data),
-            ..req
-        })
+            let CreateTableBuilderInitialData::Iterator(maybe_iter) = self.data else {
+                return Err(Error::NotSupported { message: "Creating a table with embeddings is currently not support when the input is streaming".to_string() });
+            };
+            let data = maybe_iter?;
+            let data = Box::new(WithEmbeddings::new(data, self.embeddings));
+            Ok(CreateTableRequest {
+                data: CreateTableData::Data(data),
+                ..self.request
+            })
+        }
     }
 }
 
@@ -151,7 +198,7 @@ impl CreateTableBuilder<false> {
         Self {
             parent,
             request: CreateTableRequest::new(name, CreateTableData::Empty(table_definition)),
-            data: None,
+            data: CreateTableBuilderInitialData::None,
             embeddings: Vec::default(),
             embedding_registry,
         }
@@ -432,7 +479,7 @@ impl Connection {
         TableNamesBuilder::new(self.internal.clone())
     }
 
-    /// Create a new table from data
+    /// Create a new table from an iterator of data
     ///
     /// # Parameters
     ///
@@ -444,6 +491,25 @@ impl Connection {
         initial_data: T,
     ) -> CreateTableBuilder<true> {
         CreateTableBuilder::<true>::new(
+            self.internal.clone(),
+            name.into(),
+            initial_data,
+            self.embedding_registry.clone(),
+        )
+    }
+
+    /// Create a new table from a stream of data
+    ///
+    /// # Parameters
+    ///
+    /// * `name` - The name of the table
+    /// * `initial_data` - The initial data to write to the table
+    pub fn create_table_streaming<T: IntoArrowStream>(
+        &self,
+        name: impl Into<String>,
+        initial_data: T,
+    ) -> CreateTableBuilder<true> {
+        CreateTableBuilder::<true>::new_streaming(
             self.internal.clone(),
             name.into(),
             initial_data,
@@ -788,12 +854,16 @@ mod test_utils {
 mod tests {
     use std::fs::create_dir_all;
 
+    use arrow::compute::concat_batches;
     use arrow_array::RecordBatchReader;
     use arrow_schema::{DataType, Field, Schema};
-    use futures::TryStreamExt;
+    use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::{stream, TryStreamExt};
+    use lance::error::{ArrowResult, DataFusionResult};
     use lance_testing::datagen::{BatchGenerator, IncrementingInt32};
     use tempfile::tempdir;
 
+    use crate::arrow::SimpleRecordBatchStream;
     use crate::database::listing::{ListingDatabaseOptions, NewTableConfig};
     use crate::query::QueryBase;
     use crate::query::{ExecutableQuery, QueryExecutionOptions};
@@ -974,6 +1044,63 @@ mod tests {
             .unwrap();
 
         assert_eq!(batches.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_create_table_streaming() {
+        let tmp_dir = tempdir().unwrap();
+
+        let uri = tmp_dir.path().to_str().unwrap();
+        let db = connect(uri).execute().await.unwrap();
+
+        let batches = make_data().collect::<ArrowResult<Vec<_>>>().unwrap();
+
+        let schema = batches.first().unwrap().schema();
+        let one_batch = concat_batches(&schema, batches.iter()).unwrap();
+
+        let ldb_stream = stream::iter(batches.clone().into_iter().map(|r| Result::Ok(r)));
+        let ldb_stream: SendableRecordBatchStream =
+            Box::pin(SimpleRecordBatchStream::new(ldb_stream, schema.clone()));
+
+        let tbl1 = db
+            .create_table_streaming("one", ldb_stream)
+            .execute()
+            .await
+            .unwrap();
+
+        let df_stream = stream::iter(batches.into_iter().map(|r| DataFusionResult::Ok(r)));
+        let df_stream: datafusion_physical_plan::SendableRecordBatchStream =
+            Box::pin(RecordBatchStreamAdapter::new(schema.clone(), df_stream));
+
+        let tbl2 = db
+            .create_table_streaming("two", df_stream)
+            .execute()
+            .await
+            .unwrap();
+
+        let tbl1_data = tbl1
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let tbl1_data = concat_batches(&schema, tbl1_data.iter()).unwrap();
+        assert_eq!(tbl1_data, one_batch);
+
+        let tbl2_data = tbl2
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let tbl2_data = concat_batches(&schema, tbl2_data.iter()).unwrap();
+        assert_eq!(tbl2_data, one_batch);
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/database.rs
+++ b/rust/lancedb/src/database.rs
@@ -94,14 +94,20 @@ pub enum CreateTableData {
     Empty(TableDefinition),
 }
 
-#[async_trait]
-impl StreamingWriteSource for CreateTableData {
-    fn arrow_schema(&self) -> Arc<arrow_schema::Schema> {
+impl CreateTableData {
+    pub fn schema(&self) -> Arc<arrow_schema::Schema> {
         match self {
             CreateTableData::Data(reader) => reader.schema(),
             CreateTableData::StreamingData(stream) => stream.schema(),
             CreateTableData::Empty(definition) => definition.schema.clone(),
         }
+    }
+}
+
+#[async_trait]
+impl StreamingWriteSource for CreateTableData {
+    fn arrow_schema(&self) -> Arc<arrow_schema::Schema> {
+        self.schema()
     }
     fn into_stream(self) -> datafusion_physical_plan::SendableRecordBatchStream {
         match self {

--- a/rust/lancedb/src/database.rs
+++ b/rust/lancedb/src/database.rs
@@ -97,9 +97,9 @@ pub enum CreateTableData {
 impl CreateTableData {
     pub fn schema(&self) -> Arc<arrow_schema::Schema> {
         match self {
-            CreateTableData::Data(reader) => reader.schema(),
-            CreateTableData::StreamingData(stream) => stream.schema(),
-            CreateTableData::Empty(definition) => definition.schema.clone(),
+            Self::Data(reader) => reader.schema(),
+            Self::StreamingData(stream) => stream.schema(),
+            Self::Empty(definition) => definition.schema.clone(),
         }
     }
 }
@@ -111,9 +111,9 @@ impl StreamingWriteSource for CreateTableData {
     }
     fn into_stream(self) -> datafusion_physical_plan::SendableRecordBatchStream {
         match self {
-            CreateTableData::Data(reader) => reader.into_stream(),
-            CreateTableData::StreamingData(stream) => stream.into_df_stream(),
-            CreateTableData::Empty(table_definition) => {
+            Self::Data(reader) => reader.into_stream(),
+            Self::StreamingData(stream) => stream.into_df_stream(),
+            Self::Empty(table_definition) => {
                 let schema = table_definition.schema.clone();
                 Box::pin(RecordBatchStreamAdapter::new(schema, stream::empty()))
             }

--- a/rust/lancedb/src/database.rs
+++ b/rust/lancedb/src/database.rs
@@ -18,8 +18,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_array::RecordBatchReader;
+use async_trait::async_trait;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use futures::stream;
 use lance::dataset::ReadParams;
+use lance_datafusion::utils::StreamingWriteSource;
 
+use crate::arrow::{SendableRecordBatchStream, SendableRecordBatchStreamExt};
 use crate::error::Result;
 use crate::table::{BaseTable, TableDefinition, WriteOptions};
 
@@ -81,10 +86,33 @@ impl Default for CreateTableMode {
 
 /// The data to start a table or a schema to create an empty table
 pub enum CreateTableData {
-    /// Creates a table using data, no schema required as it will be obtained from the data
+    /// Creates a table using an iterator of data, the schema will be obtained from the data
     Data(Box<dyn RecordBatchReader + Send>),
+    /// Creates a table using a stream of data, the schema will be obtained from the data
+    StreamingData(SendableRecordBatchStream),
     /// Creates an empty table, the definition / schema must be provided separately
     Empty(TableDefinition),
+}
+
+#[async_trait]
+impl StreamingWriteSource for CreateTableData {
+    fn arrow_schema(&self) -> Arc<arrow_schema::Schema> {
+        match self {
+            CreateTableData::Data(reader) => reader.schema(),
+            CreateTableData::StreamingData(stream) => stream.schema(),
+            CreateTableData::Empty(definition) => definition.schema.clone(),
+        }
+    }
+    fn into_stream(self) -> datafusion_physical_plan::SendableRecordBatchStream {
+        match self {
+            CreateTableData::Data(reader) => reader.into_stream(),
+            CreateTableData::StreamingData(stream) => stream.into_df_stream(),
+            CreateTableData::Empty(table_definition) => {
+                let schema = table_definition.schema.clone();
+                Box::pin(RecordBatchStreamAdapter::new(schema, stream::empty()))
+            }
+        }
+    }
 }
 
 /// A request to create a table

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -166,7 +166,7 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
             CreateTableData::Data(data) => data,
             CreateTableData::StreamingData(_) => {
                 return Err(Error::NotSupported {
-                    message: format!("Creating a remote table from a streaming source"),
+                    message: "Creating a remote table from a streaming source".to_string(),
                 })
             }
             CreateTableData::Empty(table_definition) => {

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -164,6 +164,11 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     async fn create_table(&self, request: CreateTableRequest) -> Result<Arc<dyn BaseTable>> {
         let data = match request.data {
             CreateTableData::Data(data) => data,
+            CreateTableData::StreamingData(_) => {
+                return Err(Error::NotSupported {
+                    message: format!("Creating a remote table from a streaming source"),
+                })
+            }
             CreateTableData::Empty(table_definition) => {
                 let schema = table_definition.schema.clone();
                 Box::new(RecordBatchIterator::new(vec![], schema))


### PR DESCRIPTION
This PR makes it possible to create a table using an asynchronous stream of input data.  Currently only a synchronous iterator is supported.  There are a number of follow-ups not yet tackled:

 * Support for embedding functions (the embedding functions wrapper needs to be re-written to be async, should be an easy lift)
 * Support for async input into the remote table (the make_ipc_batch needs to change to accept async input, leaving undone for now because I think we want to support actual streaming uploads into the remote table soon)
 * Support for async input into the add function (pretty essential, but it is a fairly distinct code path, so saving for a different PR)
