### PR TITLE
docs: add cloud & enterprise cta

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -233,13 +233,6 @@ nav:
           - 👾 JavaScript (vectordb): javascript/modules.md
           - 👾 JavaScript (lancedb): js/globals.md
           - 🦀 Rust: https://docs.rs/lancedb/latest/lancedb/
-      - ☁️ LanceDB Cloud:
-          - Overview: cloud/index.md
-          - API reference:
-              - 🐍 Python: python/saas-python.md
-              - 👾 JavaScript: javascript/modules.md
-              - REST API: cloud/rest.md
-          - FAQs: cloud/cloud_faq.md
 
   - Quick start: basic.md
   - Concepts:
@@ -363,13 +356,6 @@ nav:
       - Javascript (vectordb): javascript/modules.md
       - Javascript (lancedb): js/globals.md
       - Rust: https://docs.rs/lancedb/latest/lancedb/index.html
-  - LanceDB Cloud:
-      - Overview: cloud/index.md
-      - API reference:
-          - 🐍 Python: python/saas-python.md
-          - 👾 JavaScript: javascript/modules.md
-          - REST API: cloud/rest.md
-      - FAQs: cloud/cloud_faq.md
 
 extra_css:
   - styles/global.css

--- a/docs/src/examples/index.md
+++ b/docs/src/examples/index.md
@@ -9,7 +9,7 @@ LanceDB provides language APIs, allowing you to embed a database in your languag
 * 🦀 Rust examples (coming soon)
 
 !!! tip "LanceDB Cloud & Enterprise"
-    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise]().
+    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
 
 ## ☁️ LanceDB Cloud Exmaples 🔗
 * 🐍 [Python](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/python_notebook) examples

--- a/docs/src/examples/index.md
+++ b/docs/src/examples/index.md
@@ -9,4 +9,4 @@ LanceDB provides language APIs, allowing you to embed a database in your languag
 * 🦀 Rust examples (coming soon)
 
 !!! tip "Hosted LanceDB"
-    If you want S3 cost-efficiency and local performance via a simple serverless API, checkout LanceDB Cloud. For private deployments, high performance at extreme scale, or you have strict security requirements, talk to us about LanceDB Enterprise. [Learn more](https://docs.lancedb.com/)
+    If you want S3 cost-efficiency and local performance via a simple serverless API, checkout **LanceDB Cloud**. For private deployments, high performance at extreme scale, or if you have strict security requirements, talk to us about **LanceDB Enterprise**. [Learn more](https://docs.lancedb.com/)

--- a/docs/src/examples/index.md
+++ b/docs/src/examples/index.md
@@ -8,15 +8,10 @@ LanceDB provides language APIs, allowing you to embed a database in your languag
 * 👾 [JavaScript](examples_js.md) examples
 * 🦀 Rust examples (coming soon)
 
-## Python Applications powered by LanceDB
+!!! tip "LanceDB Cloud & Enterprise"
+    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise]().
 
-| Project Name | Description |
-| --- | --- |
-| **Ultralytics Explorer 🚀**<br>[![Ultralytics](https://img.shields.io/badge/Ultralytics-Docs-green?labelColor=0f3bc4&style=flat-square&logo=https://cdn.prod.website-files.com/646dd1f1a3703e451ba81ecc/64994922cf2a6385a4bf4489_UltralyticsYOLO_mark_blue.svg&link=https://docs.ultralytics.com/datasets/explorer/)](https://docs.ultralytics.com/datasets/explorer/)<br>[![Open In Collab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/docs/en/datasets/explorer/explorer.ipynb) |  - 🔍 **Explore CV Datasets**: Semantic search, SQL queries, vector similarity, natural language.<br>- 🖥️ **GUI & Python API**: Seamless dataset interaction.<br>- ⚡ **Efficient & Scalable**: Leverages LanceDB for large datasets.<br>- 📊 **Detailed Analysis**: Easily analyze data patterns.<br>- 🌐 **Browser GUI Demo**: Create embeddings, search images, run queries. |
-| **Website Chatbot🤖**<br>[![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/lancedb/lancedb-vercel-chatbot)<br>[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flancedb%2Flancedb-vercel-chatbot&amp;env=OPENAI_API_KEY&amp;envDescription=OpenAI%20API%20Key%20for%20chat%20completion.&amp;project-name=lancedb-vercel-chatbot&amp;repository-name=lancedb-vercel-chatbot&amp;demo-title=LanceDB%20Chatbot%20Demo&amp;demo-description=Demo%20website%20chatbot%20with%20LanceDB.&amp;demo-url=https%3A%2F%2Flancedb.vercel.app&amp;demo-image=https%3A%2F%2Fi.imgur.com%2FazVJtvr.png) | - 🌐 **Chatbot from Sitemap/Docs**: Create a chatbot using site or document context.<br>- 🚀 **Embed LanceDB in Next.js**: Lightweight, on-prem storage.<br>- 🧠 **AI-Powered Context Retrieval**: Efficiently access relevant data.<br>- 🔧 **Serverless & Native JS**: Seamless integration with Next.js.<br>- ⚡ **One-Click Deploy on Vercel**: Quick and easy setup.. |
-
-## Nodejs Applications powered by LanceDB
-
-| Project Name | Description |
-| --- | --- |
-| **Langchain Writing Assistant✍️ **<br>[![Github](../assets/github.svg)](https://github.com/lancedb/vectordb-recipes/tree/main/applications/node/lanchain_writing_assistant) |  - **📂 Data Source Integration**:  Use your own data by specifying data source file, and the app instantly processes it to provide insights. <br>- **🧠 Intelligent Suggestions**:  Powered by LangChain.js and LanceDB, it improves writing productivity and accuracy.  <br>- **💡 Enhanced Writing Experience**: It delivers real-time contextual insights and factual suggestions while the user writes. |
+## ☁️ LanceDB Cloud Exmaples 🔗
+* 🐍 [Python](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/python_notebook) examples
+* 👾 [JavaScript](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/ts_example) examples
+* 🛜 [Rest API](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/rest_api_example) examples

--- a/docs/src/examples/index.md
+++ b/docs/src/examples/index.md
@@ -9,7 +9,7 @@ LanceDB provides language APIs, allowing you to embed a database in your languag
 * 🦀 Rust examples (coming soon)
 
 !!! tip "LanceDB Cloud & Enterprise"
-    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
+    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like flexible deployment, high performance at extreme scale & security compliance, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
 
 ## ☁️ LanceDB Cloud Exmaples 🔗
 * 🐍 [Python](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/python_notebook) examples

--- a/docs/src/examples/index.md
+++ b/docs/src/examples/index.md
@@ -8,10 +8,5 @@ LanceDB provides language APIs, allowing you to embed a database in your languag
 * 👾 [JavaScript](examples_js.md) examples
 * 🦀 Rust examples (coming soon)
 
-!!! tip "LanceDB Cloud & Enterprise"
-    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like flexible deployment, high performance at extreme scale & security compliance, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
-
-## ☁️ LanceDB Cloud Exmaples 🔗
-* 🐍 [Python](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/python_notebook) examples
-* 👾 [JavaScript](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/ts_example) examples
-* 🛜 [Rest API](https://github.com/lancedb/vectordb-recipes/tree/main/examples/saas_examples/rest_api_example) examples
+!!! tip "Hosted LanceDB"
+    If you want S3 cost-efficiency and local performance via a simple serverless API, checkout LanceDB Cloud. For private deployments, high performance at extreme scale, or you have strict security requirements, talk to us about LanceDB Enterprise. [Learn more](https://docs.lancedb.com/)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ LanceDB is an open-source vector database for AI that's designed to store, manag
 Both the database and the underlying data format are designed from the ground up to be **easy-to-use**, **scalable** and **cost-effective**.
 
 !!! tip "Hosted LanceDB"
-    If you want S3 cost-efficiency and local performance via a simple serverless API, checkout LanceDB Cloud. For private deployments, high performance at extreme scale, or you have strict security requirements, talk to us about LanceDB Enterprise. [Learn more](https://docs.lancedb.com/)
+    If you want S3 cost-efficiency and local performance via a simple serverless API, checkout **LanceDB Cloud**. For private deployments, high performance at extreme scale, or if you have strict security requirements, talk to us about **LanceDB Enterprise**. [Learn more](https://docs.lancedb.com/)
 
 ![](assets/lancedb_and_lance.png)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,8 +4,8 @@ LanceDB is an open-source vector database for AI that's designed to store, manag
 
 Both the database and the underlying data format are designed from the ground up to be **easy-to-use**, **scalable** and **cost-effective**.
 
-!!! tip "LanceDB Cloud & Enterprise"
-    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like felxible deployment, high performance at extreme scale & security compliance, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
+!!! tip "Hosted LanceDB"
+    If you want S3 cost-efficiency and local performance via a simple serverless API, checkout LanceDB Cloud. For private deployments, high performance at extreme scale, or you have strict security requirements, talk to us about LanceDB Enterprise. [Learn more](https://docs.lancedb.com/)
 
 ![](assets/lancedb_and_lance.png)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,8 +5,7 @@ LanceDB is an open-source vector database for AI that's designed to store, manag
 Both the database and the underlying data format are designed from the ground up to be **easy-to-use**, **scalable** and **cost-effective**.
 
 !!! tip "LanceDB Cloud & Enterprise"
-    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise]().  
-
+    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
 
 ![](assets/lancedb_and_lance.png)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ LanceDB is an open-source vector database for AI that's designed to store, manag
 Both the database and the underlying data format are designed from the ground up to be **easy-to-use**, **scalable** and **cost-effective**.
 
 !!! tip "LanceDB Cloud & Enterprise"
-    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
+    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](https://lancedb.github.io/lancedb/cloud/). If you're looking for custom solutions like felxible deployment, high performance at extreme scale & security compliance, you can check out [LanceDB enterprise](https://docs.lancedb.com/enterprise/introduction).
 
 ![](assets/lancedb_and_lance.png)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,6 +4,10 @@ LanceDB is an open-source vector database for AI that's designed to store, manag
 
 Both the database and the underlying data format are designed from the ground up to be **easy-to-use**, **scalable** and **cost-effective**.
 
+!!! tip "LanceDB Cloud & Enterprise"
+    If your worflow requires hosted LanceDB, checkout [LanceDB Cloud](). If you're looking for custom solutions like private deployment, high performance at extreme scale, you can check out [LanceDB enterprise]().  
+
+
 ![](assets/lancedb_and_lance.png)
 
 ## Truly multi-modal


### PR DESCRIPTION
2/2 docs update this week
- Add cloud & enterprise CTA
- remove outdated projects/examples from landing page