### PR TITLE
fix: sync hybrid search ignores the distance range params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-node"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-nodejs"
-version = "0.19.0-beta.7"
+version = "0.19.0-beta.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.22.0-beta.7"
+version = "0.22.0-beta.8"
 dependencies = [
  "arrow",
  "env_logger",

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -1586,6 +1586,8 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
         self._refine_factor = None
         self._distance_type = None
         self._phrase_query = None
+        self._lower_bound = None
+        self._upper_bound = None
 
     def _validate_query(self, query, vector=None, text=None):
         if query is not None and (vector is not None or text is not None):
@@ -1665,6 +1667,10 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
             self._vector_query.ef(self._ef)
         if self._bypass_vector_index:
             self._vector_query.bypass_vector_index()
+        if self._lower_bound or self._upper_bound:
+            self._vector_query.distance_range(
+                lower_bound=self._lower_bound, upper_bound=self._upper_bound
+            )
 
         if self._reranker is None:
             self._reranker = RRFReranker()

--- a/python/python/tests/test_hybrid_query.py
+++ b/python/python/tests/test_hybrid_query.py
@@ -126,14 +126,12 @@ def test_hybrid_query_distance_range(sync_table: Table):
     result = (
         sync_table.search(query_type="hybrid")
         .vector([0.0, 0.4])
-        .text("dog")
+        .text("cat and dog")
         .distance_range(lower_bound=0.2, upper_bound=0.5)
         .rerank(reranker)
         .limit(2)
         .to_arrow()
     )
-    # the distances are [0.1, 0.26, 1.06, 6.56]
-    # so we should get 0.26 and 1.06
     assert len(result) == 2
     print(result)
     for dist in result["_distance"]:

--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -652,6 +652,11 @@ impl HybridQuery {
         self.inner_vec.bypass_vector_index();
     }
 
+    #[pyo3(signature = (lower_bound=None, upper_bound=None))]
+    pub fn distance_range(&mut self, lower_bound: Option<f32>, upper_bound: Option<f32>) {
+        self.inner_vec.distance_range(lower_bound, upper_bound);
+    }
+
     pub fn to_vector_query(&mut self) -> PyResult<VectorQuery> {
         Ok(VectorQuery {
             inner: self.inner_vec.inner.clone(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for distance range filtering in hybrid vector queries, allowing users to specify lower and upper bounds for search results.

- **Tests**
  - Introduced new tests to validate distance range filtering and reranking in both synchronous and asynchronous hybrid query scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->