### PR TITLE
feat: allow FSB to be used for btree indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,7 +4110,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.0"
+version = "0.19.0-beta.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.0"
+version = "0.19.0-beta.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.0"
+version = "0.19.0-beta.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.0"
+version = "0.22.0-beta.1"
 dependencies = [
  "arrow",
  "env_logger",

--- a/python/python/tests/test_index.py
+++ b/python/python/tests/test_index.py
@@ -31,6 +31,7 @@ async def some_table(db_async):
         {
             "id": list(range(NROWS)),
             "vector": sample_fixed_size_list_array(NROWS, DIM),
+            "fsb": pa.array([bytes([i]) for i in range(NROWS)], pa.binary(1)),
             "tags": [
                 [f"tag{random.randint(0, 8)}" for _ in range(2)] for _ in range(NROWS)
             ],
@@ -83,6 +84,16 @@ async def test_create_scalar_index(some_table: AsyncTable):
     await some_table.drop_index("id_idx")
     indices = await some_table.list_indices()
     assert len(indices) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_fixed_size_binary_index(some_table: AsyncTable):
+    await some_table.create_index("fsb", config=BTree())
+    indices = await some_table.list_indices()
+    assert str(indices) == '[Index(BTree, columns=["fsb"], name="fsb_idx")]'
+    assert len(indices) == 1
+    assert indices[0].index_type == "BTree"
+    assert indices[0].columns == ["fsb"]
 
 
 @pytest.mark.asyncio

--- a/rust/lancedb/src/utils.rs
+++ b/rust/lancedb/src/utils.rs
@@ -135,6 +135,7 @@ pub fn supported_btree_data_type(dtype: &DataType) -> bool {
                 | DataType::Date32
                 | DataType::Date64
                 | DataType::Timestamp(_, _)
+                | DataType::FixedSizeBinary(_)
         )
 }
 


### PR DESCRIPTION
We recently allowed this for lance but there was a check in lancedb as well that was preventing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for indexing fixed-size binary data using B-tree structures for efficient data storage and retrieval.
- **Tests**
  - Implemented automated tests to ensure the new binary indexing works correctly and meets the expected configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->