### PR TITLE
fix: revert change default read_consistency_interval=5s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,7 +4110,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.5"
+version = "0.19.0-beta.6"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.5"
+version = "0.19.0-beta.6"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.5"
+version = "0.19.0-beta.6"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.5"
+version = "0.22.0-beta.6"
 dependencies = [
  "arrow",
  "env_logger",

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -1001,11 +1001,9 @@ In LanceDB OSS, users can set the `read_consistency_interval` parameter on conne
 
 There are three possible settings for `read_consistency_interval`:
 
-1. **Unset**: The database does not check for updates to tables made by other processes. This setting is suitable for applications where the data does not change during the lifetime of the table reference.
-2. **Zero seconds (Strong consistency)**: The database checks for updates on every read. This provides the strongest consistency guarantees, ensuring that all clients see the latest committed data. However, it has the most overhead. This setting is suitable when consistency matters more than having high QPS. For best performance, combine this setting with the storage option `new_table_enable_v2_manifest_paths` set to `true`.
-3. **Custom interval (Eventual consistency, the default)**: The database checks for updates at a custom interval. By default, this is every 5 seconds. This provides eventual consistency, allowing for some lag between write and read operations. Performance wise, this is a middle ground between strong consistency and no consistency check. This setting is suitable for applications where immediate consistency is not critical, but clients should see updated data eventually.
-
-You can always force a synchronization by calling `checkout_latest()` / `checkoutLatest()` on a table.
+1. **Unset (default)**: The database does not check for updates to tables made by other processes. This provides the best query performance, but means that clients may not see the most up-to-date data. This setting is suitable for applications where the data does not change during the lifetime of the table reference.
+2. **Zero seconds (Strong consistency)**: The database checks for updates on every read. This provides the strongest consistency guarantees, ensuring that all clients see the latest committed data. However, it has the most overhead. This setting is suitable when consistency matters more than having high QPS.
+3. **Custom interval (Eventual consistency)**: The database checks for updates at a custom interval, such as every 5 seconds. This provides eventual consistency, allowing for some lag between write and read operations. Performance wise, this is a middle ground between strong consistency and no consistency check. This setting is suitable for applications where immediate consistency is not critical, but clients should see updated data eventually.
 
 !!! tip "Consistency in LanceDB Cloud"
 
@@ -1043,21 +1041,7 @@ You can always force a synchronization by calling `checkout_latest()` / `checkou
         --8<-- "python/python/tests/docs/test_guide_tables.py:table_async_eventual_consistency"
         ```
 
-    For no consistency, use `None`:
-
-    === "Sync API"
-
-        ```python
-        --8<-- "python/python/tests/docs/test_guide_tables.py:table_no_consistency"
-        ```
-
-    === "Async API"
-
-        ```python
-        --8<-- "python/python/tests/docs/test_guide_tables.py:table_async_no_consistency"
-        ```
-
-    To manually check for updates you can use `checkout_latest`:
+    By default, a `Table` will never check for updates from other writers. To manually check for updates you can use `checkout_latest`:
 
     === "Sync API"
 
@@ -1075,25 +1059,15 @@ You can always force a synchronization by calling `checkout_latest()` / `checkou
     To set strong consistency, use `0`:
 
     ```ts
-    --8<-- "nodejs/examples/basic.test.ts:table_strong_consistency"
+    const db = await lancedb.connect({ uri: "./.lancedb", readConsistencyInterval: 0 });
+    const tbl = await db.openTable("my_table");
     ```
 
     For eventual consistency, specify the update interval as seconds:
 
     ```ts
-    --8<-- "nodejs/examples/basic.test.ts:table_eventual_consistency"
-    ```
-
-    For no consistency, use `null`:
-
-    ```ts
-    --8<-- "nodejs/examples/basic.test.ts:table_no_consistency"
-    ```
-
-    To manually check for updates you can use `checkoutLatest`:
-
-    ```ts
-    --8<-- "nodejs/examples/basic.test.ts:table_checkout_latest"
+    const db = await lancedb.connect({ uri: "./.lancedb", readConsistencyInterval: 5 });
+    const tbl = await db.openTable("my_table");
     ```
 
 <!-- Node doesn't yet support the version time travel: https://github.com/lancedb/lancedb/issues/1007

--- a/docs/src/js/interfaces/ConnectionOptions.md
+++ b/docs/src/js/interfaces/ConnectionOptions.md
@@ -44,7 +44,7 @@ for testing purposes.
 ### readConsistencyInterval?
 
 ```ts
-optional readConsistencyInterval: null | number;
+optional readConsistencyInterval: number;
 ```
 
 (For LanceDB OSS only): The interval, in seconds, at which to check for

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -11,7 +11,6 @@ likely that someone who knows the answer will see your question.
 ## Common issues
 
 * Multiprocessing with `fork` is not supported. You should use `spawn` instead.
-* Data returned by queries may not reflect the most recent writes, depending on configuration. LanceDB uses eventual consistency by default. See [consistency](/docs/src/guides/tables.md#consistency) for more information.
 
 ## Enabling logging
 

--- a/node/src/integration_test/test.ts
+++ b/node/src/integration_test/test.ts
@@ -110,7 +110,7 @@ describe('LanceDB Mirrored Store Integration test', function () {
 
       fs.readdir(path.join(mirroredPath, 'data'), { withFileTypes: true }, (err, files) => {
         if (err != null) throw err
-        assert.equal(files.length, 1, `Found files: ${files.map(f => f.name)}`)
+        assert.equal(files.length, 1)
         assert.isTrue(files[0].name.endsWith('.lance'))
       })
 

--- a/nodejs/__test__/connection.test.ts
+++ b/nodejs/__test__/connection.test.ts
@@ -17,7 +17,7 @@ describe("when connecting", () => {
   it("should connect", async () => {
     const db = await connect(tmpDir.name);
     expect(db.display()).toBe(
-      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=5s)`,
+      `ListingDatabase(uri=${tmpDir.name}, read_consistency_interval=None)`,
     );
   });
 

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -58,7 +58,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
 
     it("be displayable", async () => {
       expect(table.display()).toMatch(
-        /NativeTable\(some_table, uri=.*, read_consistency_interval=5s\)/,
+        /NativeTable\(some_table, uri=.*, read_consistency_interval=None\)/,
       );
       table.close();
       expect(table.display()).toBe("ClosedTable(some_table)");

--- a/nodejs/examples/basic.test.ts
+++ b/nodejs/examples/basic.test.ts
@@ -202,35 +202,5 @@ test("basic table examples", async () => {
       // --8<-- [end:create_f16_table]
       await db.dropTable("f16_tbl");
     }
-    const uri = databaseDir;
-    await db.createTable("my_table", [{ id: 1 }, { id: 2 }]);
-    {
-      // --8<-- [start:table_strong_consistency]
-      const db = await lancedb.connect({ uri, readConsistencyInterval: 0 });
-      const tbl = await db.openTable("my_table");
-      // --8<-- [end:table_strong_consistency]
-    }
-    {
-      // --8<-- [start:table_eventual_consistency]
-      const db = await lancedb.connect({ uri, readConsistencyInterval: 5 });
-      const tbl = await db.openTable("my_table");
-      // --8<-- [end:table_eventual_consistency]
-    }
-    {
-      // --8<-- [start:table_no_consistency]
-      const db = await lancedb.connect({ uri, readConsistencyInterval: null });
-      const tbl = await db.openTable("my_table");
-      // --8<-- [end:table_no_consistency]
-    }
-    {
-      // --8<-- [start:table_checkout_latest]
-      const tbl = await db.openTable("my_table");
-
-      // (Other writes happen to test_table_async from another process)
-
-      // Check for updates
-      tbl.checkoutLatest();
-      // --8<-- [end:table_checkout_latest]
-    }
   });
 });

--- a/nodejs/src/connection.rs
+++ b/nodejs/src/connection.rs
@@ -48,16 +48,8 @@ impl Connection {
     pub async fn new(uri: String, options: ConnectionOptions) -> napi::Result<Self> {
         let mut builder = ConnectBuilder::new(&uri);
         if let Some(interval) = options.read_consistency_interval {
-            match interval {
-                Either::A(seconds) => {
-                    builder = builder.read_consistency_interval(Some(
-                        std::time::Duration::from_secs_f64(seconds),
-                    ));
-                }
-                Either::B(_) => {
-                    builder = builder.read_consistency_interval(None);
-                }
-            }
+            builder =
+                builder.read_consistency_interval(std::time::Duration::from_secs_f64(interval));
         }
         if let Some(storage_options) = options.storage_options {
             for (key, value) in storage_options {

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -4,7 +4,6 @@
 use std::collections::HashMap;
 
 use env_logger::Env;
-use napi::{bindgen_prelude::Null, Either};
 use napi_derive::*;
 
 mod connection;
@@ -19,6 +18,7 @@ mod table;
 mod util;
 
 #[napi(object)]
+#[derive(Debug)]
 pub struct ConnectionOptions {
     /// (For LanceDB OSS only): The interval, in seconds, at which to check for
     /// updates to the table from other processes. If None, then consistency is not
@@ -29,7 +29,7 @@ pub struct ConnectionOptions {
     /// has passed since the last check, then the table will be checked for updates.
     /// Note: this consistency only applies to read operations. Write operations are
     /// always consistent.
-    pub read_consistency_interval: Option<Either<f64, Null>>,
+    pub read_consistency_interval: Option<f64>,
     /// (For LanceDB OSS only): configuration for object storage.
     ///
     /// The available options are described at https://lancedb.github.io/lancedb/guides/storage/

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -26,7 +26,7 @@ def connect(
     api_key: Optional[str] = None,
     region: str = "us-east-1",
     host_override: Optional[str] = None,
-    read_consistency_interval: Optional[timedelta] = timedelta(seconds=5),
+    read_consistency_interval: Optional[timedelta] = None,
     request_thread_pool: Optional[Union[int, ThreadPoolExecutor]] = None,
     client_config: Union[ClientConfig, Dict[str, Any], None] = None,
     storage_options: Optional[Dict[str, str]] = None,
@@ -49,8 +49,9 @@ def connect(
     read_consistency_interval: timedelta, default None
         (For LanceDB OSS only)
         The interval at which to check for updates to the table from other
-        processes. If None, then consistency is not checked. For strong consistency,
-        set this to zero seconds. Then every read will check for updates from other
+        processes. If None, then consistency is not checked. For performance
+        reasons, this is the default. For strong consistency, set this to
+        zero seconds. Then every read will check for updates from other
         processes. As a compromise, you can set this to a non-zero timedelta
         for eventual consistency. If more than that interval has passed since
         the last check, then the table will be checked for updates. Note: this
@@ -121,7 +122,7 @@ async def connect_async(
     api_key: Optional[str] = None,
     region: str = "us-east-1",
     host_override: Optional[str] = None,
-    read_consistency_interval: Optional[timedelta] = timedelta(seconds=5),
+    read_consistency_interval: Optional[timedelta] = None,
     client_config: Optional[Union[ClientConfig, Dict[str, Any]]] = None,
     storage_options: Optional[Dict[str, str]] = None,
 ) -> AsyncConnection:
@@ -142,8 +143,9 @@ async def connect_async(
     read_consistency_interval: timedelta, default None
         (For LanceDB OSS only)
         The interval at which to check for updates to the table from other
-        processes. If None, then consistency is not checked. For strong consistency,
-        set this to zero seconds. Then every read will check for updates from other
+        processes. If None, then consistency is not checked. For performance
+        reasons, this is the default. For strong consistency, set this to
+        zero seconds. Then every read will check for updates from other
         processes. As a compromise, you can set this to a non-zero timedelta
         for eventual consistency. If more than that interval has passed since
         the last check, then the table will be checked for updates. Note: this

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from pathlib import Path
-from datetime import timedelta
 from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Union
 
 from lancedb.embeddings.registry import EmbeddingFunctionRegistry
@@ -33,6 +32,7 @@ import deprecation
 if TYPE_CHECKING:
     import pyarrow as pa
     from .pydantic import LanceModel
+    from datetime import timedelta
 
     from ._lancedb import Connection as LanceDbConnection
     from .common import DATA, URI
@@ -318,8 +318,9 @@ class LanceDBConnection(DBConnection):
         The root uri of the database.
     read_consistency_interval: timedelta, default None
         The interval at which to check for updates to the table from other
-        processes. If None, then consistency is not checked. For strong consistency,
-        set this to zero seconds. Then every read will check for updates from other
+        processes. If None, then consistency is not checked. For performance
+        reasons, this is the default. For strong consistency, set this to
+        zero seconds. Then every read will check for updates from other
         processes. As a compromise, you can set this to a non-zero timedelta
         for eventual consistency. If more than that interval has passed since
         the last check, then the table will be checked for updates. Note: this
@@ -351,7 +352,7 @@ class LanceDBConnection(DBConnection):
         self,
         uri: URI,
         *,
-        read_consistency_interval: Optional[timedelta] = timedelta(seconds=5),
+        read_consistency_interval: Optional[timedelta] = None,
         storage_options: Optional[Dict[str, str]] = None,
     ):
         if not isinstance(uri, Path):

--- a/python/python/tests/docs/test_guide_tables.py
+++ b/python/python/tests/docs/test_guide_tables.py
@@ -315,11 +315,6 @@ def test_table():
     db = lancedb.connect(uri, read_consistency_interval=timedelta(seconds=5))
     tbl = db.open_table("test_table")
     # --8<-- [end:table_eventual_consistency]
-    # --8<-- [start:table_no_consistency]
-    uri = "data/sample-lancedb"
-    db = lancedb.connect(uri, read_consistency_interval=None)
-    tbl = db.open_table("test_table")
-    # --8<-- [end:table_no_consistency]
     # --8<-- [start:table_checkout_latest]
     tbl = db.open_table("test_table")
 
@@ -567,19 +562,13 @@ async def test_table_async():
     async_db = await lancedb.connect_async(uri, read_consistency_interval=timedelta(0))
     async_tbl = await async_db.open_table("test_table_async")
     # --8<-- [end:table_async_strong_consistency]
-    # --8<-- [start:table_async_eventual_consistency]
+    # --8<-- [start:table_async_ventual_consistency]
     uri = "data/sample-lancedb"
     async_db = await lancedb.connect_async(
         uri, read_consistency_interval=timedelta(seconds=5)
     )
     async_tbl = await async_db.open_table("test_table_async")
     # --8<-- [end:table_async_eventual_consistency]
-    # --8<-- [start:table_async_no_consistency]
-    uri = "data/sample-lancedb"
-    async_db = await lancedb.connect_async(uri, read_consistency_interval=None)
-    async_tbl = await async_db.open_table("test_table_async")
-    # --8<-- [end:table_async_no_consistency]
-
     # --8<-- [start:table_async_checkout_latest]
     async_tbl = await async_db.open_table("test_table_async")
 

--- a/python/python/tests/docs/test_guide_tables.py
+++ b/python/python/tests/docs/test_guide_tables.py
@@ -562,7 +562,7 @@ async def test_table_async():
     async_db = await lancedb.connect_async(uri, read_consistency_interval=timedelta(0))
     async_tbl = await async_db.open_table("test_table_async")
     # --8<-- [end:table_async_strong_consistency]
-    # --8<-- [start:table_async_ventual_consistency]
+    # --8<-- [start:table_async_eventual_consistency]
     uri = "data/sample-lancedb"
     async_db = await lancedb.connect_async(
         uri, read_consistency_interval=timedelta(seconds=5)

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -3,6 +3,7 @@
 
 
 import re
+from datetime import timedelta
 import os
 
 import lancedb
@@ -298,10 +299,12 @@ def test_create_exist_ok(tmp_db: lancedb.DBConnection):
 @pytest.mark.asyncio
 async def test_connect(tmp_path):
     db = await lancedb.connect_async(tmp_path)
-    assert str(db) == f"ListingDatabase(uri={tmp_path}, read_consistency_interval=5s)"
-
-    db = await lancedb.connect_async(tmp_path, read_consistency_interval=None)
     assert str(db) == f"ListingDatabase(uri={tmp_path}, read_consistency_interval=None)"
+
+    db = await lancedb.connect_async(
+        tmp_path, read_consistency_interval=timedelta(seconds=5)
+    )
+    assert str(db) == f"ListingDatabase(uri={tmp_path}, read_consistency_interval=5s)"
 
 
 @pytest.mark.asyncio
@@ -450,7 +453,7 @@ async def test_open_table(tmp_path):
     assert tbl.name == "test"
     assert (
         re.search(
-            r"NativeTable\(test, uri=.*test\.lance, read_consistency_interval=5s\)",
+            r"NativeTable\(test, uri=.*test\.lance, read_consistency_interval=None\)",
             str(tbl),
         )
         is not None

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -32,11 +32,7 @@ def test_basic(mem_db: DBConnection):
     table = mem_db.create_table("test", data=data)
 
     assert table.name == "test"
-    assert (
-        "LanceTable(name='test', version=1, "
-        "read_consistency_interval=datetime.timedelta(seconds=5), "
-        "_conn=LanceDBConnection("
-    ) in repr(table)
+    assert "LanceTable(name='test', version=1, _conn=LanceDBConnection(" in repr(table)
     expected_schema = pa.schema(
         {
             "vector": pa.list_(pa.float32(), 2),

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -204,9 +204,7 @@ pub fn connect(
         }
         if let Some(read_consistency_interval) = read_consistency_interval {
             let read_consistency_interval = Duration::from_secs_f64(read_consistency_interval);
-            builder = builder.read_consistency_interval(Some(read_consistency_interval));
-        } else {
-            builder = builder.read_consistency_interval(None);
+            builder = builder.read_consistency_interval(read_consistency_interval);
         }
         if let Some(storage_options) = storage_options {
             builder = builder.storage_options(storage_options);

--- a/rust/ffi/node/src/lib.rs
+++ b/rust/ffi/node/src/lib.rs
@@ -60,7 +60,7 @@ fn database_new(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let mut conn_builder = connect(&path).storage_options(storage_options);
 
     if let Some(interval) = read_consistency_interval {
-        conn_builder = conn_builder.read_consistency_interval(Some(interval));
+        conn_builder = conn_builder.read_consistency_interval(interval);
     }
     rt.spawn(async move {
         let database = conn_builder.execute().await;

--- a/rust/lancedb/src/catalog/listing.rs
+++ b/rust/lancedb/src/catalog/listing.rs
@@ -12,7 +12,7 @@ use super::{
     Catalog, CatalogOptions, CreateDatabaseMode, CreateDatabaseRequest, DatabaseNamesRequest,
     OpenDatabaseRequest,
 };
-use crate::connection::{ConnectRequest, DEFAULT_READ_CONSISTENCY_INTERVAL};
+use crate::connection::ConnectRequest;
 use crate::database::listing::{ListingDatabase, ListingDatabaseOptions};
 use crate::database::{Database, DatabaseOptions};
 use crate::error::{CreateDirSnafu, Error, Result};
@@ -214,7 +214,7 @@ impl Catalog for ListingCatalog {
             uri: db_uri,
             #[cfg(feature = "remote")]
             client_config: Default::default(),
-            read_consistency_interval: DEFAULT_READ_CONSISTENCY_INTERVAL,
+            read_consistency_interval: None,
             options: Default::default(),
         };
 
@@ -241,7 +241,7 @@ impl Catalog for ListingCatalog {
             uri: db_path.to_string(),
             #[cfg(feature = "remote")]
             client_config: Default::default(),
-            read_consistency_interval: DEFAULT_READ_CONSISTENCY_INTERVAL,
+            read_consistency_interval: None,
             options: Default::default(),
         };
 
@@ -311,7 +311,7 @@ mod tests {
             #[cfg(feature = "remote")]
             client_config: Default::default(),
             options: Default::default(),
-            read_consistency_interval: DEFAULT_READ_CONSISTENCY_INTERVAL,
+            read_consistency_interval: None,
         };
 
         let catalog = ListingCatalog::connect(&request).await.unwrap();

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -2629,7 +2629,7 @@ mod tests {
         let dataset_path = tmp_dir.path().join("test.lance");
         let uri = dataset_path.to_str().unwrap();
         let conn = connect(uri)
-            .read_consistency_interval(Some(Duration::from_secs(0)))
+            .read_consistency_interval(Duration::from_secs(0))
             .execute()
             .await
             .unwrap();
@@ -2712,7 +2712,7 @@ mod tests {
         let dataset_path = tmp_dir.path().join("test.lance");
         let uri = dataset_path.to_str().unwrap();
         let conn = connect(uri)
-            .read_consistency_interval(Some(Duration::from_secs(0)))
+            .read_consistency_interval(Duration::from_secs(0))
             .execute()
             .await
             .unwrap();
@@ -2909,7 +2909,7 @@ mod tests {
         let dataset_path = tmp_dir.path().join("test.lance");
         let uri = dataset_path.to_str().unwrap();
         let conn = connect(uri)
-            .read_consistency_interval(Some(Duration::from_secs(0)))
+            .read_consistency_interval(Duration::from_secs(0))
             .execute()
             .await
             .unwrap();
@@ -3480,8 +3480,7 @@ mod tests {
 
             let mut conn2 = ConnectBuilder::new(uri);
             if let Some(interval) = interval {
-                conn2 = conn2
-                    .read_consistency_interval(Some(std::time::Duration::from_millis(interval)));
+                conn2 = conn2.read_consistency_interval(std::time::Duration::from_millis(interval));
             }
             let conn2 = conn2.execute().await.unwrap();
             let table2 = conn2.open_table("my_table").execute().await.unwrap();
@@ -3517,7 +3516,7 @@ mod tests {
         let uri = tmp_dir.path().to_str().unwrap();
 
         let conn = ConnectBuilder::new(uri)
-            .read_consistency_interval(Some(Duration::from_secs(0)))
+            .read_consistency_interval(Duration::from_secs(0))
             .execute()
             .await
             .unwrap();
@@ -3538,7 +3537,7 @@ mod tests {
         let uri = tmp_dir.path().to_str().unwrap();
 
         let conn = ConnectBuilder::new(uri)
-            .read_consistency_interval(Some(Duration::from_secs(0)))
+            .read_consistency_interval(Duration::from_secs(0))
             .execute()
             .await
             .unwrap();
@@ -3613,7 +3612,7 @@ mod tests {
         let uri = tmp_dir.path().to_str().unwrap();
 
         let conn = ConnectBuilder::new(uri)
-            .read_consistency_interval(Some(Duration::from_secs(0)))
+            .read_consistency_interval(Duration::from_secs(0))
             .execute()
             .await
             .unwrap();
@@ -3675,7 +3674,7 @@ mod tests {
         let uri = tmp_dir.path().to_str().unwrap();
 
         let conn = ConnectBuilder::new(uri)
-            .read_consistency_interval(Some(Duration::from_secs(0)))
+            .read_consistency_interval(Duration::from_secs(0))
             .execute()
             .await
             .unwrap();

--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -303,7 +303,7 @@ mod tests {
     #[tokio::test]
     async fn test_iops_open_strong_consistency() {
         let db = connect("memory://")
-            .read_consistency_interval(Some(Duration::ZERO))
+            .read_consistency_interval(Duration::ZERO)
             .execute()
             .await
             .expect("Failed to connect to database");


### PR DESCRIPTION
This reverts commit a547c523c2daba9e661fd2caa6770830bb0b52bb or #2281

The current implementation can cause panics and performance degradation. I will bring this back with more testing in https://github.com/lancedb/lancedb/pull/2311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced clarity on read consistency settings with updated descriptions and default behavior.
  - Removed outdated warnings about eventual consistency from the troubleshooting guide.

- **Refactor**
  - Streamlined the handling of the read consistency interval across integrations, now defaulting to "None" for improved performance.
  - Simplified internal logic to offer a more consistent experience.

- **Tests**
  - Updated test expectations to reflect the new default representation for the read consistency interval.
  - Removed redundant tests related to "no consistency" settings for streamlined testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->