### PR TITLE
fix: delete tables from DDB on drop_all_tables

### DIFF
--- a/nodejs/__test__/s3_integration.test.ts
+++ b/nodejs/__test__/s3_integration.test.ts
@@ -175,6 +175,8 @@ maybeDescribe("storage_options", () => {
 
     tableNames = await db.tableNames();
     expect(tableNames).toEqual([]);
+
+    await db.dropAllTables();
   });
 
   it("can configure encryption at connection and table level", async () => {
@@ -210,6 +212,8 @@ maybeDescribe("storage_options", () => {
     await table.add([{ a: 2, b: 3 }]);
 
     await bucket.assertAllEncrypted("test/table2.lance", kmsKey.keyId);
+
+    await db.dropAllTables();
   });
 });
 
@@ -298,6 +302,8 @@ maybeDescribe("DynamoDB Lock", () => {
 
     const rowCount = await table.countRows();
     expect(rowCount).toBe(6);
+
+    await db.dropAllTables();
   });
 
   it("clears dynamodb state after dropping all tables", async () => {
@@ -311,7 +317,7 @@ maybeDescribe("DynamoDB Lock", () => {
     await db.createTable("bar", [{ a: 1, b: 2 }]);
 
     let tableNames = await db.tableNames();
-    expect(tableNames).toEqual(["foo", "bar"]);
+    expect(tableNames).toEqual(["bar", "foo"]);
 
     await db.dropAllTables();
     tableNames = await db.tableNames();
@@ -323,5 +329,5 @@ maybeDescribe("DynamoDB Lock", () => {
     expect(tableNames).toEqual(["foo"]);
 
     await db.dropAllTables();
-  })
+  });
 });

--- a/python/Makefile
+++ b/python/Makefile
@@ -30,3 +30,7 @@ doctest:	## Run documentation tests.
 .PHONY: test
 test:		## Run tests.
 	pytest python/tests -vv --durations=10 -m "not slow and not s3_test"
+
+.PHONY: clean
+clean:
+	rm -rf data

--- a/python/python/tests/test_s3.py
+++ b/python/python/tests/test_s3.py
@@ -265,7 +265,7 @@ def test_s3_dynamodb_drop_all_tables(s3_bucket: str, commit_table: str, monkeypa
 
     db.create_table("foo", data)
     db.create_table("bar", data)
-    assert db.table_names() == ["foo", "bar"]
+    assert db.table_names() == ["bar", "foo"]
 
     # dropping all tables should clear multiple tables
     db.drop_all_tables()

--- a/python/python/tests/test_s3.py
+++ b/python/python/tests/test_s3.py
@@ -252,3 +252,27 @@ def test_s3_dynamodb_sync(s3_bucket: str, commit_table: str, monkeypatch):
     db.drop_table("test_ddb_sync")
     assert db.table_names() == []
     db.drop_database()
+
+
+@pytest.mark.s3_test
+def test_s3_dynamodb_drop_all_tables(s3_bucket: str, commit_table: str, monkeypatch):
+    for key, value in CONFIG.items():
+        monkeypatch.setenv(key.upper(), value)
+
+    uri = f"s3+ddb://{s3_bucket}/test2?ddbTableName={commit_table}"
+    db = lancedb.connect(uri, read_consistency_interval=timedelta(0))
+    data = pa.table({"x": ["a", "b", "c"]})
+
+    db.create_table("foo", data)
+    db.create_table("bar", data)
+    assert db.table_names() == ["foo", "bar"]
+
+    # dropping all tables should clear multiple tables
+    db.drop_all_tables()
+    assert db.table_names() == []
+
+    # create a new table with the same name to ensure DDB is clean
+    db.create_table("foo", data)
+    assert db.table_names() == ["foo"]
+
+    db.drop_all_tables()

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -336,6 +336,9 @@ impl ListingDatabase {
         for name in names {
             let dir_name = format!("{}.{}", name, LANCE_EXTENSION);
             let full_path = self.base_path.child(dir_name.clone());
+
+            commit_handler.delete(&full_path).await?;
+
             self.object_store
                 .remove_dir_all(full_path.clone())
                 .await
@@ -347,8 +350,6 @@ impl ListingDatabase {
                     },
                     _ => Error::from(err),
                 })?;
-
-            commit_handler.delete(&full_path).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
Prior to this commit, issuing drop_all_tables on a listing database with an external manifest store would delete physical tables but leave references behind in the manifest store. The table drop would succeed, but subsequent creation of a table with the same name would fail with a conflict.

With this patch, the external manifest store is updated to account for the dropped tables so that dropped table names can be reused.