### PR TITLE
docs: add logos in genkit docs page

### DIFF
--- a/docs/src/integrations/genkit.md
+++ b/docs/src/integrations/genkit.md
@@ -1,6 +1,8 @@
 ### genkitx-lancedb
 This is a lancedb plugin for genkit framework. It allows you to use LanceDB for ingesting and rereiving data using genkit framework.
 
+![integration-banner-genkit](https://github.com/user-attachments/assets/a6cc28af-98e9-4425-b87c-7ab139bd7893)
+
 ### Installation
 ```bash
 pnpm install genkitx-lancedb


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an integration banner image to the beginning of the Genkitx-LanceDB documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->