### PR TITLE
fix: allow re-creating tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,7 +4110,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.1"
+version = "0.19.0-beta.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.1"
+version = "0.19.0-beta.2"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.1"
+version = "0.19.0-beta.2"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.1"
+version = "0.22.0-beta.2"
 dependencies = [
  "arrow",
  "env_logger",

--- a/python/python/tests/test_s3.py
+++ b/python/python/tests/test_s3.py
@@ -276,3 +276,71 @@ def test_s3_dynamodb_drop_all_tables(s3_bucket: str, commit_table: str, monkeypa
     assert db.table_names() == ["foo"]
 
     db.drop_all_tables()
+
+
+def get_ddb_entries(client, uri, table_name):
+    return client.query(
+        TableName=table_name,
+        KeyConditions={
+            "base_uri": {"AttributeValueList": [{"S": uri}], "ComparisonOperator": "EQ"}
+        },
+    ).get("Items", [])
+
+
+@pytest.mark.s3_test
+def test_reuse_table_name(s3_bucket: str, commit_table: str):
+    storage_options = copy.copy(CONFIG)
+
+    uri = f"s3+ddb://{s3_bucket}/test3?ddbTableName={commit_table}"
+    db = lancedb.connect(
+        uri, read_consistency_interval=timedelta(0), storage_options=storage_options
+    )
+
+    # Create a table
+    data1 = pa.table({"id": range(0, 2)})
+    table = db.create_table("table", data1)
+
+    # Append to create version 2
+    data2 = pa.table({"id": range(2, 3)})
+    table.add(data2)
+
+    # Have a latest handle
+    table_latest = table
+
+    # Have a time travel handle
+    table_weak_consistency = lancedb.connect(
+        uri,
+        read_consistency_interval=timedelta(hours=1),
+        storage_options=storage_options,
+    ).open_table("table")
+
+    assert table_latest.version == 2
+    ddb = get_boto3_client("dynamodb", endpoint_url=CONFIG["dynamodb_endpoint"])
+    assert len(get_ddb_entries(ddb, "test3/table.lance", commit_table)) == 2
+
+    # Drop the table
+    db.drop_table("table")
+
+    # Assert all files deleted
+    s3 = get_boto3_client("s3", endpoint_url=CONFIG["aws_endpoint"])
+    objects = s3.list_objects_v2(Bucket=s3_bucket, Prefix="test3/table.lance").get(
+        "Contents", []
+    )
+    assert objects == []
+
+    # Assert ddb entries clear
+    assert len(get_ddb_entries(ddb, "test3/table.lance", commit_table)) == 0
+
+    # Recreate with new data
+    data3 = pa.table({"id": range(10, 12)})
+    table = db.create_table("table", data3)
+
+    assert table_latest.to_arrow() == data3
+    assert table_latest.version == 1
+
+    with pytest.raises(Exception, match="Data file not found"):
+        table_weak_consistency.to_arrow()
+
+    table_weak_consistency.checkout_latest()
+    assert table_weak_consistency.to_arrow() == data3
+    assert table_weak_consistency.version == 1

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -23,7 +23,13 @@ pub enum Error {
     IndexNotFound { name: String },
     #[snafu(display("Embedding function '{name}' was not found. : {reason}"))]
     EmbeddingFunctionNotFound { name: String, reason: String },
-
+    #[snafu(display(
+        "Data file not found: {source}. This could mean that the table was \
+         dropped or the table version has been cleaned up by optimize. \
+         Use checkout_latest to get the latest version of the table and retry
+         the operation."
+    ))]
+    DataFileNotFound { source: lance::Error },
     #[snafu(display("Table '{name}' already exists"))]
     TableAlreadyExists { name: String },
     #[snafu(display("Unable to created lance dataset at {path}: {source}"))]
@@ -96,7 +102,19 @@ impl From<lance::Error> for Error {
     fn from(source: lance::Error) -> Self {
         // TODO: Once Lance is changed to preserve ObjectStore, DataFusion, and Arrow errors, we can
         // pass those variants through here as well.
-        Self::Lance { source }
+        match source {
+            lance::Error::IO {
+                source: ref inner_source,
+                ..
+            } if inner_source
+                .to_string()
+                .to_lowercase()
+                .contains("not found") =>
+            {
+                Self::DataFileNotFound { source }
+            }
+            _ => Self::Lance { source },
+        }
     }
 }
 


### PR DESCRIPTION
This adds some better error messages catching cases where data files are missing, due to either:

1. `optimize` / `cleanup_old_version` has been called and deleted the version we are reading from
2. Another process has dropped and recreated the table.

I was thinking I could make it so we automatically catch this and retry for queries, but because we return a stream, it's difficult to do that. At the very least, we can return an error so downstream applications can do this retry if they wish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data management now ensures smoother table recreation and consistent data cleanup.
	- Improved error messaging offers clearer feedback when data assets are unavailable.
- **Tests**
	- Expanded testing verifies data storage operations, including lifecycle handling and aggressive cleanup for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->