### PR TITLE
fix(python): expose register function in embeddings module

### DIFF
--- a/python/python/lancedb/embeddings/__init__.py
+++ b/python/python/lancedb/embeddings/__init__.py
@@ -11,7 +11,7 @@ from .instructor import InstructorEmbeddingFunction
 from .ollama import OllamaEmbeddings
 from .open_clip import OpenClipEmbeddings
 from .openai import OpenAIEmbeddings
-from .registry import EmbeddingFunctionRegistry, get_registry
+from .registry import EmbeddingFunctionRegistry, get_registry, register
 from .sentence_transformers import SentenceTransformerEmbeddings
 from .gte import GteEmbeddings
 from .transformers import TransformersEmbeddingFunction, ColbertEmbeddings


### PR DESCRIPTION
## Summary
Fixes #2541

**Problem**: The `register` function was not accessible via `from lancedb.embeddings import register` as documented, causing ImportError for users trying to create custom embedding functions.

**Solution**: Added `register` to the exports in `python/lancedb/embeddings/__init__.py` to match the documented API and follow the same pattern as other registry functions (`get_registry`, `EmbeddingFunctionRegistry`).

**Root Cause**: The function existed in `lancedb.embeddings.registry` but wasn't exposed through the main embeddings module interface.

## Changes
- Add `register` to imports in `/python/python/lancedb/embeddings/__init__.py`

## Test Plan
- [x] Verified `from lancedb.embeddings import register` works as documented
- [x] Confirmed existing embedding tests pass
- [x] Checked that the fix follows existing patterns (same as `get_registry`)
- [x] Validated linting and formatting passes

## References
Fixes #2541