### PR TITLE
fix: correct rust install docs

### DIFF
--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -20,7 +20,7 @@
 //! LanceDB runs in process, to use it in your Rust project, put the following in your `Cargo.toml`:
 //!
 //! ```shell
-//! cargo install lancedb
+//! cargo add lancedb
 //! ```
 //!
 //! ## Crate Features


### PR DESCRIPTION
I'm pretty sure you mean `cargo add lancedb` here, `cargo install lancedb` fails right now.