### PR TITLE
docs: announcement for Documentation

### DIFF
--- a/docs/overrides/partials/main.html
+++ b/docs/overrides/partials/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  📚 Starting June 1st, 2025, please use <a href="https://lancedb.github.io/documentation" target="_blank">lancedb.github.io/documentation</a> for the latest docs.
+{% endblock %}

--- a/docs/overrides/partials/main.html
+++ b/docs/overrides/partials/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  📚 Starting June 1st, 2025, please use <a href="https://lancedb.github.io/documentation" target="_blank">lancedb.github.io/documentation</a> for the latest docs.
+  📚 Starting June 1st, 2025, please use <a href="https://lancedb.github.io/documentation" target="_blank" rel="noopener noreferrer">lancedb.github.io/documentation</a> for the latest docs.
 {% endblock %}


### PR DESCRIPTION
Just letting people know where to look starting June 1st. 

Both docsites should be pointing to lancedb.github.io/documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a notification banner to the documentation site informing users about a new URL for accessing the latest documentation starting June 1st, 2025. The message includes a clickable link that opens in a new tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->