### PR TITLE
fix: handling empty result sets after hard filtering

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -1745,6 +1745,9 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
                 LanceHybridQueryBuilder._normalize_scores(original_scores),
             )
 
+        if vector_results.num_rows == 0 and fts_results.num_rows == 0:
+            return pa.table({})
+
         results = reranker.rerank_hybrid(fts_query, vector_results, fts_results)
 
         check_reranker_result(results)

--- a/python/python/tests/test_empty_results_handling.py
+++ b/python/python/tests/test_empty_results_handling.py
@@ -4,14 +4,17 @@ import pytest
 from lancedb.query import LanceHybridQueryBuilder
 from lancedb.rerankers.answerdotai import AnswerDotAIReranker
 
+
 @pytest.mark.asyncio
 async def test_combine_hybrid_results_empty():
-    schema = pa.schema([
-        pa.field("_rowid", pa.int64()),
-        pa.field("_distance", pa.float32()),
-        pa.field("_score", pa.float32()),
-        pa.field("content", pa.string())
-    ])
+    schema = pa.schema(
+        [
+            pa.field("_rowid", pa.int64()),
+            pa.field("_distance", pa.float32()),
+            pa.field("_score", pa.float32()),
+            pa.field("content", pa.string()),
+        ]
+    )
 
     empty_vector_results = pa.Table.from_batches([], schema=schema)
     empty_fts_results = pa.Table.from_batches([], schema=schema)

--- a/python/python/tests/test_empty_results_handling.py
+++ b/python/python/tests/test_empty_results_handling.py
@@ -1,0 +1,43 @@
+import pyarrow as pa
+import pytest
+
+from lancedb.query import LanceHybridQueryBuilder
+from lancedb.rerankers.answerdotai import AnswerDotAIReranker
+
+@pytest.mark.asyncio
+async def test_combine_hybrid_results_empty():
+    schema = pa.schema([
+        pa.field("_rowid", pa.int64()),
+        pa.field("_distance", pa.float32()),
+        pa.field("_score", pa.float32()),
+        pa.field("content", pa.string())
+    ])
+
+    empty_vector_results = pa.Table.from_batches([], schema=schema)
+    empty_fts_results = pa.Table.from_batches([], schema=schema)
+
+    class DummyReranker:
+        def rerank_hybrid(self, fts_query, vector_results, fts_results):
+            return vector_results
+
+    reranker = DummyReranker()
+
+    results = LanceHybridQueryBuilder._combine_hybrid_results(
+        fts_results=empty_fts_results,
+        vector_results=empty_vector_results,
+        norm="rank",
+        fts_query="test query",
+        reranker=reranker,
+        limit=10,
+        with_row_ids=True,
+    )
+    assert results.num_rows == 0
+
+
+def test_rerank_empty_results():
+    reranker = AnswerDotAIReranker(column="content")
+
+    empty_table = pa.table({"content": pa.array([], pa.string())})
+
+    result = reranker._rerank(empty_table, "test query")
+    assert result.num_rows == 0


### PR DESCRIPTION
Fix #2425

This PR's modifications fix a bug that resulted in an IndexError when reranking was attempted on an empty result set following the application of hard filters. The AnswerDotAI._rerank method now has a safeguard to identify and return early if the input pyarrow.Because the table is empty, operations on empty data cannot be performed downstream. This increases the robustness of hybrid search workflows and guarantees the graceful handling of empty results. To confirm this behavior and avoid regressions, a matching unit test was also included.