### PR TITLE
docs: Make table.update() nodejs  Guide consistent with API documentation

### DIFF
--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -765,7 +765,7 @@ This can be used to update zero to all rows depending on how many rows match the
         ];
         const tbl = await db.createTable("my_table", data)
 
-        await table.update({ 
+        await tbl.update({ 
             where: "x = 2", 
             values: { vector: [10, 10] } 
         });

--- a/docs/src/guides/tables.md
+++ b/docs/src/guides/tables.md
@@ -765,7 +765,10 @@ This can be used to update zero to all rows depending on how many rows match the
         ];
         const tbl = await db.createTable("my_table", data)
 
-        await tbl.update({vector: [10, 10]}, { where: "x = 2"})
+        await table.update({ 
+            where: "x = 2", 
+            values: { vector: [10, 10] } 
+        });
         ```
 
     === "vectordb (deprecated)"


### PR DESCRIPTION
The docs in the Guide here do not match the [API reference] (https://lancedb.github.io/lancedb/js/classes/Table/#updateopts) for the nodejs client. 

I am writing an Elixir wrapper over the typescript library (Rust forthcoming!) and confirmed in testing that the API reference is correct vs the Guide. 

Following the Guide docs, the error I got was:

```
"lance error: Invalid user input: Schema error: No field named bar. Valid fields are foo.
```

For a query of: 
```js
await table.update({foo: "buzz"}, { where: "foo = 'bar'"});
```

Over a table with a schema of just `{foo: Utf8}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the syntax for the `update` method in the TypeScript section to clearly separate update conditions from values, enhancing clarity in how updates are demonstrated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->