### PR TITLE
fix: expose parsing error coming from invalid object store uri

### DIFF
--- a/rust/lancedb/src/catalog/listing.rs
+++ b/rust/lancedb/src/catalog/listing.rs
@@ -105,7 +105,7 @@ impl ListingCatalog {
     }
 
     async fn open_path(path: &str) -> Result<Self> {
-        let (object_store, base_path) = ObjectStore::from_uri(path).await.unwrap();
+        let (object_store, base_path) = ObjectStore::from_uri(path).await?;
         if object_store.is_local() {
             Self::try_create_dir(path).context(CreateDirSnafu { path })?;
         }


### PR DESCRIPTION
this PR is to expose the error from `ListingCatalog::open_path` which unwrap the Result coming from `ObjectStore::from_uri` to avoid panic