### PR TITLE
fix: make `DatasetConsistencyWrapper` public so that we can implement `BaseTable`

### DIFF
--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -71,7 +71,7 @@ use crate::utils::{
     PatchReadParam, PatchWriteParam,
 };
 
-use self::dataset::DatasetConsistencyWrapper;
+pub use self::dataset::DatasetConsistencyWrapper;
 use self::merge::MergeInsertBuilder;
 
 pub mod datafusion;


### PR DESCRIPTION
tried locally we can import `DatasetConsistencyWrapper` with this