### PR TITLE
fix: fix remote restore api to always checkout latest version

### DIFF
--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -434,6 +434,7 @@ impl<S: HttpSend> BaseTable for RemoteTable<S> {
 
         let (request_id, response) = self.client.send(request, true).await?;
         self.check_table_response(&request_id, response).await?;
+        self.checkout_latest().await?;
         Ok(())
     }
 


### PR DESCRIPTION
Fix restore to always checkout latest version, following local restore api implementation 
https://github.com/lancedb/lancedb/blob/a1d1833a40eb03f83a00921279652c36e4836e9c/rust/lancedb/src/table.rs#L1910
Otherwise
table.create_table -> version 1
table.add_table -> version 2
table.checkout(1), table.restore() -> the version remains at 1  (should checkout_latest inside restore method to update version to latest version and allow write operation)
table.checkout_latest() -> version is 3
can do write operations