### PR TITLE
fix: ensure_vector_query should raise instead of return ValueError

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -65,7 +65,7 @@ def ensure_vector_query(
 ) -> Union[List[float], List[List[float]], pa.Array, List[pa.Array]]:
     if isinstance(val, list):
         if len(val) == 0:
-            return ValueError("Vector query must be a non-empty list")
+            raise ValueError("Vector query must be a non-empty list")
         sample = val[0]
     else:
         if isinstance(val, float):
@@ -78,7 +78,7 @@ def ensure_vector_query(
         return val
     if isinstance(sample, list):
         if len(sample) == 0:
-            return ValueError("Vector query must be a non-empty list")
+            raise ValueError("Vector query must be a non-empty list")
         if isinstance(sample[0], float):
             # val is list of list of floats
             return val


### PR DESCRIPTION
## Summary

Fixed a critical bug in `ensure_vector_query` where empty vector lists would return a `ValueError` object instead of raising it, causing confusing downstream behavior for users.

## Changes

- Changed `return ValueError(...)` to `raise ValueError(...)` on lines 68 and 81 in `python/python/lancedb/query.py`
- This ensures that validation errors are properly raised instead of being returned as objects

## Impact

- **Before**: Users providing empty vector lists would get confusing downstream errors as the `ValueError` object was treated as a valid query
- **After**: Users get clear, immediate error messages when providing invalid empty vector queries

## Test plan

- [x] All existing query tests pass
- [x] Manual verification that empty lists now properly raise `ValueError`
- [x] Code formatting and linting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)