### PR TITLE
feat(java): add create/drop table for java sdk

### DIFF
--- a/java/core/lancedb-jni/src/lib.rs
+++ b/java/core/lancedb-jni/src/lib.rs
@@ -45,6 +45,7 @@ macro_rules! ok_or_throw_with_return {
 mod connection;
 pub mod error;
 mod ffi;
+mod table;
 mod traits;
 
 pub use error::{Error, Result};

--- a/java/core/lancedb-jni/src/table.rs
+++ b/java/core/lancedb-jni/src/table.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+use jni::objects::JObject;
+use jni::JNIEnv;
+use lancedb::Table;
+
+pub const NATIVE_TABLE: &str = "nativeTableHandle";
+use crate::traits::IntoJava;
+
+#[derive(Clone)]
+pub struct BlockingTable {
+    pub(crate) inner: Table,
+}
+
+impl IntoJava for BlockingTable {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> JObject<'a> {
+        attach_native_table(env, self)
+    }
+}
+
+fn attach_native_table<'local>(env: &mut JNIEnv<'local>, table: BlockingTable) -> JObject<'local> {
+    let j_table = create_java_table_object(env);
+
+    match unsafe { env.set_rust_field(&j_table, NATIVE_TABLE, table) } {
+        Ok(_) => j_table,
+        Err(err) => {
+            env.throw_new(
+                "java/lang/RuntimeException",
+                format!("Failed to set native handle for Table: {}", err),
+            )
+            .expect("Error throwing exception");
+            JObject::null()
+        }
+    }
+}
+
+fn create_java_table_object<'a>(env: &mut JNIEnv<'a>) -> JObject<'a> {
+    env.new_object("com/lancedb/lancedb/Table", "()V", &[])
+        .expect("Failed to create Java Lance Table instance")
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_lancedb_lancedb_Table_releaseNativeTable(
+    mut env: JNIEnv,
+    j_table: JObject,
+) {
+    let _: BlockingTable = unsafe {
+        env.take_rust_field(j_table, NATIVE_TABLE)
+            .expect("Failed to take native Table handle")
+    };
+}

--- a/java/core/src/main/java/com/lancedb/lancedb/Connection.java
+++ b/java/core/src/main/java/com/lancedb/lancedb/Connection.java
@@ -92,6 +92,14 @@ public class Connection implements Closeable {
    */
   public native List<String> tableNames(Optional<String> startAfter, Optional<Integer> limit);
 
+  /**
+   * Create a new table in the LanceDB database with initial data.
+   *
+   * @param tableName The name of the table to create.
+   * @param initialData The initial data to populate the table, represented as an Arrow
+   *     VectorSchemaRoot.
+   * @return A new {@link Table} instance representing the created table.
+   */
   public Table createTable(String tableName, VectorSchemaRoot initialData) throws IOException {
     try (ByteArrayOutputStream out = new ByteArrayOutputStream();
         ArrowStreamWriter writer =

--- a/java/core/src/main/java/com/lancedb/lancedb/Table.java
+++ b/java/core/src/main/java/com/lancedb/lancedb/Table.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lancedb;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public class Table implements Closeable {
+
+  private long nativeTableHandle;
+
+  @Override
+  public void close() throws IOException {
+    if (nativeTableHandle != 0) {
+      releaseNativeTable(nativeTableHandle);
+      nativeTableHandle = 0;
+    }
+  }
+
+  /**
+   * Native method to release the Lance table resources associated with the given handle.
+   *
+   * @param handle The native handle to the table resource.
+   */
+  private native void releaseNativeTable(long handle);
+
+  private Table() {}
+}

--- a/java/core/src/test/java/com/lancedb/lancedb/ConnectionTest.java
+++ b/java/core/src/test/java/com/lancedb/lancedb/ConnectionTest.java
@@ -13,15 +13,28 @@
  */
 package com.lancedb.lancedb;
 
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConnectionTest {
@@ -130,6 +143,80 @@ public class ConnectionTest {
       // Start after the last table with a limit
       tableNames = conn.tableNames(TABLE_NAMES[3], 1);
       assertEquals(0, tableNames.size());
+    }
+  }
+
+  @Test
+  void createTableWithInitialData() throws IOException {
+    try (Connection conn = Connection.connect(lanceDbURL.toString())) {
+      String newTableName = "new_table_with_initial_data";
+      List<String> tableNames = conn.tableNames();
+      assertFalse(tableNames.contains(newTableName));
+      List<Field> fields = new ArrayList<>();
+      fields.add(new Field("id", FieldType.nullable(new ArrowType.Int(8, true)), null));
+      fields.add(new Field("name", FieldType.nullable(new ArrowType.Utf8()), null));
+      Schema schema = new Schema(fields);
+      VectorSchemaRoot initialData = VectorSchemaRoot.create(schema, new RootAllocator());
+      TinyIntVector idVector = (TinyIntVector) initialData.getVector("id");
+      idVector.allocateNew();
+      idVector.setSafe(0, 1);
+      idVector.setSafe(1, 2);
+      idVector.setValueCount(2);
+
+      VarCharVector nameVector = (VarCharVector) initialData.getVector("name");
+      nameVector.allocateNew();
+      nameVector.setSafe(0, "Alice".getBytes());
+      nameVector.setSafe(1, "Bob".getBytes());
+      nameVector.setValueCount(2);
+
+      initialData.setRowCount(2);
+
+      try (Table table = conn.createTable(newTableName, initialData)) {
+        assertNotNull(table);
+      }
+      tableNames = conn.tableNames();
+      assertTrue(tableNames.contains(newTableName));
+
+      conn.dropTable(newTableName);
+    }
+  }
+
+  @Test
+  void createEmptyTable() throws IOException {
+    try (Connection conn = Connection.connect(lanceDbURL.toString())) {
+      String newTableName = "new_empty_table";
+      List<String> tableNames = conn.tableNames();
+      assertFalse(tableNames.contains(newTableName));
+      List<Field> fields = new ArrayList<>();
+      fields.add(new Field("id", FieldType.nullable(new ArrowType.Int(8, true)), null));
+      fields.add(new Field("name", FieldType.nullable(new ArrowType.Utf8()), null));
+      Schema schema = new Schema(fields);
+      try (Table table = conn.createEmptyTable(newTableName, schema)) {
+        assertNotNull(table);
+      }
+      tableNames = conn.tableNames();
+      assertTrue(tableNames.contains(newTableName));
+
+      conn.dropTable(newTableName);
+    }
+  }
+
+  @Test
+  void dropTable() throws IOException {
+    try (Connection conn = Connection.connect(lanceDbURL.toString())) {
+      String newTableName = "new_empty_table_for_drop";
+      List<Field> fields = new ArrayList<>();
+      fields.add(new Field("id", FieldType.nullable(new ArrowType.Int(8, true)), null));
+      fields.add(new Field("name", FieldType.nullable(new ArrowType.Utf8()), null));
+      Schema schema = new Schema(fields);
+      try (Table table = conn.createEmptyTable(newTableName, schema)) {}
+      assertTrue(conn.tableNames().contains(newTableName));
+      conn.dropTable(newTableName);
+      assertFalse(conn.tableNames().contains(newTableName));
+
+      IllegalArgumentException exception =
+          assertThrows(IllegalArgumentException.class, () -> conn.dropTable(newTableName));
+      assertEquals("Table '" + newTableName + "' was not found", exception.getMessage());
     }
   }
 }


### PR DESCRIPTION
This PR adds the implementation of three methods, createTable/createEmptyTable/dropTable, for the Java SDK. 

The original logic is used, the Java side responsible for provided interface, and Rust is responsible for calling the underlying method. The table data transmission between Java and Rust is implemented through Arrow.