### PR TITLE
fix: restore pylance as mandatory dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic>=1.10",
     "packaging",
     "overrides>=0.7",
+    "pylance>=0.23.2",
 ]
 description = "lancedb"
 authors = [{ name = "LanceDB Devs", email = "dev@lancedb.com" }]
@@ -54,7 +55,6 @@ tests = [
     "polars>=0.19, <=1.3.0",
     "tantivy",
     "pyarrow-stubs",
-    "pylance>=0.23.2",
 ]
 dev = [
     "ruff",


### PR DESCRIPTION
We attempted to make pylance optional in https://github.com/lancedb/lancedb/pull/2156 but it appears this did not quite work.  Users are unable to use lancedb from a fresh install.  This reverts the optional-ness so we can get back in a working state while we fix the issue.