### PR TITLE
feat: add new table API to wait for async indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.6"
+version = "0.19.0-beta.7"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.6"
+version = "0.19.0-beta.7"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.6"
+version = "0.19.0-beta.7"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4244,7 +4244,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.6"
+version = "0.22.0-beta.7"
 dependencies = [
  "arrow",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.7"
+version = "0.22.0-beta.8"
 dependencies = [
  "arrow",
  "env_logger",

--- a/docs/src/js/classes/Table.md
+++ b/docs/src/js/classes/Table.md
@@ -46,9 +46,11 @@ abstract add(data, options?): Promise<void>
 Insert records into this Table.
 
 #### Parameters
-    * **data**: [`Data`](../type-aliases/Data.md)
+
+* **data**: [`Data`](../type-aliases/Data.md)
     Records to be inserted into the Table
-    * **options?**: `Partial`&lt;[`AddDataOptions`](../interfaces/AddDataOptions.md)&gt;
+
+* **options?**: `Partial`&lt;[`AddDataOptions`](../interfaces/AddDataOptions.md)&gt;
 
 #### Returns
 
@@ -65,7 +67,8 @@ abstract addColumns(newColumnTransforms): Promise<void>
 Add new columns with defined values.
 
 #### Parameters
-    * **newColumnTransforms**: [`AddColumnsSql`](../interfaces/AddColumnsSql.md)[]
+
+* **newColumnTransforms**: [`AddColumnsSql`](../interfaces/AddColumnsSql.md)[]
     pairs of column names and
     the SQL expression to use to calculate the value of the new column. These
     expressions will be evaluated for each row in the table, and can
@@ -86,7 +89,8 @@ abstract alterColumns(columnAlterations): Promise<void>
 Alter the name or nullability of columns.
 
 #### Parameters
-    * **columnAlterations**: [`ColumnAlteration`](../interfaces/ColumnAlteration.md)[]
+
+* **columnAlterations**: [`ColumnAlteration`](../interfaces/ColumnAlteration.md)[]
     One or more alterations to
     apply to columns.
 
@@ -112,7 +116,8 @@ Calling this method will set the table into time-travel mode. If you
 wish to return to standard mode, call `checkoutLatest`.
 
 #### Parameters
-    * **version**: `number`
+
+* **version**: `number`
     The version to checkout
 
 #### Returns
@@ -181,7 +186,8 @@ abstract countRows(filter?): Promise<number>
 Count the total number of rows in the dataset.
 
 #### Parameters
-    * **filter?**: `string`
+
+* **filter?**: `string`
 
 #### Returns
 
@@ -206,8 +212,10 @@ We currently don't support custom named indexes.
 The index name will always be `${column}_idx`.
 
 #### Parameters
-    * **column**: `string`
-    * **options?**: `Partial`&lt;[`IndexOptions`](../interfaces/IndexOptions.md)&gt;
+
+* **column**: `string`
+
+* **options?**: `Partial`&lt;[`IndexOptions`](../interfaces/IndexOptions.md)&gt;
 
 #### Returns
 
@@ -250,7 +258,8 @@ abstract delete(predicate): Promise<void>
 Delete the rows that satisfy the predicate.
 
 #### Parameters
-    * **predicate**: `string`
+
+* **predicate**: `string`
 
 #### Returns
 
@@ -286,7 +295,8 @@ call ``compact_files`` to rewrite the data without the removed columns and
 then call ``cleanup_files`` to remove the old files.
 
 #### Parameters
-    * **columnNames**: `string`[]
+
+* **columnNames**: `string`[]
     The names of the columns to drop. These can
     be nested column references (e.g. "a.b.c") or top-level column names
     (e.g. "a").
@@ -306,7 +316,8 @@ abstract dropIndex(name): Promise<void>
 Drop an index from the table.
 
 #### Parameters
-    * **name**: `string`
+
+* **name**: `string`
     The name of the index.
     This does not delete the index from disk, it just removes it from the table.
     To delete the index, run [Table#optimize](Table.md#optimize) after dropping the index.
@@ -327,7 +338,8 @@ abstract indexStats(name): Promise<undefined | IndexStatistics>
 List all the stats of a specified index
 
 #### Parameters
-    * **name**: `string`
+
+* **name**: `string`
     The name of the index.
 
 #### Returns
@@ -389,7 +401,8 @@ abstract mergeInsert(on): MergeInsertBuilder
 ```
 
 #### Parameters
-    * **on**: `string` \| `string`[]
+
+* **on**: `string` \| `string`[]
 
 #### Returns
 
@@ -432,7 +445,8 @@ Modeled after ``VACUUM`` in PostgreSQL.
  modification operations.
 
 #### Parameters
-    * **options?**: `Partial`&lt;[`OptimizeOptions`](../interfaces/OptimizeOptions.md)&gt;
+
+* **options?**: `Partial`&lt;[`OptimizeOptions`](../interfaces/OptimizeOptions.md)&gt;
 
 #### Returns
 
@@ -449,7 +463,8 @@ abstract prewarmIndex(name): Promise<void>
 Prewarm an index in the table.
 
 #### Parameters
-    * **name**: `string`
+
+* **name**: `string`
     The name of the index.
     This will load the index into memory.  This may reduce the cold-start time for
     future queries.  If the index does not fit in the cache then this call may be
@@ -581,11 +596,14 @@ Create a search query to find the nearest neighbors
 of the given query
 
 #### Parameters
-    * **query**: `string` \| [`IntoVector`](../type-aliases/IntoVector.md) \| [`FullTextQuery`](../interfaces/FullTextQuery.md)
+
+* **query**: `string` \| [`IntoVector`](../type-aliases/IntoVector.md) \| [`FullTextQuery`](../interfaces/FullTextQuery.md)
     the query, a vector or string
-    * **queryType?**: `string`
+
+* **queryType?**: `string`
     the type of the query, "vector", "fts", or "auto"
-    * **ftsColumns?**: `string` \| `string`[]
+
+* **ftsColumns?**: `string` \| `string`[]
     the columns to search in for full text search
     for now, only one column can be searched at a time.
     when "auto" is used, if the query is a string and an embedding function is defined, it will be treated as a vector query
@@ -622,7 +640,8 @@ abstract update(opts): Promise<void>
 Update existing records in the Table
 
 ##### Parameters
-    * **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
+
+* **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
 
 ##### Returns
 
@@ -643,7 +662,8 @@ abstract update(opts): Promise<void>
 Update existing records in the Table
 
 ##### Parameters
-    * **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
+
+* **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
 
 ##### Returns
 
@@ -677,14 +697,16 @@ better performance with a single [`merge_insert`] call instead of
 repeatedly calilng this method.
 
 ##### Parameters
-    * **updates**: `Record`&lt;`string`, `string`&gt; \| `Map`&lt;`string`, `string`&gt;
+
+* **updates**: `Record`&lt;`string`, `string`&gt; \| `Map`&lt;`string`, `string`&gt;
     the
     columns to update
     Keys in the map should specify the name of the column to update.
     Values in the map provide the new value of the column.  These can
     be SQL literal strings (e.g. "7" or "'foo'") or they can be expressions
     based on the row being updated (e.g. "my_col + 1")
-    * **options?**: `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
+
+* **options?**: `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
     additional options to control
     the update behavior
 
@@ -707,7 +729,8 @@ is the same thing as calling `nearestTo` on the builder returned
 by `query`.
 
 #### Parameters
-    * **vector**: [`IntoVector`](../type-aliases/IntoVector.md)
+
+* **vector**: [`IntoVector`](../type-aliases/IntoVector.md)
 
 #### Returns
 
@@ -730,3 +753,26 @@ Retrieve the version of the table
 #### Returns
 
 `Promise`&lt;`number`&gt;
+
+***
+
+### waitForIndex()
+
+```ts
+abstract waitForIndex(indexNames, timeoutSeconds): Promise<void>
+```
+
+Waits for asynchronous indexing to complete on the table.
+
+#### Parameters
+
+* **indexNames**: `string`[]
+    The name of the indices to wait for
+
+* **timeoutSeconds**: `number`
+    The number of seconds to wait before timing out
+    This will raise an error if the indices are not created and fully indexed within the timeout.
+
+#### Returns
+
+`Promise`&lt;`void`&gt;

--- a/docs/src/js/classes/Table.md
+++ b/docs/src/js/classes/Table.md
@@ -46,11 +46,9 @@ abstract add(data, options?): Promise<void>
 Insert records into this Table.
 
 #### Parameters
-
-* **data**: [`Data`](../type-aliases/Data.md)
+    * **data**: [`Data`](../type-aliases/Data.md)
     Records to be inserted into the Table
-
-* **options?**: `Partial`&lt;[`AddDataOptions`](../interfaces/AddDataOptions.md)&gt;
+    * **options?**: `Partial`&lt;[`AddDataOptions`](../interfaces/AddDataOptions.md)&gt;
 
 #### Returns
 
@@ -67,8 +65,7 @@ abstract addColumns(newColumnTransforms): Promise<void>
 Add new columns with defined values.
 
 #### Parameters
-
-* **newColumnTransforms**: [`AddColumnsSql`](../interfaces/AddColumnsSql.md)[]
+    * **newColumnTransforms**: [`AddColumnsSql`](../interfaces/AddColumnsSql.md)[]
     pairs of column names and
     the SQL expression to use to calculate the value of the new column. These
     expressions will be evaluated for each row in the table, and can
@@ -89,8 +86,7 @@ abstract alterColumns(columnAlterations): Promise<void>
 Alter the name or nullability of columns.
 
 #### Parameters
-
-* **columnAlterations**: [`ColumnAlteration`](../interfaces/ColumnAlteration.md)[]
+    * **columnAlterations**: [`ColumnAlteration`](../interfaces/ColumnAlteration.md)[]
     One or more alterations to
     apply to columns.
 
@@ -116,8 +112,7 @@ Calling this method will set the table into time-travel mode. If you
 wish to return to standard mode, call `checkoutLatest`.
 
 #### Parameters
-
-* **version**: `number`
+    * **version**: `number`
     The version to checkout
 
 #### Returns
@@ -186,8 +181,7 @@ abstract countRows(filter?): Promise<number>
 Count the total number of rows in the dataset.
 
 #### Parameters
-
-* **filter?**: `string`
+    * **filter?**: `string`
 
 #### Returns
 
@@ -212,10 +206,8 @@ We currently don't support custom named indexes.
 The index name will always be `${column}_idx`.
 
 #### Parameters
-
-* **column**: `string`
-
-* **options?**: `Partial`&lt;[`IndexOptions`](../interfaces/IndexOptions.md)&gt;
+    * **column**: `string`
+    * **options?**: `Partial`&lt;[`IndexOptions`](../interfaces/IndexOptions.md)&gt;
 
 #### Returns
 
@@ -258,8 +250,7 @@ abstract delete(predicate): Promise<void>
 Delete the rows that satisfy the predicate.
 
 #### Parameters
-
-* **predicate**: `string`
+    * **predicate**: `string`
 
 #### Returns
 
@@ -295,8 +286,7 @@ call ``compact_files`` to rewrite the data without the removed columns and
 then call ``cleanup_files`` to remove the old files.
 
 #### Parameters
-
-* **columnNames**: `string`[]
+    * **columnNames**: `string`[]
     The names of the columns to drop. These can
     be nested column references (e.g. "a.b.c") or top-level column names
     (e.g. "a").
@@ -316,8 +306,7 @@ abstract dropIndex(name): Promise<void>
 Drop an index from the table.
 
 #### Parameters
-
-* **name**: `string`
+    * **name**: `string`
     The name of the index.
     This does not delete the index from disk, it just removes it from the table.
     To delete the index, run [Table#optimize](Table.md#optimize) after dropping the index.
@@ -338,8 +327,7 @@ abstract indexStats(name): Promise<undefined | IndexStatistics>
 List all the stats of a specified index
 
 #### Parameters
-
-* **name**: `string`
+    * **name**: `string`
     The name of the index.
 
 #### Returns
@@ -401,8 +389,7 @@ abstract mergeInsert(on): MergeInsertBuilder
 ```
 
 #### Parameters
-
-* **on**: `string` \| `string`[]
+    * **on**: `string` \| `string`[]
 
 #### Returns
 
@@ -445,8 +432,7 @@ Modeled after ``VACUUM`` in PostgreSQL.
  modification operations.
 
 #### Parameters
-
-* **options?**: `Partial`&lt;[`OptimizeOptions`](../interfaces/OptimizeOptions.md)&gt;
+    * **options?**: `Partial`&lt;[`OptimizeOptions`](../interfaces/OptimizeOptions.md)&gt;
 
 #### Returns
 
@@ -463,8 +449,7 @@ abstract prewarmIndex(name): Promise<void>
 Prewarm an index in the table.
 
 #### Parameters
-
-* **name**: `string`
+    * **name**: `string`
     The name of the index.
     This will load the index into memory.  This may reduce the cold-start time for
     future queries.  If the index does not fit in the cache then this call may be
@@ -596,14 +581,11 @@ Create a search query to find the nearest neighbors
 of the given query
 
 #### Parameters
-
-* **query**: `string` \| [`IntoVector`](../type-aliases/IntoVector.md) \| [`FullTextQuery`](../interfaces/FullTextQuery.md)
+    * **query**: `string` \| [`IntoVector`](../type-aliases/IntoVector.md) \| [`FullTextQuery`](../interfaces/FullTextQuery.md)
     the query, a vector or string
-
-* **queryType?**: `string`
+    * **queryType?**: `string`
     the type of the query, "vector", "fts", or "auto"
-
-* **ftsColumns?**: `string` \| `string`[]
+    * **ftsColumns?**: `string` \| `string`[]
     the columns to search in for full text search
     for now, only one column can be searched at a time.
     when "auto" is used, if the query is a string and an embedding function is defined, it will be treated as a vector query
@@ -640,8 +622,7 @@ abstract update(opts): Promise<void>
 Update existing records in the Table
 
 ##### Parameters
-
-* **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
+    * **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
 
 ##### Returns
 
@@ -662,8 +643,7 @@ abstract update(opts): Promise<void>
 Update existing records in the Table
 
 ##### Parameters
-
-* **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
+    * **opts**: `object` & `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
 
 ##### Returns
 
@@ -697,16 +677,14 @@ better performance with a single [`merge_insert`] call instead of
 repeatedly calilng this method.
 
 ##### Parameters
-
-* **updates**: `Record`&lt;`string`, `string`&gt; \| `Map`&lt;`string`, `string`&gt;
+    * **updates**: `Record`&lt;`string`, `string`&gt; \| `Map`&lt;`string`, `string`&gt;
     the
     columns to update
     Keys in the map should specify the name of the column to update.
     Values in the map provide the new value of the column.  These can
     be SQL literal strings (e.g. "7" or "'foo'") or they can be expressions
     based on the row being updated (e.g. "my_col + 1")
-
-* **options?**: `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
+    * **options?**: `Partial`&lt;[`UpdateOptions`](../interfaces/UpdateOptions.md)&gt;
     additional options to control
     the update behavior
 
@@ -729,8 +707,7 @@ is the same thing as calling `nearestTo` on the builder returned
 by `query`.
 
 #### Parameters
-
-* **vector**: [`IntoVector`](../type-aliases/IntoVector.md)
+    * **vector**: [`IntoVector`](../type-aliases/IntoVector.md)
 
 #### Returns
 

--- a/docs/src/js/interfaces/IndexOptions.md
+++ b/docs/src/js/interfaces/IndexOptions.md
@@ -40,11 +40,10 @@ that index is out of date.
 
 The default is true
 
+***
+
 ### waitTimeoutSeconds?
 
 ```ts
 optional waitTimeoutSeconds: number;
 ```
-
-
-Whether to wait for asynchronous indexing to complete. If set, an error will be raised if the timeout is exceeded.

--- a/docs/src/js/interfaces/IndexOptions.md
+++ b/docs/src/js/interfaces/IndexOptions.md
@@ -39,3 +39,11 @@ and the same name, then an error will be returned.  This is true even if
 that index is out of date.
 
 The default is true
+
+### waitTimeoutSeconds?
+
+```ts
+optional waitTimeoutSeconds: number;
+```
+
+Whether to wait for asynchronous indexing to complete. If set, an error will be raised if the timeout is exceeded.

--- a/docs/src/js/interfaces/IndexOptions.md
+++ b/docs/src/js/interfaces/IndexOptions.md
@@ -46,4 +46,5 @@ The default is true
 optional waitTimeoutSeconds: number;
 ```
 
+
 Whether to wait for asynchronous indexing to complete. If set, an error will be raised if the timeout is exceeded.

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -507,6 +507,15 @@ describe("When creating an index", () => {
     expect(indices2.length).toBe(0);
   });
 
+  it("should wait for index readiness", async () => {
+    // Create an index and then wait for it to be ready
+    await tbl.createIndex("vec");
+    const indices = await tbl.listIndices();
+    expect(indices.length).toBeGreaterThan(0);
+    const idxName = indices[0].name;
+    await expect(tbl.waitForIndex([idxName], 5)).resolves.toBeUndefined();
+  });
+
   it("should search with distance range", async () => {
     await tbl.createIndex("vec");
 
@@ -824,6 +833,7 @@ describe("When creating an index", () => {
     // Only build index over v1
     await tbl.createIndex("vec", {
       config: Index.ivfPq({ numPartitions: 2, numSubVectors: 2 }),
+      waitTimeoutSeconds: 30,
     });
 
     const rst = await tbl

--- a/nodejs/lancedb/indices.ts
+++ b/nodejs/lancedb/indices.ts
@@ -681,4 +681,6 @@ export interface IndexOptions {
    * The default is true
    */
   replace?: boolean;
+
+  waitTimeoutSeconds?: number;
 }

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -602,7 +602,7 @@ export class LocalTable extends Table {
     indexNames: string[],
     timeoutSeconds: number,
   ): Promise<void> {
-    await this.inner.waitforIndex(indexNames, timeoutSeconds);
+    await this.inner.waitForIndex(indexNames, timeoutSeconds);
   }
 
   query(): Query {

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -247,6 +247,19 @@ export abstract class Table {
   abstract prewarmIndex(name: string): Promise<void>;
 
   /**
+   * Waits for asynchronous indexing to complete on the table.
+   *
+   * @param indexNames The name of the indices to wait for
+   * @param timeoutSeconds The number of seconds to wait before timing out
+   *
+   * This will raise an error if the indices are not created and fully indexed within the timeout.
+   */
+  abstract waitForIndex(
+    indexNames: string[],
+    timeoutSeconds: number,
+  ): Promise<void>;
+
+  /**
    * Create a {@link Query} Builder.
    *
    * Queries allow you to search your existing data.  By default the query will
@@ -569,7 +582,12 @@ export class LocalTable extends Table {
     // Bit of a hack to get around the fact that TS has no package-scope.
     // biome-ignore lint/suspicious/noExplicitAny: skip
     const nativeIndex = (options?.config as any)?.inner;
-    await this.inner.createIndex(nativeIndex, column, options?.replace);
+    await this.inner.createIndex(
+      nativeIndex,
+      column,
+      options?.replace,
+      options?.waitTimeoutSeconds,
+    );
   }
 
   async dropIndex(name: string): Promise<void> {
@@ -578,6 +596,13 @@ export class LocalTable extends Table {
 
   async prewarmIndex(name: string): Promise<void> {
     await this.inner.prewarmIndex(name);
+  }
+
+  async waitForIndex(
+    indexNames: string[],
+    timeoutSeconds: number,
+  ): Promise<void> {
+    await this.inner.waitforIndex(indexNames, timeoutSeconds);
   }
 
   query(): Query {

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -127,7 +127,11 @@ class RemoteTable(Table):
         else:
             raise ValueError(f"Unknown index type: {index_type}")
 
-        LOOP.run(self._table.create_index(column, config=config, replace=replace, wait_timeout=wait_timeout))
+        LOOP.run(
+            self._table.create_index(
+                column, config=config, replace=replace, wait_timeout=wait_timeout
+            )
+        )
 
     def create_fts_index(
         self,
@@ -155,7 +159,11 @@ class RemoteTable(Table):
             remove_stop_words=remove_stop_words,
             ascii_folding=ascii_folding,
         )
-        LOOP.run(self._table.create_index(column, config=config, replace=replace, wait_timeout=wait_timeout))
+        LOOP.run(
+            self._table.create_index(
+                column, config=config, replace=replace, wait_timeout=wait_timeout
+            )
+        )
 
     def create_index(
         self,
@@ -239,7 +247,11 @@ class RemoteTable(Table):
                 " 'IVF_FLAT', 'IVF_PQ', 'IVF_HNSW_PQ', 'IVF_HNSW_SQ'"
             )
 
-        LOOP.run(self._table.create_index(vector_column_name, config=config, wait_timeout=wait_timeout))
+        LOOP.run(
+            self._table.create_index(
+                vector_column_name, config=config, wait_timeout=wait_timeout
+            )
+        )
 
     def add(
         self,
@@ -557,7 +569,9 @@ class RemoteTable(Table):
     def drop_index(self, index_name: str):
         return LOOP.run(self._table.drop_index(index_name))
 
-    def wait_for_index(self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)):
+    def wait_for_index(
+        self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)
+    ):
         return LOOP.run(self._table.wait_for_index(index_names, timeout))
 
     def uses_v2_manifest_paths(self) -> bool:

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -696,8 +696,9 @@ class Table(ABC):
         self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)
     ) -> None:
         """
-        Wait for indexing to complete for the given index names. This will poll the table until all the indices are
-        fully indexed, or raise a timeout exception if the timeout is reached.
+        Wait for indexing to complete for the given index names.
+        This will poll the table until all the indices are fully indexed,
+        or raise a timeout exception if the timeout is reached.
 
         Parameters
         ----------
@@ -3081,8 +3082,9 @@ class AsyncTable:
         self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)
     ) -> None:
         """
-        Wait for indexing to complete for the given index names. This will poll the table until all the indices are
-        fully indexed, or raise a timeout exception if the timeout is reached.
+        Wait for indexing to complete for the given index names.
+        This will poll the table until all the indices are fully indexed,
+        or raise a timeout exception if the timeout is reached.
 
         Parameters
         ----------

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -692,7 +692,9 @@ class Table(ABC):
         """
         raise NotImplementedError
 
-    def wait_for_index(self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)) -> None:
+    def wait_for_index(
+        self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)
+    ) -> None:
         """
         Wait for indexing to complete for the given index names. This will poll the table until all the indices are
         fully indexed, or raise a timeout exception if the timeout is reached.
@@ -1793,7 +1795,9 @@ class LanceTable(Table):
         """
         return LOOP.run(self._table.prewarm_index(name))
 
-    def wait_for_index(self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)) -> None:
+    def wait_for_index(
+        self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)
+    ) -> None:
         return LOOP.run(self._table.wait_for_index(index_names, timeout))
 
     def create_scalar_index(
@@ -3026,7 +3030,9 @@ class AsyncTable:
                     " Bitmap, LabelList, or FTS"
                 )
         try:
-            await self._inner.create_index(column, index=config, replace=replace, wait_timeout=wait_timeout)
+            await self._inner.create_index(
+                column, index=config, replace=replace, wait_timeout=wait_timeout
+            )
         except ValueError as e:
             if "not support the requested language" in str(e):
                 supported_langs = ", ".join(lang_mapping.values())
@@ -3071,7 +3077,9 @@ class AsyncTable:
         """
         await self._inner.prewarm_index(name)
 
-    async def wait_for_index(self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)) -> None:
+    async def wait_for_index(
+        self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)
+    ) -> None:
         """
         Wait for indexing to complete for the given index names. This will poll the table until all the indices are
         fully indexed, or raise a timeout exception if the timeout is reached.

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -631,6 +631,7 @@ class Table(ABC):
         index_cache_size: Optional[int] = None,
         *,
         index_type: VectorIndexType = "IVF_PQ",
+        wait_timeout: Optional[timedelta] = None,
         num_bits: int = 8,
         max_iterations: int = 50,
         sample_rate: int = 256,
@@ -666,6 +667,8 @@ class Table(ABC):
         num_bits: int
             The number of bits to encode sub-vectors. Only used with the IVF_PQ index.
             Only 4 and 8 are supported.
+        wait_timeout: timedelta, optional
+            The timeout to wait if indexing is asynchronous.
         """
         raise NotImplementedError
 
@@ -689,6 +692,20 @@ class Table(ABC):
         """
         raise NotImplementedError
 
+    def wait_for_index(self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)) -> None:
+        """
+        Wait for indexing to complete for the given index names. This will poll the table until all the indices are
+        fully indexed, or raise a timeout exception if the timeout is reached.
+
+        Parameters
+        ----------
+        index_names: str
+            The name of the indices to poll
+        timeout: timedelta
+            Timeout to wait for asynchronous indexing. The default is 5 minutes.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def create_scalar_index(
         self,
@@ -696,6 +713,7 @@ class Table(ABC):
         *,
         replace: bool = True,
         index_type: ScalarIndexType = "BTREE",
+        wait_timeout: Optional[timedelta] = None,
     ):
         """Create a scalar index on a column.
 
@@ -708,7 +726,8 @@ class Table(ABC):
             Replace the existing index if it exists.
         index_type: Literal["BTREE", "BITMAP", "LABEL_LIST"], default "BTREE"
             The type of index to create.
-
+        wait_timeout: timedelta, optional
+            The timeout to wait if indexing is asynchronous.
         Examples
         --------
 
@@ -767,6 +786,7 @@ class Table(ABC):
         stem: bool = False,
         remove_stop_words: bool = False,
         ascii_folding: bool = False,
+        wait_timeout: Optional[timedelta] = None,
     ):
         """Create a full-text search index on the table.
 
@@ -822,6 +842,8 @@ class Table(ABC):
         ascii_folding : bool, default False
             Whether to fold ASCII characters. This converts accented characters to
             their ASCII equivalent. For example, "café" would be converted to "cafe".
+        wait_timeout: timedelta, optional
+            The timeout to wait if indexing is asynchronous.
         """
         raise NotImplementedError
 
@@ -1746,6 +1768,9 @@ class LanceTable(Table):
 
     def drop_index(self, name: str) -> None:
         return LOOP.run(self._table.drop_index(name))
+
+    def wait_for_index(self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)) -> None:
+        return LOOP.run(self._table.wait_for_index(index_names, timeout))
 
     def create_scalar_index(
         self,
@@ -2940,6 +2965,7 @@ class AsyncTable:
         config: Optional[
             Union[IvfFlat, IvfPq, HnswPq, HnswSq, BTree, Bitmap, LabelList, FTS]
         ] = None,
+        wait_timeout: Optional[timedelta] = None,
     ):
         """Create an index to speed up queries
 
@@ -2964,6 +2990,8 @@ class AsyncTable:
             For advanced configuration you can specify the type of index you would
             like to create.   You can also specify index-specific parameters when
             creating an index object.
+        wait_timeout: timedelta, optional
+            The timeout to wait if indexing is asynchronous.
         """
         if config is not None:
             if not isinstance(
@@ -2974,7 +3002,7 @@ class AsyncTable:
                     " Bitmap, LabelList, or FTS"
                 )
         try:
-            await self._inner.create_index(column, index=config, replace=replace)
+            await self._inner.create_index(column, index=config, replace=replace, wait_timeout=wait_timeout)
         except ValueError as e:
             if "not support the requested language" in str(e):
                 supported_langs = ", ".join(lang_mapping.values())
@@ -3001,6 +3029,20 @@ class AsyncTable:
         of the indices.
         """
         await self._inner.drop_index(name)
+
+    async def wait_for_index(self, index_names: Iterable[str], timeout: timedelta = timedelta(seconds=300)) -> None:
+        """
+        Wait for indexing to complete for the given index names. This will poll the table until all the indices are
+        fully indexed, or raise a timeout exception if the timeout is reached.
+
+        Parameters
+        ----------
+        index_names: str
+            The name of the indices to poll
+        timeout: timedelta
+            Timeout to wait for asynchronous indexing. The default is 5 minutes.
+        """
+        await self._inner.wait_for_index(index_names, timeout)
 
     async def add(
         self,

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -236,9 +236,8 @@ def test_table_add_in_threadpool():
 def test_table_create_indices():
     def handler(request):
         index_stats = dict(
-            index_type="IVF_PQ",
-            num_indexed_rows=1000,
-            num_unindexed_rows=0)
+            index_type="IVF_PQ", num_indexed_rows=1000, num_unindexed_rows=0
+        )
 
         if request.path == "/v1/table/test/create_index/":
             request.send_response(200)
@@ -281,7 +280,7 @@ def test_table_create_indices():
                         {
                             "index_name": "vector_idx",
                             "columns": ["vector"],
-                        }
+                        },
                     ]
                 )
             )
@@ -290,25 +289,19 @@ def test_table_create_indices():
             request.send_response(200)
             request.send_header("Content-Type", "application/json")
             request.end_headers()
-            payload = json.dumps(
-                index_stats
-            )
+            payload = json.dumps(index_stats)
             request.wfile.write(payload.encode())
         elif request.path == "/v1/table/test/index/text_idx/stats/":
             request.send_response(200)
             request.send_header("Content-Type", "application/json")
             request.end_headers()
-            payload = json.dumps(
-                index_stats
-            )
+            payload = json.dumps(index_stats)
             request.wfile.write(payload.encode())
         elif request.path == "/v1/table/test/index/vector_idx/stats/":
             request.send_response(200)
             request.send_header("Content-Type", "application/json")
             request.end_headers()
-            payload = json.dumps(
-                index_stats
-            )
+            payload = json.dumps(index_stats)
             request.wfile.write(payload.encode())
         elif "/drop/" in request.path:
             request.send_response(200)
@@ -323,7 +316,9 @@ def test_table_create_indices():
         table = db.create_table("test", [{"id": 1}])
         table.create_scalar_index("id", wait_timeout=timedelta(seconds=2))
         table.create_fts_index("text", wait_timeout=timedelta(seconds=2))
-        table.create_index(vector_column_name="vector", wait_timeout=timedelta(seconds=10))
+        table.create_index(
+            vector_column_name="vector", wait_timeout=timedelta(seconds=10)
+        )
         table.wait_for_index(["id_idx"], timedelta(seconds=2))
         table.wait_for_index(["text_idx", "vector_idx"], timedelta(seconds=2))
         table.drop_index("vector_idx")
@@ -334,9 +329,8 @@ def test_table_create_indices():
 def test_table_wait_for_index_timeout():
     def handler(request):
         index_stats = dict(
-            index_type="BTREE",
-            num_indexed_rows=1000,
-            num_unindexed_rows=1)
+            index_type="BTREE", num_indexed_rows=1000, num_unindexed_rows=1
+        )
 
         if request.path == "/v1/table/test/create/?mode=create":
             request.send_response(200)
@@ -377,9 +371,7 @@ def test_table_wait_for_index_timeout():
             request.send_response(200)
             request.send_header("Content-Type", "application/json")
             request.end_headers()
-            payload = json.dumps(
-                index_stats
-            )
+            payload = json.dumps(index_stats)
             print(f"{index_stats=}")
             request.wfile.write(payload.encode())
         else:
@@ -388,7 +380,12 @@ def test_table_wait_for_index_timeout():
 
     with mock_lancedb_connection(handler) as db:
         table = db.create_table("test", [{"id": 1}])
-        with pytest.raises(RuntimeError, match=re.escape('Timeout error: timed out waiting for indices: ["id_idx"] after 1s')):
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                'Timeout error: timed out waiting for indices: ["id_idx"] after 1s'
+            ),
+        ):
             table.wait_for_index(["id_idx"], timedelta(seconds=1))
 
 

--- a/rust/lancedb/src/error.rs
+++ b/rust/lancedb/src/error.rs
@@ -35,6 +35,8 @@ pub enum Error {
     Schema { message: String },
     #[snafu(display("Runtime error: {message}"))]
     Runtime { message: String },
+    #[snafu(display("Timeout error: {message}"))]
+    Timeout { message: String },
 
     // 3rd party / external errors
     #[snafu(display("object_store error: {source}"))]

--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -97,7 +97,7 @@ impl IndexBuilder {
     /// Duration of time to wait for asynchronous indexing to complete. If not set,
     /// `create_index()` will not wait.
     ///
-    /// This is ignored for `NativeTable` since indexing is synchronous.
+    /// This is not supported for `NativeTable` since indexing is synchronous.
     pub fn wait_timeout(mut self, d: Duration) -> Self {
         self.wait_timeout = Some(d);
         self

--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -17,6 +17,7 @@ use self::{
 
 pub mod scalar;
 pub mod vector;
+pub mod waiter;
 
 /// Supported index types.
 #[derive(Debug, Clone)]

--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-use std::sync::Arc;
-use std::time::Duration;
 use scalar::FtsIndexBuilder;
 use serde::Deserialize;
 use serde_with::skip_serializing_none;
+use std::sync::Arc;
+use std::time::Duration;
 use vector::IvfFlatIndexBuilder;
 
 use crate::{table::BaseTable, DistanceType, Error, Result};

--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use std::sync::Arc;
-
+use std::time::Duration;
 use scalar::FtsIndexBuilder;
 use serde::Deserialize;
 use serde_with::skip_serializing_none;
@@ -70,6 +70,7 @@ pub struct IndexBuilder {
     pub(crate) index: Index,
     pub(crate) columns: Vec<String>,
     pub(crate) replace: bool,
+    pub(crate) wait_timeout: Option<Duration>,
 }
 
 impl IndexBuilder {
@@ -79,6 +80,7 @@ impl IndexBuilder {
             index,
             columns,
             replace: true,
+            wait_timeout: None,
         }
     }
 
@@ -89,6 +91,15 @@ impl IndexBuilder {
     /// that index is out of date.
     pub fn replace(mut self, v: bool) -> Self {
         self.replace = v;
+        self
+    }
+
+    /// Duration of time to wait for asynchronous indexing to complete. If not set,
+    /// `create_index()` will not wait.
+    ///
+    /// This is ignored for `NativeTable` since indexing is synchronous.
+    pub fn wait_timeout(mut self, d: Duration) -> Self {
+        self.wait_timeout = Some(d);
         self
     }
 

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -36,7 +36,7 @@ pub async fn wait_for_index(
         let mut completed = vec![];
         let indices = table.list_indices().await?;
 
-        for idx in remaining {
+        for &idx in &remaining {
             if !indices.iter().any(|i| i.name == *idx) {
                 debug!("still waiting for new index '{}'", idx);
                 continue;
@@ -73,13 +73,12 @@ pub async fn wait_for_index(
         sleep(Duration::from_millis(DEFAULT_SLEEP_MS)).await;
     }
 
-    // debug log some diagnostics
-    for r in &remaining {
+    // debug log index diagnostics
+    for &r in &remaining {
         let stats = table.index_stats(r.as_ref()).await?;
-        if let Some(s) = stats {
-            debug!("index {} not fully indexed after {:?}. stats: {:?}", r, timeout, s)
-        } else {
-            debug!("index {} not found after {:?}", r, timeout)
+        match stats {
+            Some(s) => debug!("index '{}' not fully indexed after {:?}. stats: {:?}", r, timeout, s),
+            None => debug!("index '{}' not found after {:?}", r, timeout),
         }
     }
 

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -36,7 +36,7 @@ pub async fn wait_for_index(
         let mut completed = vec![];
         let indices = table.list_indices().await?;
 
-        for idx in index_names {
+        for idx in remaining {
             if !indices.iter().any(|i| i.name == *idx) {
                 debug!("still waiting for new index '{}'", idx);
                 continue;

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -7,8 +7,8 @@ use crate::Error;
 use log::debug;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
-/// Poll until the columns are fully indexed. Will return Error::Timeout if the columns
-/// are not fully indexed within the timeout.
+/// Poll the table using list_indices() and index_stats() until all of the indices have 0 un-indexed rows.
+/// Will return Error::Timeout if the columns are not fully indexed within the timeout.
 pub async fn wait_for_index(
     table: &dyn BaseTable,
     index_names: &[&str],

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -2,15 +2,15 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use crate::error::Result;
+use crate::index::IndexStatistics;
 use crate::table::BaseTable;
 use crate::Error;
-use log::{debug};
+use log::debug;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
-use crate::index::IndexStatistics;
 
 const DEFAULT_SLEEP_MS: u64 = 1000;
-const MAX_WAIT: Duration = Duration::from_secs(2 * 60  * 60);
+const MAX_WAIT: Duration = Duration::from_secs(2 * 60 * 60);
 
 /// Poll the table using list_indices() and index_stats() until all of the indices have 0 un-indexed rows.
 /// Will return Error::Timeout if the columns are not fully indexed within the timeout.
@@ -21,11 +21,7 @@ pub async fn wait_for_index(
 ) -> Result<()> {
     if timeout > MAX_WAIT {
         return Err(Error::InvalidInput {
-            message: format!(
-                "timeout must be less than {:?}",
-                MAX_WAIT
-            )
-            .to_string(),
+            message: format!("timeout must be less than {:?}", MAX_WAIT).to_string(),
         });
     }
     let start = Instant::now();
@@ -77,7 +73,10 @@ pub async fn wait_for_index(
     for &r in &remaining {
         let stats = table.index_stats(r.as_ref()).await?;
         match stats {
-            Some(s) => debug!("index '{}' not fully indexed after {:?}. stats: {:?}", r, timeout, s),
+            Some(s) => debug!(
+                "index '{}' not fully indexed after {:?}. stats: {:?}",
+                r, timeout, s
+            ),
             None => debug!("index '{}' not found after {:?}", r, timeout),
         }
     }

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use crate::error::Result;
-use crate::index::IndexStatistics;
 use crate::table::BaseTable;
 use crate::Error;
 use log::debug;
@@ -62,7 +61,7 @@ pub async fn wait_for_index(
                 }
             }
         }
-        remaining.retain(|idx| !completed.contains(&idx));
+        remaining.retain(|idx| !completed.contains(idx));
         if remaining.is_empty() {
             return Ok(());
         }

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -1,0 +1,51 @@
+use std::time::{Duration, Instant};
+use log::debug;
+use tokio::time::sleep;
+use crate::Error;
+use crate::table::BaseTable;
+use crate::{
+    error::Result,
+};
+/// Poll until the columns are fully indexed. Will return Error::Timeout if the columns
+/// are not fully indexed within the timeout.
+pub async fn wait_for_index(table: &dyn BaseTable, index_names: &[&str], timeout: Duration) -> Result<()>{
+    let start = Instant::now();
+    let mut remaining = index_names.to_vec();
+
+    // poll via list_indices() and index_stats() until all indices are created and fully indexed
+    while start.elapsed() < timeout {
+        let mut completed = vec![];
+        let indices = table.list_indices().await?;
+
+        for idx in index_names {
+            if let None = indices.iter().find(|i| i.name == *idx) {
+                debug!("still waiting for new index '{}'", idx);
+                continue;
+            }
+
+            let stats = table.index_stats(idx.as_ref()).await?;
+            match stats {
+                None => {
+                    debug!("still waiting for new index '{}'", idx);
+                    continue;
+                },
+                Some(s) => {
+                    if s.num_unindexed_rows == 0 {
+                        completed.push(idx);
+                        debug!("fully indexed '{}'. indexed rows: {}", idx, s.num_indexed_rows);
+                    } else {
+                        debug!("still waiting for index '{}'. unindexed rows: {}", idx, s.num_unindexed_rows);
+                    }
+                }
+            }
+        }
+        remaining.retain(|idx| !completed.contains(&idx));
+        if remaining.is_empty() {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(1000)).await;
+    }
+    Err(Error::Timeout {
+        message: format!("timed out waiting for indices: {:?} after {:?}", remaining, timeout).to_string()
+    })
+}

--- a/rust/lancedb/src/index/waiter.rs
+++ b/rust/lancedb/src/index/waiter.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
 use crate::error::Result;
 use crate::table::BaseTable;
 use crate::Error;

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -800,6 +800,11 @@ impl<S: HttpSend> BaseTable for RemoteTable<S> {
 
         self.check_table_response(&request_id, response).await?;
 
+        if let Some(wait_timeout) = index.wait_timeout {
+            let name = format!("{}_idx", column);
+            self.wait_for_index(&[&name], wait_timeout).await?;
+        }
+
         Ok(())
     }
 

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -2509,10 +2509,7 @@ mod tests {
             };
             let body = serde_json::to_string(&response_body).unwrap();
             let status = if body == "null" { 404 } else { 200 };
-            http::Response::builder()
-                .status(status)
-                .body(body)
-                .unwrap()
+            http::Response::builder().status(status).body(body).unwrap()
         });
         table
     }

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -1078,7 +1078,6 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use chrono::{DateTime, Utc};
     use futures::{future::BoxFuture, StreamExt, TryFutureExt};
-    use http::Response;
     use lance_index::scalar::inverted::query::MatchQuery;
     use lance_index::scalar::FullTextSearchQuery;
     use reqwest::Body;
@@ -2503,7 +2502,7 @@ mod tests {
                         "index_type": "LABEL_LIST"
                     })
                 }
-                path => {
+                _path => {
                     serde_json::json!(None::<String>)
                 }
             };

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -2009,12 +2009,6 @@ impl BaseTable for NativeTable {
                 message: "Multi-column (composite) indices are not yet supported".to_string(),
             });
         }
-        if opts.wait_timeout.is_some() {
-            return Err(Error::InvalidInput {
-                message: "wait_timeout must be None for NativeTable".to_string(),
-            });
-        }
-
         let schema = self.schema().await?;
 
         let field = schema.field_with_name(&opts.columns[0])?;

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -775,6 +775,23 @@ impl Table {
         )
     }
 
+    /// See [Table::create_index]
+    /// For remote tables, this allows an optional wait_timeout to poll until asynchronous indexing is complete
+    pub fn create_index_with_timeout(&self, columns: &[impl AsRef<str>], index: Index, wait_timeout: Option<std::time::Duration>) -> IndexBuilder {
+        let mut builder = IndexBuilder::new(
+            self.inner.clone(),
+            columns
+                .iter()
+                .map(|val| val.as_ref().to_string())
+                .collect::<Vec<_>>(),
+            index,
+        );
+        if let Some(timeout) = wait_timeout {
+            builder = builder.wait_timeout(timeout);
+        }
+        builder
+    }
+
     /// Create a builder for a merge insert operation
     ///
     /// This operation can add rows, update rows, and remove rows all in a single
@@ -3479,7 +3496,7 @@ mod tests {
             .unwrap();
 
         table
-            .create_index(&["text"], Index::FTS(Default::default()))
+            .create_index_with_timeout(&["text"], Index::FTS(Default::default()))
             .execute()
             .await
             .unwrap();

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1985,6 +1985,12 @@ impl BaseTable for NativeTable {
                 message: "Multi-column (composite) indices are not yet supported".to_string(),
             });
         }
+        if let Some(_) = opts.wait_timeout {
+            return Err(Error::InvalidInput {
+                message: "wait_timeout must be None for NativeTable".to_string(),
+            });
+        }
+
         let schema = self.schema().await?;
 
         let field = schema.field_with_name(&opts.columns[0])?;

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -779,7 +779,12 @@ impl Table {
 
     /// See [Table::create_index]
     /// For remote tables, this allows an optional wait_timeout to poll until asynchronous indexing is complete
-    pub fn create_index_with_timeout(&self, columns: &[impl AsRef<str>], index: Index, wait_timeout: Option<std::time::Duration>) -> IndexBuilder {
+    pub fn create_index_with_timeout(
+        &self,
+        columns: &[impl AsRef<str>],
+        index: Index,
+        wait_timeout: Option<std::time::Duration>,
+    ) -> IndexBuilder {
         let mut builder = IndexBuilder::new(
             self.inner.clone(),
             columns

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -3496,7 +3496,7 @@ mod tests {
             .unwrap();
 
         table
-            .create_index_with_timeout(&["text"], Index::FTS(Default::default()))
+            .create_index(&["text"], Index::FTS(Default::default()))
             .execute()
             .await
             .unwrap();


### PR DESCRIPTION
* Add new wait_for_index() table operation that polls until indices are created/fully indexed
* Add an optional wait timeout parameter to all create_index operations
* Python and NodeJS interfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added optional waiting for index creation completion with configurable timeout.
  - Introduced methods to poll and wait for indices to be fully built across sync and async tables.
  - Extended index creation APIs to accept a wait timeout parameter.
- **Bug Fixes**
  - Added a new timeout error variant for improved error reporting on index operations.
- **Tests**
  - Added tests covering successful index readiness waiting, timeout scenarios, and missing index cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->