### PR TITLE
fix: change 'return' to 'raise' for unimplemented remote table function

### DIFF
--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -89,7 +89,7 @@ class RemoteTable(Table):
 
     def to_pandas(self):
         """to_pandas() is not yet supported on LanceDB cloud."""
-        return NotImplementedError("to_pandas() is not yet supported on LanceDB cloud.")
+        raise NotImplementedError("to_pandas() is not yet supported on LanceDB cloud.")
 
     def checkout(self, version: Union[int, str]):
         return LOOP.run(self._table.checkout(version))

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -209,6 +209,7 @@ async def test_retry_error():
         assert cause.request_id == request_id_holder["request_id"]
         assert cause.status_code == 429
 
+
 def test_table_unimplemented_functions():
     def handler(request):
         if request.path == "/v1/table/test/create/?mode=create":
@@ -226,7 +227,6 @@ def test_table_unimplemented_functions():
             table.to_arrow()
         with pytest.raises(NotImplementedError):
             table.to_pandas()
-
 
 
 def test_table_add_in_threadpool():

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -209,6 +209,25 @@ async def test_retry_error():
         assert cause.request_id == request_id_holder["request_id"]
         assert cause.status_code == 429
 
+def test_table_unimplemented_functions():
+    def handler(request):
+        if request.path == "/v1/table/test/create/?mode=create":
+            request.send_response(200)
+            request.send_header("Content-Type", "application/json")
+            request.end_headers()
+            request.wfile.write(b"{}")
+        else:
+            request.send_response(404)
+            request.end_headers()
+
+    with mock_lancedb_connection(handler) as db:
+        table = db.create_table("test", [{"id": 1}])
+        with pytest.raises(NotImplementedError):
+            table.to_arrow()
+        with pytest.raises(NotImplementedError):
+            table.to_pandas()
+
+
 
 def test_table_add_in_threadpool():
     def handler(request):


### PR DESCRIPTION
just noticed that we're doing a 'return' instead of a 'raise' while trying to get remote functionality working for my project. I went ahead and implemented tests for both of the unimplemented functions (to_pandas and to_arrow) while I was in there.
