### PR TITLE
fix: make pylance a core dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic>=1.10",
     "packaging",
     "overrides>=0.7",
+    "pylance>=0.23.2",
 ]
 description = "lancedb"
 authors = [{ name = "LanceDB Devs", email = "dev@lancedb.com" }]


### PR DESCRIPTION
Lance is used as a normal dependency in embeddings/utils.py https://github.com/lancedb/lancedb/blob/main/python/python/lancedb/embeddings/utils.py#L19

This is causing some of our CI tests to fail, here I am making it a core dependency. I pinned it to the same version as the tests.