### PR TITLE
fix: update explain plan tests for Lance 0.32.0-beta.2 compatibility

### DIFF
--- a/python/python/tests/test_hybrid_query.py
+++ b/python/python/tests/test_hybrid_query.py
@@ -166,7 +166,7 @@ async def test_explain_plan(table: AsyncTable):
     assert "Vector Search Plan" in plan
     assert "KNNVectorDistance" in plan
     assert "FTS Search Plan" in plan
-    assert "LanceScan" in plan
+    assert "LanceRead" in plan
 
 
 @pytest.mark.asyncio

--- a/python/python/tests/test_query.py
+++ b/python/python/tests/test_query.py
@@ -850,7 +850,8 @@ async def test_explain_plan_with_filters(table_async: AsyncTable):
     )
     plan_fts_filter = await query_fts_filter.where("id = 1").explain_plan()
     assert "MatchQuery: query=dog" in plan_fts_filter
-    assert "FilterExec: id@" in plan_fts_filter  # Should show filter details
+    assert "LanceRead" in plan_fts_filter
+    assert "full_filter=id = Int64(1)" in plan_fts_filter  # Should show filter details
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Updates test expectations to match the new explain plan output format introduced in Lance 0.32.0-beta.2 (PR #2525).

## Problem

Three tests were failing in CI due to changes in the explain plan output format:
- `test_explain_plan` in `test_hybrid_query.py`
- `test_explain_plan_with_filters` in `test_query.py`

## Changes

**Format changes in Lance 0.32.0-beta.2:**
- `LanceScan` → `LanceRead` in explain plan output
- Filter information moved from `FilterExec: id@` format to `full_filter=` parameter in LanceRead

**Test updates:**
- Updated `test_explain_plan` to check for `LanceRead` instead of `LanceScan`
- Updated `test_explain_plan_with_filters` to check for `LanceRead` in FTS plan
- Updated `test_explain_plan_with_filters` to check for `full_filter=id = Int64(1)` instead of `FilterExec: id@`

## Test Results

- ✅ All previously failing tests now pass
- ✅ No regression in other tests
- ✅ Code formatting and linting checks pass

## Root Cause

This issue was introduced by the Lance version upgrade in PR #2525 which updated Lance to 0.32.0-beta.2. The explain plan output format changed but the test expectations were not updated accordingly.