### PR TITLE
fix: to_pydantic typing

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -14,7 +14,6 @@ from typing import (
     Literal,
     Optional,
     Tuple,
-    Type,
     TypeVar,
     Union,
     Any,

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TypeVar,
     Union,
     Any,
 )
@@ -57,6 +58,8 @@ if TYPE_CHECKING:
         from typing import Self
     else:
         from typing_extensions import Self
+
+T = TypeVar("T", bound="LanceModel")
 
 
 # Pydantic validation function for vector queries
@@ -746,8 +749,8 @@ class LanceQueryBuilder(ABC):
         return self.to_arrow(timeout=timeout).to_pylist()
 
     def to_pydantic(
-        self, model: Type[LanceModel], *, timeout: Optional[timedelta] = None
-    ) -> List[LanceModel]:
+        self, model: type[T], *, timeout: Optional[timedelta] = None
+    ) -> list[T]:
         """Return the table as a list of pydantic models.
 
         Parameters


### PR DESCRIPTION
currently, to_pydantic will always return LanceModel. If type checking is enabled in my project. I have to use `cast(data, List[RealModelType])` to solve type error. This PR uses generic to solve this problem.