### PR TITLE
fix: support __len__ on remote table

### DIFF
--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -47,9 +47,6 @@ class RemoteTable(Table):
     def __repr__(self) -> str:
         return f"RemoteTable({self.db_name}.{self.name})"
 
-    def __len__(self) -> int:
-        self.count_rows(None)
-
     @property
     def schema(self) -> pa.Schema:
         """The [Arrow Schema](https://arrow.apache.org/docs/python/api/datatypes.html#)

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -620,6 +620,10 @@ class Table(ABC):
         """
         raise NotImplementedError
 
+    def __len__(self) -> int:
+        """The number of rows in this Table"""
+        return self.count_rows(None)
+
     @property
     @abstractmethod
     def embedding_functions(self) -> Dict[str, EmbeddingFunctionConfig]:
@@ -1761,9 +1765,6 @@ class LanceTable(Table):
 
     def count_rows(self, filter: Optional[str] = None) -> int:
         return LOOP.run(self._table.count_rows(filter))
-
-    def __len__(self) -> int:
-        return self.count_rows()
 
     def __repr__(self) -> str:
         val = f"{self.__class__.__name__}(name={self.name!r}, version={self.version}"

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -149,6 +149,24 @@ async def test_async_checkout():
         assert await table.count_rows() == 300
 
 
+def test_table_len_sync():
+    def handler(request):
+        if request.path == "/v1/table/test/create/?mode=create":
+            request.send_response(200)
+            request.send_header("Content-Type", "application/json")
+            request.end_headers()
+            request.wfile.write(b"{}")
+
+        request.send_response(200)
+        request.send_header("Content-Type", "application/json")
+        request.end_headers()
+        request.wfile.write(json.dumps(1).encode())
+
+    with mock_lancedb_connection(handler) as db:
+        table = db.create_table("test", [{"id": 1}])
+        assert len(table) == 1
+
+
 @pytest.mark.asyncio
 async def test_http_error():
     request_id_holder = {"request_id": None}


### PR DESCRIPTION
This moves the __len__ method from LanceTable and RemoteTable to Table so that child classes don't need to implement their own. In the process, it fixes the implementation of RemoteTable's length method, which was previously missing a return statement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized the table length functionality in the base table class, simplifying subclass behavior.
  - Removed redundant or non-functional length methods from specific table classes.

- **Tests**
  - Added a new test to verify correct table length reporting for remote tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->