### PR TITLE
fix: allow re-creating tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,8 +2672,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "rand",
 ]
@@ -3648,8 +3648,8 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3708,8 +3708,8 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3726,8 +3726,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3763,8 +3763,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3790,8 +3790,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3829,8 +3829,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3864,8 +3864,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3917,8 +3917,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3956,8 +3956,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -3980,8 +3980,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4020,8 +4020,8 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "0.25.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.25.0-beta.5#f02095ddb4a57f15769e028919f343e38866d155"
+version = "0.25.1"
+source = "git+https://github.com/wjones127/lance.git?branch=manifest-etag#340c1a842535fa08564d763bca2fc4b287f9eecd"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.18.1"
+version = "0.18.2-beta.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.18.1"
+version = "0.18.2-beta.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.18.1"
+version = "0.18.2-beta.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.21.1"
+version = "0.21.2-beta.0"
 dependencies = [
  "arrow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,26 @@ categories = ["database-implementations"]
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-lance = { "version" = "=0.25.0", "features" = [
+lance = { "version" = "=0.25.1", "features" = [
     "dynamodb",
-], tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
-lance-io = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
-lance-index = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
-lance-linalg = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
-lance-table = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
-lance-testing = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
-lance-datafusion = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
-lance-encoding = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+], branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+lance-io = { version = "=0.25.1", branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+lance-index = { version = "=0.25.1", branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+lance-linalg = { version = "=0.25.1", branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+lance-table = { version = "=0.25.1", branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+lance-testing = { version = "=0.25.1", branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+lance-datafusion = { version = "=0.25.1", branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+lance-encoding = { version = "=0.25.1", branch = "manifest-etag", git = "https://github.com/wjones127/lance.git" }
+# lance = { "version" = "=0.25.0", "features" = [
+#     "dynamodb",
+# ], tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+# lance-io = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+# lance-index = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+# lance-linalg = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+# lance-table = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+# lance-testing = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+# lance-datafusion = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
+# lance-encoding = { version = "=0.25.0", tag = "v0.25.0-beta.5", git = "https://github.com/lancedb/lance.git" }
 # Note that this one does not include pyarrow
 arrow = { version = "54.1", optional = false }
 arrow-array = "54.1"

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -227,6 +227,7 @@ impl Default for OptimizeAction {
 }
 
 /// Statistics about the optimization.
+#[derive(Debug, Clone)]
 pub struct OptimizeStats {
     /// Stats of the file compaction.
     pub compaction: Option<CompactionMetrics>,

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -227,7 +227,6 @@ impl Default for OptimizeAction {
 }
 
 /// Statistics about the optimization.
-#[derive(Debug, Clone)]
 pub struct OptimizeStats {
     /// Stats of the file compaction.
     pub compaction: Option<CompactionMetrics>,

--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -2,10 +2,12 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use std::{
-    future::Future, ops::{Deref, DerefMut}, sync::Arc, time::{self, Duration, Instant}
+    future::Future,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+    time::{self, Duration, Instant},
 };
 
-use futures::FutureExt;
 use lance::Dataset;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -22,16 +24,13 @@ pub struct DatasetConsistencyWrapper(Arc<RwLock<DatasetRef>>);
 ///
 /// The dataset is lazily loaded, and starts off as None. On the first access,
 /// the dataset is loaded.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum DatasetRef {
     /// In this mode, the dataset is always the latest version.
     Latest {
         dataset: Dataset,
         read_consistency_interval: Option<Duration>,
         last_consistency_check: Option<time::Instant>,
-        /// A background task loading the next version of the dataset. This happens
-        /// in the background so as not to block the current thread.
-        refresh_task: Option<tokio::task::JoinHandle<Result<Dataset>>>,
     },
     /// In this mode, the dataset is a specific version. It cannot be mutated.
     TimeTravel { dataset: Dataset, version: u64 },
@@ -44,18 +43,9 @@ impl DatasetRef {
             Self::Latest {
                 dataset,
                 last_consistency_check,
-                refresh_task,
                 ..
             } => {
-                // Replace the refresh task
-                if let Some(refresh_task) = refresh_task {
-                    refresh_task.abort();
-                }
-                let mut new_dataset = dataset.clone();
-                refresh_task.replace(tokio::spawn(async move {
-                    new_dataset.checkout_latest().await?;
-                    Ok(new_dataset)
-                }));
+                dataset.checkout_latest().await?;
                 last_consistency_check.replace(Instant::now());
             }
             Self::TimeTravel { dataset, version } => {
@@ -69,29 +59,26 @@ impl DatasetRef {
         matches!(self, Self::Latest { .. })
     }
 
-    fn strong_consistency(&self) -> bool {
-        match self {
-            Self::Latest {
-                read_consistency_interval,
-                ..
-            } => match read_consistency_interval {
-                Some(interval) if interval.as_nanos() == 0 => true,
-                _ => false,
-            },
-            Self::TimeTravel { .. } => false,
-        }
+    async fn need_reload(&self) -> Result<bool> {
+        Ok(match self {
+            Self::Latest { dataset, .. } => {
+                dataset.latest_version_id().await? != dataset.version().version
+            }
+            Self::TimeTravel { dataset, version } => dataset.version().version != *version,
+        })
     }
 
     async fn as_latest(&mut self, read_consistency_interval: Option<Duration>) -> Result<()> {
         match self {
             Self::Latest { .. } => Ok(()),
             Self::TimeTravel { dataset, .. } => {
-                dataset.checkout_latest().await?;
+                dataset
+                    .checkout_version(dataset.latest_version_id().await?)
+                    .await?;
                 *self = Self::Latest {
                     dataset: dataset.clone(),
                     read_consistency_interval,
                     last_consistency_check: Some(Instant::now()),
-                    refresh_task: None,
                 };
                 Ok(())
             }
@@ -129,82 +116,11 @@ impl DatasetRef {
         match self {
             Self::Latest {
                 dataset: ref mut ds,
-                refresh_task,
-                last_consistency_check,
                 ..
             } => {
                 *ds = dataset;
-                if let Some(refresh_task) = refresh_task {
-                    refresh_task.abort();
-                }
-                *refresh_task = None;
-                *last_consistency_check = Some(Instant::now());
             }
             _ => unreachable!("Dataset should be in latest mode at this point"),
-        }
-    }
-
-    /// Wait for the background refresh task to complete.
-    async fn await_refresh(&mut self) -> Result<()> {
-        match self {
-            Self::Latest {
-                refresh_task,
-                read_consistency_interval,
-                ..
-            } => {
-                if let Some(refresh_task) = refresh_task {
-                    let dataset = refresh_task.await.expect("Refresh task panicked")?;
-                    *self = Self::Latest {
-                        dataset,
-                        read_consistency_interval: *read_consistency_interval,
-                        last_consistency_check: Some(Instant::now()),
-                        refresh_task: None,
-                    };
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    /// Check if background refresh task is done, and if so, update the dataset.
-    fn check_refresh(&mut self) -> Result<()> {
-        match self {
-            Self::Latest {
-                refresh_task,
-                read_consistency_interval,
-                ..
-            } => {
-                if let Some(refresh_task) = refresh_task {
-                    if refresh_task.is_finished() {
-                        let dataset = refresh_task
-                            .now_or_never()
-                            .unwrap()
-                            .expect("Refresh task panicked")?;
-                        *self = Self::Latest {
-                            dataset,
-                            read_consistency_interval: *read_consistency_interval,
-                            last_consistency_check: Some(Instant::now()),
-                            refresh_task: None,
-                        };
-                    }
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn refresh_is_ready(&self) -> bool {
-        match self {
-            Self::Latest { refresh_task, .. } => {
-                if let Some(refresh_task) = refresh_task {
-                    refresh_task.is_finished()
-                } else {
-                    false
-                }
-            }
-            _ => false,
         }
     }
 }
@@ -216,7 +132,6 @@ impl DatasetConsistencyWrapper {
             dataset,
             read_consistency_interval,
             last_consistency_check: Some(Instant::now()),
-            refresh_task: None,
         })))
     }
 
@@ -252,15 +167,16 @@ impl DatasetConsistencyWrapper {
     ///
     /// This is robust to cleanup and recreation of the dataset.
     pub async fn run_safe<T, F>(&self, f: impl Fn(&Dataset) -> F) -> Result<T>
-    where F: Future<Output = Result<T>> {
+    where
+        F: Future<Output = Result<T>>,
+    {
         let dataset = self.get().await?;
         match f(&*dataset).await {
             Ok(value) => Ok(value),
             // This likely means we are reading a version that doesn't exist anymore.
-            Err(Error::Lance { source: LanceError::IO {
-                source,
-                ..
-            } }) if source.to_string().contains("Not found") => {
+            Err(Error::Lance {
+                source: LanceError::IO { source, .. },
+            }) if source.to_string().contains("Not found") => {
                 if dataset.guard.is_latest() {
                     self.reload().await?;
                     f(&*dataset).await
@@ -269,21 +185,22 @@ impl DatasetConsistencyWrapper {
                         message: "Checked out version no longer exists. This could be because it was deleted by Optimize or the table was dropped.".to_string(),
                     })
                 }
-            },
+            }
             Err(err) => Err(err),
         }
     }
 
     pub async fn run_safe_mut<T, F>(&self, f: impl Fn(&mut Dataset) -> F) -> Result<T>
-    where F: Future<Output = Result<T>> {
+    where
+        F: Future<Output = Result<T>>,
+    {
         let mut dataset = self.get_mut().await?;
         match f(&mut *dataset).await {
             Ok(value) => Ok(value),
             // This likely means we are reading a version that doesn't exist anymore.
-            Err(Error::Lance { source: LanceError::IO {
-                source,
-                ..
-            } }) if source.to_string().contains("Not found") => {
+            Err(Error::Lance {
+                source: LanceError::IO { source, .. },
+            }) if source.to_string().contains("Not found") => {
                 if dataset.guard.is_latest() {
                     self.reload().await?;
                     f(&mut *dataset).await
@@ -292,7 +209,7 @@ impl DatasetConsistencyWrapper {
                         message: "Checked out version no longer exists. This could be because it was deleted by Optimize or the table was dropped.".to_string(),
                     })
                 }
-            },
+            }
             Err(err) => Err(err),
         }
     }
@@ -323,13 +240,19 @@ impl DatasetConsistencyWrapper {
         self.0.write().await.set_latest(dataset);
     }
 
-    /// Perform a hard reload.
     pub async fn reload(&self) -> Result<()> {
-        let mut write_guard = self.0.write().await;
-        // actually need reloading
-        write_guard.reload().await?;
+        if !self.0.read().await.need_reload().await? {
+            return Ok(());
+        }
 
-        write_guard.await_refresh().await
+        let mut write_guard = self.0.write().await;
+        // on lock escalation -- check if someone else has already reloaded
+        if !write_guard.need_reload().await? {
+            return Ok(());
+        }
+
+        // actually need reloading
+        write_guard.reload().await
     }
 
     /// Returns the version, if in time travel mode, or None otherwise
@@ -375,26 +298,9 @@ impl DatasetConsistencyWrapper {
     /// Ensures that the dataset is loaded and up-to-date with consistency and
     /// version parameters.
     async fn ensure_up_to_date(&self) -> Result<()> {
-        // We may have previously created a background task to fetch the new
-        // version of the dataset. If that task is done, we should update the
-        // dataset.
-        {
-            let read_guard = self.0.read().await;
-            if read_guard.refresh_is_ready() {
-                drop(read_guard);
-                self.0.write().await.check_refresh()?;
-            }
-        }
-
         if !self.is_up_to_date().await? {
             self.reload().await?;
         }
-
-        // If we are in strong consistency mode, we should await the refresh task.
-        if self.0.read().await.strong_consistency() {
-            self.0.write().await.await_refresh().await?;
-        }
-
         Ok(())
     }
 }
@@ -446,33 +352,36 @@ mod tests {
     use futures::StreamExt;
     use tempfile::tempdir;
 
-    use crate::{connection::ConnectBuilder, query::ExecutableQuery, table::{AddDataMode, OptimizeAction}, Table};
+    use crate::{
+        connection::ConnectBuilder,
+        query::ExecutableQuery,
+        table::{AddDataMode, OptimizeAction},
+        Table,
+    };
 
     use super::*;
 
-    fn batch_from_vec(
-        data: Vec<i64>,
-    ) -> RecordBatch {
+    fn batch_from_vec(data: Vec<i64>) -> RecordBatch {
         let schema = Schema::new(vec![Field::new("a", DataType::Int64, false)]);
         let columns = vec![Arc::new(Int64Array::from(data)) as ArrayRef];
         RecordBatch::try_new(Arc::new(schema), columns).unwrap()
     }
 
-    fn reader_from_batch(
-        batch: RecordBatch,
-    ) -> Box<dyn RecordBatchReader + Send + 'static> {
+    fn reader_from_batch(batch: RecordBatch) -> Box<dyn RecordBatchReader + Send + 'static> {
         let schema = batch.schema();
         Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema))
     }
 
-    async fn query_rows(
-        table: &Table
-    ) -> Result<Vec<i64>> {
+    async fn query_rows(table: &Table) -> Result<Vec<i64>> {
         let mut stream = table.query().execute().await?;
         let mut values = vec![];
         while let Some(batch) = stream.next().await {
             let batch = batch?;
-            let a = batch["a"].as_any().downcast_ref::<Int64Array>().unwrap().values();
+            let a = batch["a"]
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values();
             values.extend_from_slice(a);
         }
         Ok(values)
@@ -483,10 +392,7 @@ mod tests {
         let tmp_dir = tempdir().unwrap();
         let uri = tmp_dir.path().to_str().unwrap();
         // TODO: if we change the consistency interval, make this none
-        let conn = ConnectBuilder::new(uri)
-            .execute()
-            .await
-            .unwrap();
+        let conn = ConnectBuilder::new(uri).execute().await.unwrap();
         let table = conn
             .create_table("my_table", reader_from_batch(batch_from_vec(vec![1])))
             .execute()
@@ -495,16 +401,13 @@ mod tests {
 
         // Checkout one handle as time travel, one as latest
         let table_latest = table;
-        let table_time_travel = conn.open_table("my_table")
-            .execute()
-            .await
-            .unwrap();
-        table_time_travel.checkout(1)
-            .await.unwrap();
+        let table_time_travel = conn.open_table("my_table").execute().await.unwrap();
+        table_time_travel.checkout(1).await.unwrap();
 
         // In another handle, create a new version
         let table_new = conn.open_table("my_table").execute().await.unwrap();
-        table_new.add(reader_from_batch(batch_from_vec(vec![2, 3])))
+        table_new
+            .add(reader_from_batch(batch_from_vec(vec![2, 3])))
             .mode(AddDataMode::Overwrite)
             .execute()
             .await
@@ -518,11 +421,14 @@ mod tests {
         assert_eq!(query_rows(&table_new).await.unwrap(), vec![2, 3]);
 
         // In new handle, optimize aggressively, to delete old version
-        let stats= table_new.optimize(OptimizeAction::Prune {
-            older_than: Some(TimeDelta::zero()),
-            delete_unverified: Some(true),
-            error_if_tagged_old_versions: None,
-        }).await.unwrap();
+        let stats = table_new
+            .optimize(OptimizeAction::Prune {
+                older_than: Some(TimeDelta::zero()),
+                delete_unverified: Some(true),
+                error_if_tagged_old_versions: None,
+            })
+            .await
+            .unwrap();
         dbg!(stats);
 
         // Show that latest one moves on to new version
@@ -532,7 +438,10 @@ mod tests {
         // Show that the time travel one provides a sensible error.
         let res = query_rows(&table_latest).await;
         assert!(res.is_err());
-        assert_eq!(res.unwrap_err().to_string(), "Checked out version no longer exists.");
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Checked out version no longer exists."
+        );
     }
 
     #[tokio::test]
@@ -540,10 +449,7 @@ mod tests {
         // Create a table
         let tmp_dir = tempdir().unwrap();
         let uri = tmp_dir.path().to_str().unwrap();
-        let conn = ConnectBuilder::new(uri)
-            .execute()
-            .await
-            .unwrap();
+        let conn = ConnectBuilder::new(uri).execute().await.unwrap();
         let table = conn
             .create_table("my_table", reader_from_batch(batch_from_vec(vec![1])))
             .execute()
@@ -552,29 +458,25 @@ mod tests {
 
         // Checkout one handle as time travel, one as latest
         let table_latest = table;
-        let table_time_travel = conn.open_table("my_table")
-            .execute()
-            .await
-            .unwrap();
+        let table_time_travel = conn.open_table("my_table").execute().await.unwrap();
 
         // In new handle, recreate the table
         conn.drop_table("my_table").await.unwrap();
-        conn
-            .create_table("my_table", reader_from_batch(batch_from_vec(vec![2, 3])))
+        conn.create_table("my_table", reader_from_batch(batch_from_vec(vec![2, 3])))
             .execute()
             .await
             .unwrap();
 
         // Show that latest one moves on to new version
         assert_eq!(table_latest.version().await.unwrap(), 1);
-        assert_eq!(
-            query_rows(&table_latest).await.unwrap(),
-            &[2, 3]
-        );
+        assert_eq!(query_rows(&table_latest).await.unwrap(), &[2, 3]);
 
         // Show that the time travel one provides a sensible error.
         let res = query_rows(&table_time_travel).await;
         assert!(res.is_err());
-        assert_eq!(res.unwrap_err().to_string(), "Checked out version no longer exists.");
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Checked out version no longer exists."
+        );
     }
 }


### PR DESCRIPTION
This adds some better error messages catching cases where data files are missing, due to either:

1. `optimize` / `cleanup_old_version` has been called and deleted the version we are reading from
2. Another process has dropped and recreated the table.

I was thinking I could make it so we automatically catch this and retry for queries, but because we return a stream, it's difficult to do that. At the very least, we can return an error so downstream applications can do this retry if they wish.