### PR TITLE
refactor: rework catalog/database options

### DIFF
--- a/rust/lancedb/src/catalog/listing.rs
+++ b/rust/lancedb/src/catalog/listing.rs
@@ -52,6 +52,7 @@ impl ListingCatalogOptions {
     }
 }
 
+#[derive(Clone, Debug, Default)]
 pub struct ListingCatalogOptionsBuilder {
     options: ListingCatalogOptions,
 }

--- a/rust/lancedb/src/catalog/listing.rs
+++ b/rust/lancedb/src/catalog/listing.rs
@@ -9,17 +9,69 @@ use std::path::Path;
 use std::sync::Arc;
 
 use super::{
-    Catalog, CreateDatabaseMode, CreateDatabaseRequest, DatabaseNamesRequest, OpenDatabaseRequest,
+    Catalog, CatalogOptions, CreateDatabaseMode, CreateDatabaseRequest, DatabaseNamesRequest,
+    OpenDatabaseRequest,
 };
 use crate::connection::ConnectRequest;
-use crate::database::listing::ListingDatabase;
-use crate::database::Database;
+use crate::database::listing::{ListingDatabase, ListingDatabaseOptions};
+use crate::database::{Database, DatabaseOptions};
 use crate::error::{CreateDirSnafu, Error, Result};
 use async_trait::async_trait;
 use lance::io::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
 use lance_io::local::to_local_path;
 use object_store::path::Path as ObjectStorePath;
 use snafu::ResultExt;
+
+/// Options for the listing catalog
+///
+/// Note: the catalog will use the `storage_options` configured on
+/// db_options to configure storage for listing / creating / deleting
+/// databases.
+#[derive(Clone, Debug, Default)]
+pub struct ListingCatalogOptions {
+    /// The options to use for databases opened by this catalog
+    ///
+    /// This also contains the storage options used by the catalog
+    pub db_options: ListingDatabaseOptions,
+}
+
+impl CatalogOptions for ListingCatalogOptions {
+    fn serialize_into_map(&self, map: &mut HashMap<String, String>) {
+        self.db_options.serialize_into_map(map);
+    }
+}
+
+impl ListingCatalogOptions {
+    pub fn builder() -> ListingCatalogOptionsBuilder {
+        ListingCatalogOptionsBuilder::new()
+    }
+
+    pub(crate) fn parse_from_map(map: &HashMap<String, String>) -> Result<Self> {
+        let db_options = ListingDatabaseOptions::parse_from_map(map)?;
+        Ok(Self { db_options })
+    }
+}
+
+pub struct ListingCatalogOptionsBuilder {
+    options: ListingCatalogOptions,
+}
+
+impl ListingCatalogOptionsBuilder {
+    pub fn new() -> Self {
+        Self {
+            options: ListingCatalogOptions::default(),
+        }
+    }
+
+    pub fn db_options(mut self, db_options: ListingDatabaseOptions) -> Self {
+        self.options.db_options = db_options;
+        self
+    }
+
+    pub fn build(self) -> ListingCatalogOptions {
+        self.options
+    }
+}
 
 /// A catalog implementation that works by listing subfolders in a directory
 ///
@@ -34,7 +86,7 @@ pub struct ListingCatalog {
 
     base_path: ObjectStorePath,
 
-    storage_options: HashMap<String, String>,
+    options: ListingCatalogOptions,
 }
 
 impl ListingCatalog {
@@ -61,7 +113,7 @@ impl ListingCatalog {
             uri: path.to_string(),
             base_path,
             object_store,
-            storage_options: HashMap::new(),
+            options: ListingCatalogOptions::default(),
         })
     }
 
@@ -69,13 +121,15 @@ impl ListingCatalog {
         let uri = &request.uri;
         let parse_res = url::Url::parse(uri);
 
+        let options = ListingCatalogOptions::parse_from_map(&request.options)?;
+
         match parse_res {
             Ok(url) if url.scheme().len() == 1 && cfg!(windows) => Self::open_path(uri).await,
             Ok(url) => {
                 let plain_uri = url.to_string();
 
                 let registry = Arc::new(ObjectStoreRegistry::default());
-                let storage_options = request.storage_options.clone();
+                let storage_options = options.db_options.storage_options.clone();
                 let os_params = ObjectStoreParams {
                     storage_options: Some(storage_options.clone()),
                     ..Default::default()
@@ -90,7 +144,7 @@ impl ListingCatalog {
                     uri: String::from(url.clone()),
                     base_path,
                     object_store,
-                    storage_options,
+                    options,
                 })
             }
             Err(_) => Self::open_path(uri).await,
@@ -155,16 +209,18 @@ impl Catalog for ListingCatalog {
 
         let db_uri = format!("/{}/{}", self.base_path, request.name);
 
-        let connect_request = ConnectRequest {
+        let mut connect_request = ConnectRequest {
             uri: db_uri,
-            api_key: None,
-            region: None,
-            host_override: None,
             #[cfg(feature = "remote")]
             client_config: Default::default(),
             read_consistency_interval: None,
-            storage_options: self.storage_options.clone(),
+            options: Default::default(),
         };
+
+        // Add the db options to the connect request
+        self.options
+            .db_options
+            .serialize_into_map(&mut connect_request.options);
 
         Ok(Arc::new(
             ListingDatabase::connect_with_options(&connect_request).await?,
@@ -180,16 +236,18 @@ impl Catalog for ListingCatalog {
             return Err(Error::DatabaseNotFound { name: request.name });
         }
 
-        let connect_request = ConnectRequest {
+        let mut connect_request = ConnectRequest {
             uri: db_path.to_string(),
-            api_key: None,
-            region: None,
-            host_override: None,
             #[cfg(feature = "remote")]
             client_config: Default::default(),
             read_consistency_interval: None,
-            storage_options: self.storage_options.clone(),
+            options: Default::default(),
         };
+
+        // Add the db options to the connect request
+        self.options
+            .db_options
+            .serialize_into_map(&mut connect_request.options);
 
         Ok(Arc::new(
             ListingDatabase::connect_with_options(&connect_request).await?,
@@ -249,12 +307,9 @@ mod tests {
 
         let request = ConnectRequest {
             uri: uri.clone(),
-            api_key: None,
-            region: None,
-            host_override: None,
             #[cfg(feature = "remote")]
             client_config: Default::default(),
-            storage_options: HashMap::new(),
+            options: Default::default(),
             read_consistency_interval: None,
         };
 
@@ -513,12 +568,9 @@ mod tests {
 
         let request = ConnectRequest {
             uri: path.to_string(),
-            api_key: None,
-            region: None,
-            host_override: None,
             #[cfg(feature = "remote")]
             client_config: Default::default(),
-            storage_options: HashMap::new(),
+            options: Default::default(),
             read_consistency_interval: None,
         };
 
@@ -535,12 +587,9 @@ mod tests {
 
         let request = ConnectRequest {
             uri: uri.clone(),
-            api_key: None,
-            region: None,
-            host_override: None,
             #[cfg(feature = "remote")]
             client_config: Default::default(),
-            storage_options: HashMap::new(),
+            options: Default::default(),
             read_consistency_interval: None,
         };
 
@@ -554,12 +603,9 @@ mod tests {
         let invalid_uri = "invalid:///path";
         let request = ConnectRequest {
             uri: invalid_uri.to_string(),
-            api_key: None,
-            region: None,
-            host_override: None,
             #[cfg(feature = "remote")]
             client_config: Default::default(),
-            storage_options: HashMap::new(),
+            options: Default::default(),
             read_consistency_interval: None,
         };
 

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -117,6 +117,7 @@ impl DatabaseOptions for ListingDatabaseOptions {
     }
 }
 
+#[derive(Clone, Debug, Default)]
 pub struct ListingDatabaseOptionsBuilder {
     options: ListingDatabaseOptions,
 }

--- a/rust/lancedb/src/remote.rs
+++ b/rust/lancedb/src/remote.rs
@@ -18,3 +18,4 @@ const ARROW_FILE_CONTENT_TYPE: &str = "application/vnd.apache.arrow.file";
 const JSON_CONTENT_TYPE: &str = "application/json";
 
 pub use client::{ClientConfig, RetryConfig, TimeoutConfig};
+pub use db::{RemoteDatabaseOptions, RemoteDatabaseOptionsBuilder};

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -86,9 +86,9 @@ impl RemoteDatabaseOptions {
     }
 
     pub(crate) fn parse_from_map(map: &HashMap<String, String>) -> Result<Self> {
-        let api_key = map.get(OPT_REMOTE_API_KEY).map(|v| v.clone());
-        let region = map.get(OPT_REMOTE_REGION).map(|v| v.clone());
-        let host_override = map.get(OPT_REMOTE_HOST_OVERRIDE).map(|v| v.clone());
+        let api_key = map.get(OPT_REMOTE_API_KEY).cloned();
+        let region = map.get(OPT_REMOTE_REGION).cloned();
+        let host_override = map.get(OPT_REMOTE_HOST_OVERRIDE).cloned();
         let storage_options = map
             .iter()
             .filter(|(key, _)| !key.starts_with(OPT_REMOTE_PREFIX))
@@ -120,6 +120,7 @@ impl DatabaseOptions for RemoteDatabaseOptions {
     }
 }
 
+#[derive(Clone, Debug, Default)]
 pub struct RemoteDatabaseOptionsBuilder {
     options: RemoteDatabaseOptions,
 }


### PR DESCRIPTION
The `ConnectRequest` has a set of properties that only make sense for listing databases / catalogs and a set of properties that only make sense for remote databases.

This PR reduces all options to a single `HashMap<String, String>`.  This makes it easier to add new database / catalog implementations and makes it clearer to users which options are applicable in which situations.

I don't believe there are any breaking changes here.  The closest thing is that I placed the `ConnectBuilder` methods `api_key`, `region`, and `host_override` behind a `remote` feature gate.  This is not strictly needed and I could remove the feature gate but it seemed appropriate.  Since using these methods without the remote feature would have been meaningless I don't feel this counts as a breaking change.

We could look at removing these methods entirely from the `ConnectBuilder` (and encouraging users to use `RemoteDatabaseOptions` instead) but I'm not sure how I feel about that.

Another approach we could take is to move these methods into a `RemoteConnectBuilderExt` trait (and there could be a similar `ListingConnectBuilderExt` trait to add methods for the listing database / catalog).

For now though my main goal is to simplify `ConnectRequest` as much as possible (I see this being part of the key public API for database / catalog integrations, similar to the `BaseTable`, `Catalog`, and `Database` traits and I'd like it to be simple).