### PR TITLE
docs: replace Lancedb Cloud link

### DIFF
--- a/docs/src/cloud/index.md
+++ b/docs/src/cloud/index.md
@@ -2,7 +2,7 @@
 
 LanceDB Cloud is a SaaS (software-as-a-service) solution that runs serverless in the cloud, clearly separating storage from compute. It's designed to be highly scalable without breaking the bank. LanceDB Cloud is currently in private beta with general availability coming soon, but you can apply for early access with the private beta release by signing up below.
 
-[Try out LanceDB Cloud](https://noteforms.com/forms/lancedb-mailing-list-cloud-kty1o5?notionforms=1&utm_source=notionforms){ .md-button .md-button--primary }
+[Try out LanceDB Cloud (Public Beta)](https://cloud.lancedb.com){ .md-button .md-button--primary }
 
 ## Architecture
 

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -942,28 +942,6 @@ rewriting the column, which can be a heavy operation.
     ```
     **API Reference:** [lancedb.Table.alterColumns](../js/classes/Table.md/#altercolumns)
 
-You can even cast the a vector column to a different dimension:
-
-=== "Python"
-
-    === "Sync API"
-
-        ```python
-        --8<-- "python/python/tests/docs/test_guide_tables.py:import-pyarrow"
-        --8<-- "python/python/tests/docs/test_basic.py:alter_columns_vector"
-        ```
-    === "Async API"
-
-        ```python
-        --8<-- "python/python/tests/docs/test_guide_tables.py:import-pyarrow"
-        --8<-- "python/python/tests/docs/test_basic.py:alter_columns_async_vector"
-        ```
-=== "Typescript"
-
-    ```typescript
-    --8<-- "nodejs/examples/basic.test.ts:alter_columns_vector"
-    ```
-
 ### Dropping columns
 
 You can drop columns from the table with the `drop_columns` method. This will

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ LanceDB **OSS** is an **open-source**, batteries-included embedded vector databa
 
 LanceDB **Cloud** is a SaaS (software-as-a-service) solution that runs serverless in the cloud, making the storage clearly separated from compute. It's designed to be cost-effective and highly scalable without breaking the bank. LanceDB Cloud is currently in private beta with general availability coming soon, but you can apply for early access with the private beta release by signing up below.
 
-[Try out LanceDB Cloud](https://noteforms.com/forms/lancedb-mailing-list-cloud-kty1o5?notionforms=1&utm_source=notionforms){ .md-button .md-button--primary }
+[Try out LanceDB Cloud (Public Beta) Now](https://cloud.lancedb.com){ .md-button .md-button--primary }
 
 ## Why use LanceDB?
 


### PR DESCRIPTION
* direct users to cloud.lancedb.com since LanceDB Cloud is in public beta
* removed the `cast vector dimension` from alter columns as we don't support it