### PR TITLE
docs: remove trailing commas from AWS IAM Policies

### DIFF
--- a/docs/src/guides/storage.md
+++ b/docs/src/guides/storage.md
@@ -374,7 +374,7 @@ For **read-only access**, LanceDB will need a policy such as:
         {
             "Effect": "Allow",
             "Action": [
-              "s3:GetObject",
+              "s3:GetObject"
             ],
             "Resource": "arn:aws:s3:::<bucket>/<prefix>/*"
         },

--- a/docs/src/guides/storage.md
+++ b/docs/src/guides/storage.md
@@ -342,7 +342,7 @@ For **read and write access**, LanceDB will need a policy such as:
             "Action": [
               "s3:PutObject",
               "s3:GetObject",
-              "s3:DeleteObject",
+              "s3:DeleteObject"
             ],
             "Resource": "arn:aws:s3:::<bucket>/<prefix>/*"
         },


### PR DESCRIPTION
Before:

<img width="1173" alt="Screenshot 2025-04-08 at 10 58 50 AM" src="https://github.com/user-attachments/assets/e5c69c45-ab68-488f-9c7f-e12f7ecbfaab" />

After:
<img width="1136" alt="Screenshot 2025-04-08 at 10 58 58 AM" src="https://github.com/user-attachments/assets/108c11ea-09b3-49b5-9a50-b880e72a0270" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated JSON policy examples in the storage guides to correct formatting issues and enhance syntax clarity for readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->