### PR TITLE
feat: provide timeout parameter for merge_insert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,7 +2738,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 [[package]]
 name = "fsst"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "lance"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "lance-core"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "lance-datafusion"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "lance-datagen"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "lance-encoding"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "lance-file"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "lance-index"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "lance-io"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "lance-linalg"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "lance-table"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "lance-testing"
 version = "0.27.0"
-source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.2#cf903b470be1aaff2998830bd0358226f27f4185"
+source = "git+https://github.com/lancedb/lance.git?tag=v0.27.0-beta.5#80a3f8796aee814c60cbdc94179b4e6231fa54e4"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ categories = ["database-implementations"]
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-lance = { "version" = "=0.27.0", "features" = ["dynamodb"], tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
-lance-io = { version = "=0.27.0", tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
-lance-index = { version = "=0.27.0", tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
-lance-linalg = { version = "=0.27.0", tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
-lance-table = { version = "=0.27.0", tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
-lance-testing = { version = "=0.27.0", tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
-lance-datafusion = { version = "=0.27.0", tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
-lance-encoding = { version = "=0.27.0", tag = "v0.27.0-beta.2", git="https://github.com/lancedb/lance.git" }
+lance = { "version" = "=0.27.0", "features" = ["dynamodb"], tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
+lance-io = { version = "=0.27.0", tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
+lance-index = { version = "=0.27.0", tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
+lance-linalg = { version = "=0.27.0", tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
+lance-table = { version = "=0.27.0", tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
+lance-testing = { version = "=0.27.0", tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
+lance-datafusion = { version = "=0.27.0", tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
+lance-encoding = { version = "=0.27.0", tag = "v0.27.0-beta.5", git="https://github.com/lancedb/lance.git" }
 # Note that this one does not include pyarrow
 arrow = { version = "54.1", optional = false }
 arrow-array = "54.1"

--- a/docs/src/js/classes/MergeInsertBuilder.md
+++ b/docs/src/js/classes/MergeInsertBuilder.md
@@ -33,7 +33,7 @@ Construct a MergeInsertBuilder. __Internal use only.__
 ### execute()
 
 ```ts
-execute(data): Promise<MergeResult>
+execute(data, execOptions?): Promise<MergeResult>
 ```
 
 Executes the merge insert operation
@@ -41,6 +41,8 @@ Executes the merge insert operation
 #### Parameters
 
 * **data**: [`Data`](../type-aliases/Data.md)
+
+* **execOptions?**: `Partial`&lt;[`WriteExecutionOptions`](../interfaces/WriteExecutionOptions.md)&gt;
 
 #### Returns
 

--- a/docs/src/js/globals.md
+++ b/docs/src/js/globals.md
@@ -72,6 +72,7 @@
 - [UpdateOptions](interfaces/UpdateOptions.md)
 - [UpdateResult](interfaces/UpdateResult.md)
 - [Version](interfaces/Version.md)
+- [WriteExecutionOptions](interfaces/WriteExecutionOptions.md)
 
 ## Type Aliases
 

--- a/docs/src/js/interfaces/WriteExecutionOptions.md
+++ b/docs/src/js/interfaces/WriteExecutionOptions.md
@@ -14,6 +14,13 @@
 optional timeoutMs: number;
 ```
 
-Maximum time (in milliseconds) to run the operation before cancelling it.
-Default is no timeout for first attempt, but an overall timeout of
-30 seconds is applied after that.
+Maximum time to run the operation before cancelling it.
+
+By default, there is a 30-second timeout that is only enforced after the
+first attempt. This is to prevent spending too long retrying to resolve
+conflicts. For example, if a write attempt takes 20 seconds and fails,
+the second attempt will be cancelled after 10 seconds, hitting the
+30-second timeout. However, a write that takes one hour and succeeds on the
+first attempt will not be cancelled.
+
+When this is set, the timeout is enforced on all attempts, including the first.

--- a/docs/src/js/interfaces/WriteExecutionOptions.md
+++ b/docs/src/js/interfaces/WriteExecutionOptions.md
@@ -1,0 +1,19 @@
+[**@lancedb/lancedb**](../README.md) • **Docs**
+
+***
+
+[@lancedb/lancedb](../globals.md) / WriteExecutionOptions
+
+# Interface: WriteExecutionOptions
+
+## Properties
+
+### timeoutMs?
+
+```ts
+optional timeoutMs: number;
+```
+
+Maximum time (in milliseconds) to run the operation before cancelling it.
+Default is no timeout for first attempt, but an overall timeout of
+30 seconds is applied after that.

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -349,7 +349,7 @@ describe("merge insert", () => {
       .mergeInsert("a")
       .whenMatchedUpdateAll()
       .whenNotMatchedInsertAll()
-      .execute(newData);
+      .execute(newData, { timeoutMs: 10_000 });
     expect(mergeInsertRes).toHaveProperty("version");
     expect(mergeInsertRes.version).toBe(2);
     expect(mergeInsertRes.numInsertedRows).toBe(1);
@@ -462,6 +462,20 @@ describe("merge insert", () => {
     );
     res = res.sort((a, b) => a.a - b.a);
     expect(res).toEqual(expected);
+  });
+
+  test("timeout", async () => {
+    const newData = [
+      { a: 2, b: "x" },
+      { a: 4, b: "z" },
+    ];
+    await expect(
+      table
+        .mergeInsert("a")
+        .whenMatchedUpdateAll()
+        .whenNotMatchedInsertAll()
+        .execute(newData, { timeoutMs: 0 }),
+    ).rejects.toThrow("merge insert timed out");
   });
 });
 

--- a/nodejs/lancedb/index.ts
+++ b/nodejs/lancedb/index.ts
@@ -86,7 +86,7 @@ export {
   ColumnAlteration,
 } from "./table";
 
-export { MergeInsertBuilder } from "./merge";
+export { MergeInsertBuilder, WriteExecutionOptions } from "./merge";
 
 export * as embedding from "./embedding";
 export * as rerankers from "./rerankers";

--- a/nodejs/lancedb/merge.ts
+++ b/nodejs/lancedb/merge.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
-import { exec } from "child_process";
 import { Data, Schema, fromDataToBuffer } from "./arrow";
 import { MergeResult, NativeMergeInsertBuilder } from "./native";
 

--- a/nodejs/lancedb/merge.ts
+++ b/nodejs/lancedb/merge.ts
@@ -98,9 +98,16 @@ export class MergeInsertBuilder {
 
 export interface WriteExecutionOptions {
   /**
-   * Maximum time (in milliseconds) to run the operation before cancelling it.
-   * Default is no timeout for first attempt, but an overall timeout of
-   * 30 seconds is applied after that.
+   * Maximum time to run the operation before cancelling it.
+   *
+   * By default, there is a 30-second timeout that is only enforced after the
+   * first attempt. This is to prevent spending too long retrying to resolve
+   * conflicts. For example, if a write attempt takes 20 seconds and fails,
+   * the second attempt will be cancelled after 10 seconds, hitting the
+   * 30-second timeout. However, a write that takes one hour and succeeds on the
+   * first attempt will not be cancelled.
+   *
+   * When this is set, the timeout is enforced on all attempts, including the first.
    */
   timeoutMs?: number;
 }

--- a/nodejs/src/merge.rs
+++ b/nodejs/src/merge.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
+use std::time::Duration;
+
 use lancedb::{arrow::IntoArrow, ipc::ipc_file_to_batches, table::merge::MergeInsertBuilder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -34,6 +36,11 @@ impl NativeMergeInsertBuilder {
         let mut this = self.clone();
         this.inner.when_not_matched_by_source_delete(filter);
         this
+    }
+
+    #[napi]
+    pub fn set_timeout(&mut self, timeout: u32) {
+        self.inner.timeout(Duration::from_millis(timeout as u64));
     }
 
     #[napi(catch_unwind)]

--- a/python/python/lancedb/merge.py
+++ b/python/python/lancedb/merge.py
@@ -102,9 +102,17 @@ class LanceMergeInsertBuilder(object):
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         timeout: Optional[timedelta], default None
-            Maximum time to run the operation before cancelling it. Default is
-            no timeout for first attempt, but an overall timeout of 30 seconds
-            is applied after that.
+            Maximum time to run the operation before cancelling it.
+
+            By default, there is a 30-second timeout that is only enforced after the
+            first attempt. This is to prevent spending too long retrying to resolve
+            conflicts. For example, if a write attempt takes 20 seconds and fails,
+            the second attempt will be cancelled after 10 seconds, hitting the
+            30-second timeout. However, a write that takes one hour and succeeds on the
+            first attempt will not be cancelled.
+
+            When this is set, the timeout is enforced on all attempts, including
+            the first.
 
         Returns
         -------

--- a/python/python/lancedb/merge.py
+++ b/python/python/lancedb/merge.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
@@ -31,6 +32,7 @@ class LanceMergeInsertBuilder(object):
         self._when_not_matched_insert_all = False
         self._when_not_matched_by_source_delete = False
         self._when_not_matched_by_source_condition = None
+        self._timeout = None
 
     def when_matched_update_all(
         self, *, where: Optional[str] = None
@@ -81,6 +83,7 @@ class LanceMergeInsertBuilder(object):
         new_data: DATA,
         on_bad_vectors: str = "error",
         fill_value: float = 0.0,
+        timeout: Optional[timedelta] = None,
     ) -> MergeInsertResult:
         """
         Executes the merge insert operation
@@ -98,10 +101,16 @@ class LanceMergeInsertBuilder(object):
             One of "error", "drop", "fill".
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
+        timeout: Optional[timedelta], default None
+            Maximum time to run the operation before cancelling it. Default is
+            no timeout for first attempt, but an overall timeout of 30 seconds
+            is applied after that.
 
         Returns
         -------
         MergeInsertResult
             version: the new version number of the table after doing merge insert.
         """
+        if timeout is not None:
+            self._timeout = timeout
         return self._table._do_merge(self, new_data, on_bad_vectors, fill_value)

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -3715,6 +3715,7 @@ class AsyncTable:
                 when_not_matched_insert_all=merge._when_not_matched_insert_all,
                 when_not_matched_by_source_delete=merge._when_not_matched_by_source_delete,
                 when_not_matched_by_source_condition=merge._when_not_matched_by_source_condition,
+                timeout=merge._timeout,
             ),
         )
 

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -937,7 +937,7 @@ def test_merge_insert(mem_db: DBConnection):
         table.merge_insert("a")
         .when_matched_update_all()
         .when_not_matched_insert_all()
-        .execute(new_data)
+        .execute(new_data, timeout=timedelta(seconds=10))
     )
     assert merge_insert_res.version == 2
     assert merge_insert_res.num_inserted_rows == 1
@@ -1012,6 +1012,12 @@ def test_merge_insert(mem_db: DBConnection):
 
     expected = pa.table({"a": [2, 4], "b": ["x", "z"]})
     assert table.to_arrow().sort_by("a") == expected
+
+    # timeout
+    with pytest.raises(Exception, match="merge insert timed out"):
+        table.merge_insert("a").when_matched_update_all().execute(
+            new_data, timeout=timedelta(0)
+        )
 
 
 # We vary the data format because there are slight differences in how

--- a/python/src/table.rs
+++ b/python/src/table.rs
@@ -649,6 +649,9 @@ impl Table {
             builder
                 .when_not_matched_by_source_delete(parameters.when_not_matched_by_source_condition);
         }
+        if let Some(timeout) = parameters.timeout {
+            builder.timeout(timeout);
+        }
 
         future_into_py(self_.py(), async move {
             let res = builder.execute(Box::new(batches)).await.infer_error()?;
@@ -807,6 +810,7 @@ pub struct MergeInsertParams {
     when_not_matched_insert_all: bool,
     when_not_matched_by_source_delete: bool,
     when_not_matched_by_source_condition: Option<String>,
+    timeout: Option<std::time::Duration>,
 }
 
 #[pyclass]

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -2014,7 +2014,7 @@ impl NativeTable {
     /// more information.
     pub async fn uses_v2_manifest_paths(&self) -> Result<bool> {
         let dataset = self.dataset.get().await?;
-        Ok(dataset.manifest_naming_scheme == ManifestNamingScheme::V2)
+        Ok(dataset.manifest_location().naming_scheme == ManifestNamingScheme::V2)
     }
 
     /// Migrate the table to use the new manifest path scheme.

--- a/rust/lancedb/src/table/merge.rs
+++ b/rust/lancedb/src/table/merge.rs
@@ -88,8 +88,14 @@ impl MergeInsertBuilder {
 
     /// Maximum time to run the operation before cancelling it.
     ///
-    /// Default is no timeout for first attempt, but an overall timeout of 30
-    /// seconds is applied after that.
+    /// By default, there is a 30-second timeout that is only enforced after the
+    /// first attempt. This is to prevent spending too long retrying to resolve
+    /// conflicts. For example, if a write attempt takes 20 seconds and fails,
+    /// the second attempt will be cancelled after 10 seconds, hitting the
+    /// 30-second timeout. However, a write that takes one hour and succeeds on the
+    /// first attempt will not be cancelled.
+    ///
+    /// When this is set, the timeout is enforced on all attempts, including the first.
     pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
         self.timeout = Some(timeout);
         self

--- a/rust/lancedb/src/table/merge.rs
+++ b/rust/lancedb/src/table/merge.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use arrow_array::RecordBatchReader;
 
@@ -21,6 +21,7 @@ pub struct MergeInsertBuilder {
     pub(crate) when_not_matched_insert_all: bool,
     pub(crate) when_not_matched_by_source_delete: bool,
     pub(crate) when_not_matched_by_source_delete_filt: Option<String>,
+    pub(crate) timeout: Option<Duration>,
 }
 
 impl MergeInsertBuilder {
@@ -33,6 +34,7 @@ impl MergeInsertBuilder {
             when_not_matched_insert_all: false,
             when_not_matched_by_source_delete: false,
             when_not_matched_by_source_delete_filt: None,
+            timeout: None,
         }
     }
 
@@ -81,6 +83,15 @@ impl MergeInsertBuilder {
     pub fn when_not_matched_by_source_delete(&mut self, filter: Option<String>) -> &mut Self {
         self.when_not_matched_by_source_delete = true;
         self.when_not_matched_by_source_delete_filt = filter;
+        self
+    }
+
+    /// Maximum time to run the operation before cancelling it.
+    ///
+    /// Default is no timeout for first attempt, but an overall timeout of 30
+    /// seconds is applied after that.
+    pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.timeout = Some(timeout);
         self
     }
 


### PR DESCRIPTION
Provides the ability to set a timeout for merge insert. The default underlying timeout is however long the first attempt takes, or if there are multiple attempts, 30 seconds. This has two use cases:

1. Make the timeout shorter, when you want to fail if it takes too long.
2. Allow taking more time to do retries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a timeout when performing merge insert operations in Python, Node.js, and Rust APIs.
  - Introduced a new option to control the maximum allowed execution time for merge inserts, including retry timeout handling.

- **Documentation**
  - Updated and added documentation to describe the new timeout option and its usage in APIs.

- **Tests**
  - Added and updated tests to verify correct timeout behavior during merge insert operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->