### PR TITLE
chore: fix cleanupOlderThan docs

### DIFF
--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -75,10 +75,10 @@ export interface OptimizeOptions {
    * // Delete all versions older than 1 day
    * const olderThan = new Date();
    * olderThan.setDate(olderThan.getDate() - 1));
-   * tbl.cleanupOlderVersions(olderThan);
+   * tbl.optimize({cleanupOlderThan: olderThan});
    *
    * // Delete all versions except the current version
-   * tbl.cleanupOlderVersions(new Date());
+   * tbl.optimize({cleanupOlderThan: new Date()});
    */
   cleanupOlderThan: Date;
   deleteUnverified: boolean;


### PR DESCRIPTION
Thanks for all your work.

The docstring for `OptimizeOptions ` seems to reference a non-existent method on `Table`. I believe this is the correct example for `cleanupOlderThan`.

This also appears in the generated docs, but I assume they live downstream from this code?