### PR TITLE
feat(python): handle strenum in pydantic

### DIFF
--- a/python/python/lancedb/pydantic.py
+++ b/python/python/lancedb/pydantic.py
@@ -28,6 +28,12 @@ import pyarrow as pa
 import pydantic
 from packaging.version import Version
 
+# StrEnum was introduced in 3.11
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    StrEnum = None  # type: ignore
+
 PYDANTIC_VERSION = Version(pydantic.__version__)
 try:
     from pydantic_core import CoreSchema, core_schema
@@ -262,8 +268,8 @@ def _py_type_to_arrow_type(py_type: Type[Any], field: FieldInfo) -> pa.DataType:
         return pa.int64()
     elif py_type is float:
         return pa.float64()
-    elif py_type is str:
-        return pa.utf8()
+    elif py_type is str or (StrEnum is not None and issubclass(py_type, StrEnum)):
+        return pa.dictionary(pa.int16(), pa.string())
     elif py_type is bool:
         return pa.bool_()
     elif py_type is bytes:

--- a/python/python/tests/docs/test_pydantic_integration.py
+++ b/python/python/tests/docs/test_pydantic_integration.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 # --8<-- [start:imports]
+import sys
+
 import lancedb
+import pytest
 from lancedb.pydantic import Vector, LanceModel
 # --8<-- [end:imports]
 
@@ -33,4 +36,45 @@ def test_pydantic_model(tmp_path):
     assert table.count_rows() == 2
     person = table.search([0.0, 0.0]).limit(1).to_pydantic(PersonModel)
     assert person[0].name == "bob"
+    # --8<-- [end:base_example]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="StrEnum where only introduced in python 3.11",
+)
+def test_pydantic_str_enum(tmp_path):
+    from enum import StrEnum
+
+    # --8<-- [start:base_model]
+    class Status(StrEnum):
+        Pending = "pending"
+        Running = "running"
+        Finished = "finished"
+
+    class JobModel(LanceModel):
+        name: str
+        status: Status
+
+    # --8<-- [end:base_model]
+
+    # --8<-- [start:set_url]
+    url = "./example"
+    # --8<-- [end:set_url]
+    url = tmp_path
+
+    # --8<-- [start:base_example]
+    db = lancedb.connect(url)
+    table = db.create_table("person", schema=JobModel)
+    table.add(
+        [
+            JobModel(name="insert_articles", status=Status.Running),
+            JobModel(name="insert_podcasts", status=Status.Finished),
+        ]
+    )
+    assert table.count_rows() == 2
+    job = (
+        table.search().where("name = 'insert_articles'").limit(1).to_pydantic(JobModel)
+    )
+    assert job[0].status == Status.Running
     # --8<-- [end:base_example]

--- a/python/python/tests/test_pydantic.py
+++ b/python/python/tests/test_pydantic.py
@@ -412,3 +412,28 @@ def test_multi_vector_in_lance_model():
 
     t = TestModel(id=1)
     assert t.vectors == [[0.0] * 16]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="StrEnum where only introduced in python 3.11",
+)
+def test_str_enum():
+    from enum import StrEnum
+
+    class Status(StrEnum):
+        Pending = "pending"
+        Running = "running"
+        Finished = "finished"
+
+    class TestModel(pydantic.BaseModel):
+        status: Status
+
+    schema = pydantic_to_schema(TestModel)
+
+    expect_schema = pa.schema(
+        [
+            pa.field("status", pa.dictionary(pa.int16(), pa.string()), False),
+        ]
+    )
+    assert schema == expect_schema


### PR DESCRIPTION
This PR aims at handling strenum in pydantic conversion in python.

(happy to squash and/or edit commit message), opening this as a proof of concept to get some feedback.

closes https://github.com/lancedb/lancedb/issues/2392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced support for StrEnum fields in Pydantic models with optimized dictionary-encoded string handling.
- **Tests**
  - Added tests validating schema conversion and data querying for models using StrEnum fields (Python 3.11+).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->