### PR TITLE
fix(python): make sure pandas is optional

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -138,7 +138,7 @@ jobs:
           integration: true
       - name: Test without pylance
         run: |
-          pip uninstall -y pylance
+          pip uninstall -y pylance pandas
           pytest -vv python/tests/test_table.py
       # Make sure wheels are not included in the Rust cache
       - name: Delete wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: ./.github/workflows/run_tests
         with:
           integration: true
-      - name: Test without pylance
+      - name: Test without pylance or pandas
         run: |
           pip uninstall -y pylance pandas
           pytest -vv python/tests/test_table.py

--- a/python/python/lancedb/common.py
+++ b/python/python/lancedb/common.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.dataset
 
-from .dependencies import pandas as pd
+from .dependencies import _check_for_pandas, pandas as pd
 
 DATA = Union[List[dict], "pd.DataFrame", pa.Table, Iterable[pa.RecordBatch]]
 VEC = Union[list, np.ndarray, pa.Array, pa.ChunkedArray]
@@ -63,7 +63,7 @@ def data_to_reader(
     data: DATA, schema: Optional[pa.Schema] = None
 ) -> pa.RecordBatchReader:
     """Convert various types of input into a RecordBatchReader"""
-    if pd is not None and isinstance(data, pd.DataFrame):
+    if _check_for_pandas(data) and isinstance(data, pd.DataFrame):
         return pa.Table.from_pandas(data, schema=schema).to_reader()
     elif isinstance(data, pa.Table):
         return data.to_reader()


### PR DESCRIPTION
Fixes #2344


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated tests to use PyArrow Tables instead of pandas DataFrames where possible, reducing reliance on pandas.
  - Tests that require pandas are now automatically skipped if pandas is not installed.
- **Chores**
  - Improved workflow to uninstall both pylance and pandas in a specific test step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->