### PR TITLE
fix: move timeout to avoid retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.7"
+version = "0.22.0-beta.8"
 dependencies = [
  "arrow",
  "env_logger",

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -364,10 +364,10 @@ impl<S: HttpSend> RemoteTable<S> {
             tokio::pin!(streams);
             tokio::select! {
                 _ = &mut timeout_future => {
-                    return Err(Error::Other {
+                    Err(Error::Other {
                         message: format!("Query timeout after {} ms", timeout.as_millis()),
                         source: None,
-                    });
+                    })
                 }
                 result = &mut streams => {
                     Ok(result?)


### PR DESCRIPTION
I added a timeout to query execution options in https://github.com/lancedb/lancedb/pull/2288. However, this was send to the request timeout, but the retry implementation is unaware of this timeout. So once the query timed out, a retry would be triggered. Instead, this PR changes it so the timeout happens outside the retry loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query timeout handling to provide clearer error messages and more reliable cancellation if a query takes too long to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->