### PR TITLE
feat: respect datafusion's batch size when running as a table provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.21.0-beta.0"
+version = "0.21.0-beta.1"
 dependencies = [
  "arrow",
  "env_logger",


### PR DESCRIPTION
Datafusion makes the batch size available as part of the `SessionState`.  We should use that to set the `max_batch_length` property in the `QueryExecutionOptions`.
