### PR TITLE
feat(node): parse arrow types in `alterColumns()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.18.0-beta.0"
+version = "0.18.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.18.0-beta.0"
+version = "0.18.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.18.0-beta.0"
+version = "0.18.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.21.0-beta.1"
+version = "0.21.1"
 dependencies = [
  "arrow",
  "env_logger",

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -942,6 +942,28 @@ rewriting the column, which can be a heavy operation.
     ```
     **API Reference:** [lancedb.Table.alterColumns](../js/classes/Table.md/#altercolumns)
 
+You can even cast the a vector column to a different dimension:
+
+=== "Python"
+
+    === "Sync API"
+
+        ```python
+        --8<-- "python/python/tests/docs/test_guide_tables.py:import-pyarrow"
+        --8<-- "python/python/tests/docs/test_basic.py:alter_columns_vector"
+        ```
+    === "Async API"
+
+        ```python
+        --8<-- "python/python/tests/docs/test_guide_tables.py:import-pyarrow"
+        --8<-- "python/python/tests/docs/test_basic.py:alter_columns_async_vector"
+        ```
+=== "Typescript"
+
+    ```typescript
+    --8<-- "nodejs/examples/basic.test.ts:alter_columns_vector"
+    ```
+
 ### Dropping columns
 
 You can drop columns from the table with the `drop_columns` method. This will

--- a/docs/src/js/interfaces/ColumnAlteration.md
+++ b/docs/src/js/interfaces/ColumnAlteration.md
@@ -16,7 +16,7 @@ must be provided.
 ### dataType?
 
 ```ts
-optional dataType: string;
+optional dataType: string | DataType<Type, any>;
 ```
 
 A new data type for the column. If not provided then the data type will not be changed.

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -920,6 +920,23 @@ describe("schema evolution", function () {
       new Field("price", new Float64(), true),
     ]);
     expect(await table.schema()).toEqual(expectedSchema2);
+
+    await table.alterColumns([
+      {
+        path: "vector",
+        dataType: new FixedSizeList(2, new Field("item", new Float64(), true)),
+      },
+    ]);
+    const expectedSchema3 = new Schema([
+      new Field("new_id", new Int32(), true),
+      new Field(
+        "vector",
+        new FixedSizeList(2, new Field("item", new Float64(), true)),
+        true,
+      ),
+      new Field("price", new Float64(), true),
+    ]);
+    expect(await table.schema()).toEqual(expectedSchema3);
   });
 
   it("can drop a column from the schema", async function () {

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -24,6 +24,7 @@ import {
   Utf8,
   makeArrowTable,
 } from "../lancedb/arrow";
+import * as arrow from "../lancedb/arrow";
 import {
   EmbeddingFunction,
   LanceSchema,
@@ -937,6 +938,76 @@ describe("schema evolution", function () {
       new Field("price", new Float64(), true),
     ]);
     expect(await table.schema()).toEqual(expectedSchema3);
+  });
+
+  it("can cast to various types", async function () {
+    const con = await connect(tmpDir.name);
+
+    // integers
+    const intTypes = [
+      new arrow.Int8(),
+      new arrow.Int16(),
+      new arrow.Int32(),
+      new arrow.Int64(),
+      new arrow.Uint8(),
+      new arrow.Uint16(),
+      new arrow.Uint32(),
+      new arrow.Uint64(),
+    ];
+    const tableInts = await con.createTable("ints", [{ id: 1n }], {
+      schema: new Schema([new Field("id", new Int64(), true)]),
+    });
+    for (const intType of intTypes) {
+      await tableInts.alterColumns([{ path: "id", dataType: intType }]);
+      const schema = new Schema([new Field("id", intType, true)]);
+      expect(await tableInts.schema()).toEqual(schema);
+    }
+
+    // floats
+    const floatTypes = [
+      new arrow.Float16(),
+      new arrow.Float32(),
+      new arrow.Float64(),
+    ];
+    const tableFloats = await con.createTable("floats", [{ val: 2.1 }], {
+      schema: new Schema([new Field("val", new Float32(), true)]),
+    });
+    for (const floatType of floatTypes) {
+      await tableFloats.alterColumns([{ path: "val", dataType: floatType }]);
+      const schema = new Schema([new Field("val", floatType, true)]);
+      expect(await tableFloats.schema()).toEqual(schema);
+    }
+
+    // Lists of floats
+    const listTypes = [
+      new arrow.List(new arrow.Field("item", new arrow.Float32(), true)),
+      new arrow.FixedSizeList(
+        2,
+        new arrow.Field("item", new arrow.Float64(), true),
+      ),
+      new arrow.FixedSizeList(
+        2,
+        new arrow.Field("item", new arrow.Float16(), true),
+      ),
+      new arrow.FixedSizeList(
+        2,
+        new arrow.Field("item", new arrow.Float32(), true),
+      ),
+    ];
+    const tableLists = await con.createTable("lists", [{ val: [2.1, 3.2] }], {
+      schema: new Schema([
+        new Field(
+          "val",
+          new FixedSizeList(2, new arrow.Field("item", new Float32())),
+          true,
+        ),
+      ]),
+    });
+    for (const listType of listTypes) {
+      await tableLists.alterColumns([{ path: "val", dataType: listType }]);
+      const schema = new Schema([new Field("val", listType, true)]);
+      expect(await tableLists.schema()).toEqual(schema);
+    }
   });
 
   it("can drop a column from the schema", async function () {

--- a/nodejs/examples/basic.test.ts
+++ b/nodejs/examples/basic.test.ts
@@ -132,6 +132,17 @@ test("basic table examples", async () => {
       },
     ]);
     // --8<-- [end:alter_columns]
+    // --8<-- [start:alter_columns_vector]
+    await tbl.alterColumns([
+      {
+        path: "vector",
+        dataType: new arrow.FixedSizeList(
+          2,
+          new arrow.Field("item", new arrow.Float16(), false),
+        ),
+      },
+    ]);
+    // --8<-- [end:alter_columns_vector]
     // --8<-- [start:drop_columns]
     await tbl.dropColumns(["dbl_price"]);
     // --8<-- [end:drop_columns]

--- a/nodejs/lancedb/index.ts
+++ b/nodejs/lancedb/index.ts
@@ -14,7 +14,6 @@ import {
 
 export {
   AddColumnsSql,
-  ColumnAlteration,
   ConnectionOptions,
   IndexStatistics,
   IndexConfig,
@@ -65,6 +64,7 @@ export {
   UpdateOptions,
   OptimizeOptions,
   Version,
+  ColumnAlteration,
 } from "./table";
 
 export { MergeInsertBuilder } from "./merge";

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -4,8 +4,10 @@
 import {
   Table as ArrowTable,
   Data,
+  DataType,
   IntoVector,
   Schema,
+  dataTypeToJson,
   fromDataToBuffer,
   tableFromIPC,
 } from "./arrow";
@@ -15,13 +17,13 @@ import { IndexOptions } from "./indices";
 import { MergeInsertBuilder } from "./merge";
 import {
   AddColumnsSql,
-  ColumnAlteration,
   IndexConfig,
   IndexStatistics,
   OptimizeStats,
   Table as _NativeTable,
 } from "./native";
 import { Query, VectorQuery } from "./query";
+import { sanitizeType } from "./sanitize";
 import { IntoSql, toSQL } from "./util";
 export { IndexConfig } from "./native";
 
@@ -618,7 +620,26 @@ export class LocalTable extends Table {
   }
 
   async alterColumns(columnAlterations: ColumnAlteration[]): Promise<void> {
-    await this.inner.alterColumns(columnAlterations);
+    const processedAlterations = columnAlterations.map((alteration) => {
+      if (typeof alteration.dataType === "string") {
+        return {
+          ...alteration,
+          dataType: JSON.stringify({ type: alteration.dataType }),
+        };
+      } else if (alteration.dataType === undefined) {
+        return {
+          ...alteration,
+          dataType: undefined,
+        };
+      } else {
+        const dataType = sanitizeType(alteration.dataType);
+        return {
+          ...alteration,
+          dataType: dataTypeToJson(dataType),
+        };
+      }
+    });
+    await this.inner.alterColumns(processedAlterations);
   }
 
   async dropColumns(columnNames: string[]): Promise<void> {
@@ -710,4 +731,39 @@ export class LocalTable extends Table {
   async migrateManifestPathsV2(): Promise<void> {
     await this.inner.migrateManifestPathsV2();
   }
+}
+
+/**
+ *  A definition of a column alteration. The alteration changes the column at
+ * `path` to have the new name `name`, to be nullable if `nullable` is true,
+ * and to have the data type `data_type`. At least one of `rename` or `nullable`
+ * must be provided.
+ */
+export interface ColumnAlteration {
+  /**
+   * The path to the column to alter. This is a dot-separated path to the column.
+   * If it is a top-level column then it is just the name of the column. If it is
+   * a nested column then it is the path to the column, e.g. "a.b.c" for a column
+   * `c` nested inside a column `b` nested inside a column `a`.
+   */
+  path: string;
+  /**
+   * The new name of the column. If not provided then the name will not be changed.
+   * This must be distinct from the names of all other columns in the table.
+   */
+  rename?: string;
+  /**
+   * A new data type for the column. If not provided then the data type will not be changed.
+   * Changing data types is limited to casting to the same general type. For example, these
+   * changes are valid:
+   * * `int32` -> `int64` (integers)
+   * * `double` -> `float` (floats)
+   * * `string` -> `large_string` (strings)
+   * But these changes are not:
+   * * `int32` -> `double` (mix integers and floats)
+   * * `string` -> `int32` (mix strings and integers)
+   */
+  dataType?: string | DataType;
+  /** Set the new nullability. Note that a nullable column cannot be made non-nullable. */
+  nullable?: boolean;
 }

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -635,10 +635,11 @@ export class LocalTable extends Table {
         const dataType = sanitizeType(alteration.dataType);
         return {
           ...alteration,
-          dataType: dataTypeToJson(dataType),
+          dataType: JSON.stringify(dataTypeToJson(dataType)),
         };
       }
     });
+
     await this.inner.alterColumns(processedAlterations);
   }
 

--- a/python/python/tests/docs/test_basic.py
+++ b/python/python/tests/docs/test_basic.py
@@ -83,6 +83,14 @@ def test_quickstart(tmp_path):
         }
     )
     # --8<-- [end:alter_columns]
+    # --8<-- [start:alter_columns_vector]
+    tbl.alter_columns(
+        {
+            "path": "vector",
+            "data_type": pa.list_(pa.float16(), list_size=2),
+        }
+    )
+    # --8<-- [end:alter_columns_vector]
     # --8<-- [start:drop_columns]
     tbl.drop_columns(["dbl_price"])
     # --8<-- [end:drop_columns]
@@ -162,6 +170,14 @@ async def test_quickstart_async(tmp_path):
         }
     )
     # --8<-- [end:alter_columns_async]
+    # --8<-- [start:alter_columns_async_vector]
+    await tbl.alter_columns(
+        {
+            "path": "vector",
+            "data_type": pa.list_(pa.float16(), list_size=2),
+        }
+    )
+    # --8<-- [end:alter_columns_async_vector]
     # --8<-- [start:drop_columns_async]
     await tbl.drop_columns(["dbl_price"])
     # --8<-- [end:drop_columns_async]

--- a/python/python/tests/docs/test_basic.py
+++ b/python/python/tests/docs/test_basic.py
@@ -91,6 +91,13 @@ def test_quickstart(tmp_path):
         }
     )
     # --8<-- [end:alter_columns_vector]
+    # Change it back since we can get a panic with fp16
+    tbl.alter_columns(
+        {
+            "path": "vector",
+            "data_type": pa.list_(pa.float32(), list_size=2),
+        }
+    )
     # --8<-- [start:drop_columns]
     tbl.drop_columns(["dbl_price"])
     # --8<-- [end:drop_columns]
@@ -178,6 +185,13 @@ async def test_quickstart_async(tmp_path):
         }
     )
     # --8<-- [end:alter_columns_async_vector]
+    # Change it back since we can get a panic with fp16
+    await tbl.alter_columns(
+        {
+            "path": "vector",
+            "data_type": pa.list_(pa.float32(), list_size=2),
+        }
+    )
     # --8<-- [start:drop_columns_async]
     await tbl.drop_columns(["dbl_price"])
     # --8<-- [end:drop_columns_async]

--- a/rust/lancedb/src/utils.rs
+++ b/rust/lancedb/src/utils.rs
@@ -166,13 +166,16 @@ pub fn supported_vector_data_type(dtype: &DataType) -> bool {
 
 /// Note: this is temporary until we get a proper datatype conversion in Lance.
 pub fn string_to_datatype(s: &str) -> Option<DataType> {
-    let mut data_type = serde_json::Value::String(s.to_string());
-    dbg!(&data_type);
+    let mut data_type: serde_json::Value = {
+        if let Ok(data_type) = serde_json::from_str(s) {
+            data_type
+        } else {
+            serde_json::Value::String(s.to_string())
+        }
+    };
     if data_type.get("type").is_none() {
         data_type = serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
     }
-    // let json_type =
-    //     serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
     let json_type: JsonDataType = serde_json::from_value(data_type).ok()?;
     (&json_type).try_into().ok()
 }

--- a/rust/lancedb/src/utils.rs
+++ b/rust/lancedb/src/utils.rs
@@ -166,10 +166,14 @@ pub fn supported_vector_data_type(dtype: &DataType) -> bool {
 
 /// Note: this is temporary until we get a proper datatype conversion in Lance.
 pub fn string_to_datatype(s: &str) -> Option<DataType> {
-    let data_type = serde_json::Value::String(s.to_string());
-    let json_type =
-        serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
-    let json_type: JsonDataType = serde_json::from_value(json_type).ok()?;
+    let mut data_type = serde_json::Value::String(s.to_string());
+    dbg!(&data_type);
+    if data_type.get("type").is_none() {
+        data_type = serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
+    }
+    // let json_type =
+    //     serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
+    let json_type: JsonDataType = serde_json::from_value(data_type).ok()?;
     (&json_type).try_into().ok()
 }
 

--- a/rust/lancedb/src/utils.rs
+++ b/rust/lancedb/src/utils.rs
@@ -174,7 +174,8 @@ pub fn string_to_datatype(s: &str) -> Option<DataType> {
         }
     };
     if data_type.get("type").is_none() {
-        data_type = serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
+        data_type =
+            serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
     }
     let json_type: JsonDataType = serde_json::from_value(data_type).ok()?;
     (&json_type).try_into().ok()

--- a/rust/lancedb/src/utils.rs
+++ b/rust/lancedb/src/utils.rs
@@ -166,17 +166,13 @@ pub fn supported_vector_data_type(dtype: &DataType) -> bool {
 
 /// Note: this is temporary until we get a proper datatype conversion in Lance.
 pub fn string_to_datatype(s: &str) -> Option<DataType> {
-    let mut data_type: serde_json::Value = {
+    let data_type: serde_json::Value = {
         if let Ok(data_type) = serde_json::from_str(s) {
             data_type
         } else {
-            serde_json::Value::String(s.to_string())
+            serde_json::json!({ "type": s })
         }
     };
-    if data_type.get("type").is_none() {
-        data_type =
-            serde_json::Value::Object([("type".to_string(), data_type)].iter().cloned().collect());
-    }
     let json_type: JsonDataType = serde_json::from_value(data_type).ok()?;
     (&json_type).try_into().ok()
 }


### PR DESCRIPTION
Previously, users could only specify new data types in `alterColumns` as strings:

```ts
await tbl.alterColumns([
  path: "price",
  dataType: "float"
]);
```

But this has some problems:

1. It wasn't clear what were valid types
2. It was impossible to specify nested types, like lists and vector columns.

This PR changes it to take an Arrow data type, similar to how the Python API works. This allows casting vector types:

```ts
await tbl.alterColumns([
  {
    path: "vector",
    dataType: new arrow.FixedSizeList(
      2,
      new arrow.Field("item", new arrow.Float16(), false),
    ),
  },
]);
```

Closes #2185