### PR TITLE
chore: don't require exact version of half

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ datafusion-execution = "48.0"
 datafusion-expr = "48.0"
 datafusion-physical-plan = "48.0"
 env_logger = "0.11"
-half = { "version" = "=2.6.0", default-features = false, features = [
+half = { "version" = "2.6.0", default-features = false, features = [
     "num-traits",
 ] }
 futures = "0"


### PR DESCRIPTION
I can't find any reason for pinning this dependency and the fact that it is pinned can be kind of annoying to use downstream (e.g. datafusion currently requires >= 2.6).