### PR TITLE
fix: remote limit to avoid "Limit must be non-negative"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.9"
+version = "0.19.0-beta.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.9"
+version = "0.19.0-beta.10"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.9"
+version = "0.19.0-beta.10"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.9"
+version = "0.22.0-beta.10"
 dependencies = [
  "arrow",
  "env_logger",

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -224,7 +224,8 @@ impl<S: HttpSend> RemoteTable<S> {
         }
 
         // Server requires k.
-        let limit = params.limit.unwrap_or(usize::MAX);
+        // use isize::MAX as usize to avoid overflow: https://github.com/lancedb/lancedb/issues/2211
+        let limit = params.limit.unwrap_or(isize::MAX as usize);
         body["k"] = serde_json::Value::Number(serde_json::Number::from(limit));
 
         if let Some(filter) = &params.filter {
@@ -1616,7 +1617,7 @@ mod tests {
             let body = request.body().unwrap().as_bytes().unwrap();
             let body: serde_json::Value = serde_json::from_slice(body).unwrap();
             let expected_body = serde_json::json!({
-                "k": usize::MAX,
+                "k": isize::MAX as usize,
                 "prefilter": true,
                 "vector": [], // Empty vector means no vector query.
                 "version": null,


### PR DESCRIPTION
To workaround this issue: https://github.com/lancedb/lancedb/issues/2211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of large query parameters to prevent potential overflow issues when using the "k" parameter in queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->