### PR TITLE
enhance: infer vector columns when name contains 'vector' or 'embedding'

### DIFF
--- a/nodejs/__test__/arrow.test.ts
+++ b/nodejs/__test__/arrow.test.ts
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-import { Bool, Field, Int32, List, Schema, Struct, Utf8 } from "apache-arrow";
+import {
+  Bool,
+  Field,
+  Int32,
+  List,
+  Schema,
+  Struct,
+  Uint8,
+  Utf8,
+} from "apache-arrow";
 
 import * as arrow15 from "apache-arrow-15";
 import * as arrow16 from "apache-arrow-16";
@@ -253,6 +262,89 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
         expect(actual.numRows).toBe(3);
         const actualSchema = actual.schema;
         expect(actualSchema).toEqual(schema);
+      });
+
+      it("will detect vector columns when name contains 'vector' or 'embedding'", async function () {
+        // Test various naming patterns that should be detected as vector columns
+        const table = makeArrowTable([
+          {
+            // Float vectors (use decimal values to ensure they're treated as floats)
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            user_vector: [1.1, 2.2],
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            text_embedding: [3.3, 4.4],
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            doc_embeddings: [5.5, 6.6],
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            my_vector_field: [7.7, 8.8],
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            embedding_model: [9.9, 10.1],
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            VECTOR_COL: [11.1, 12.2], // uppercase
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            Vector_Mixed: [13.3, 14.4], // mixed case
+            // Integer vectors (use whole numbers to be detected as integers)
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            vector_int: [1, 2],
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            embedding_int: [3, 4],
+            // biome-ignore lint/style/useNamingConvention: Testing vector column detection patterns
+            normal_list: [15.5, 16.6], // should NOT be detected as vector
+          },
+        ]);
+
+        // Check that columns with 'vector' or 'embedding' in name are converted to FixedSizeList
+        expect(
+          DataType.isFixedSizeList(table.getChild("user_vector")?.type),
+        ).toBe(true);
+        expect(
+          DataType.isFixedSizeList(table.getChild("text_embedding")?.type),
+        ).toBe(true);
+        expect(
+          DataType.isFixedSizeList(table.getChild("doc_embeddings")?.type),
+        ).toBe(true);
+        expect(
+          DataType.isFixedSizeList(table.getChild("my_vector_field")?.type),
+        ).toBe(true);
+        expect(
+          DataType.isFixedSizeList(table.getChild("embedding_model")?.type),
+        ).toBe(true);
+        expect(
+          DataType.isFixedSizeList(table.getChild("VECTOR_COL")?.type),
+        ).toBe(true);
+        expect(
+          DataType.isFixedSizeList(table.getChild("Vector_Mixed")?.type),
+        ).toBe(true);
+
+        // Integer vectors should also be detected (when implemented)
+        expect(
+          DataType.isFixedSizeList(table.getChild("vector_int")?.type),
+        ).toBe(true);
+        expect(
+          DataType.isFixedSizeList(table.getChild("embedding_int")?.type),
+        ).toBe(true);
+
+        // Normal list should NOT be converted to FixedSizeList
+        expect(
+          DataType.isFixedSizeList(table.getChild("normal_list")?.type),
+        ).toBe(false);
+        expect(DataType.isList(table.getChild("normal_list")?.type)).toBe(true);
+
+        // Check that float vectors use Float32 by default
+        expect(
+          table.getChild("user_vector")?.type.children[0].type.toString(),
+        ).toEqual(new Float32().toString());
+        expect(
+          table.getChild("text_embedding")?.type.children[0].type.toString(),
+        ).toEqual(new Float32().toString());
+
+        // Check that integer vectors use Uint8
+        expect(
+          table.getChild("vector_int")?.type.children[0].type.toString(),
+        ).toEqual(new Uint8().toString());
+        expect(
+          table.getChild("embedding_int")?.type.children[0].type.toString(),
+        ).toEqual(new Uint8().toString());
       });
 
       it("will allow different vector column types", async function () {

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2918,6 +2918,12 @@ def has_nan_values(arr: Union[pa.ListArray, pa.ChunkedArray]) -> pa.BooleanArray
     return pc.is_in(indices, has_nan_indices)
 
 
+def _name_suggests_vector_column(field_name: str) -> bool:
+    """Check if a field name indicates a vector column."""
+    name_lower = field_name.lower()
+    return "vector" in name_lower or "embedding" in name_lower
+
+
 def _infer_target_schema(
     reader: pa.RecordBatchReader,
 ) -> Tuple[pa.Schema, pa.RecordBatchReader]:
@@ -2925,35 +2931,27 @@ def _infer_target_schema(
     peeked = None
 
     for i, field in enumerate(schema):
-        if (
-            field.name == VECTOR_COLUMN_NAME
-            and (pa.types.is_list(field.type) or pa.types.is_large_list(field.type))
-            and pa.types.is_floating(field.type.value_type)
-        ):
+        is_list_type = pa.types.is_list(field.type) or pa.types.is_large_list(
+            field.type
+        )
+
+        if _name_suggests_vector_column(field.name) and is_list_type:
             if peeked is None:
                 peeked, reader = peek_reader(reader)
             # Use the most common length of the list as the dimensions
             dim = _modal_list_size(peeked.column(i))
 
-            new_field = pa.field(
-                VECTOR_COLUMN_NAME,
-                pa.list_(pa.float32(), dim),
-                nullable=field.nullable,
-            )
+            # Determine target type based on value type
+            if pa.types.is_floating(field.type.value_type):
+                target_type = pa.list_(pa.float32(), dim)
+            elif pa.types.is_integer(field.type.value_type):
+                target_type = pa.list_(pa.uint8(), dim)
+            else:
+                continue  # Skip non-numeric types
 
-            schema = schema.set(i, new_field)
-        elif (
-            field.name == VECTOR_COLUMN_NAME
-            and (pa.types.is_list(field.type) or pa.types.is_large_list(field.type))
-            and pa.types.is_integer(field.type.value_type)
-        ):
-            if peeked is None:
-                peeked, reader = peek_reader(reader)
-            # Use the most common length of the list as the dimensions
-            dim = _modal_list_size(peeked.column(i))
             new_field = pa.field(
-                VECTOR_COLUMN_NAME,
-                pa.list_(pa.uint8(), dim),
+                field.name,  # preserve original field name
+                target_type,
                 nullable=field.nullable,
             )
 


### PR DESCRIPTION
## Summary

- Enhanced vector column detection to use substring matching instead of exact matching
- Now detects columns with names containing "vector" or "embedding" (case-insensitive)
- Added integer vector support to Node.js implementation (matching Python)
- Comprehensive test coverage for both float and integer vector types

## Changes

### Python (`python/python/lancedb/table.py`)
- Updated `_infer_target_schema()` to use substring matching with helper function `_is_vector_column()`
- Preserved original field names instead of forcing "vector"
- Consolidated duplicate logic for better maintainability

### Node.js (`nodejs/lancedb/arrow.ts`)
- Enhanced type inference with `nameSuggestsVectorColumn()` helper function
- Added `isAllIntegers()` function with performance optimization (checks first 10 elements)
- Implemented integer vector support using `Uint8` type (matching Python)
- Improved type safety by removing `any` usage

### Tests
- **Python**: Added `test_infer_target_schema_with_vector_embedding_names()` in `test_util.py`
- **Node.js**: Added comprehensive test case in `arrow.test.ts`
- Both test suites cover various naming patterns and integer/float vector types

## Examples of newly supported column names:
- `user_vector`, `text_embedding`, `doc_embeddings`
- `my_vector_field`, `embedding_model`
- `VECTOR_COL`, `Vector_Mixed` (case-insensitive)
- Both float and integer arrays are properly converted to fixed-size lists

## Test plan
- [x] All existing tests pass (backward compatibility maintained)
- [x] New tests pass for both Python and Node.js implementations
- [x] Integer vector detection works correctly in Node.js
- [x] Code passes linting and formatting checks
- [x] Performance optimized for large vector arrays

Fixes #2546

🤖 Generated with [Claude Code](https://claude.ai/code)