### PR TITLE
fix: only monotonically update dataset

### DIFF
--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -129,7 +129,9 @@ impl DatasetRef {
                 dataset: ref mut ds,
                 ..
             } => {
-                *ds = dataset;
+                if dataset.manifest().version > ds.manifest().version {
+                    *ds = dataset;
+                }
             }
             _ => unreachable!("Dataset should be in latest mode at this point"),
         }


### PR DESCRIPTION
Make sure we only update the latest version if it's actually newer. This is important if there are concurrent queries, as they can take different amounts of time.