### PR TITLE
feat: add table metadata support for local and remote tables

### DIFF
--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -315,6 +315,28 @@ impl Table {
     }
 
     #[napi(catch_unwind)]
+    pub async fn table_metadata(&self) -> napi::Result<HashMap<String, String>> {
+        let inner = self.inner_ref()?;
+        inner.table_metadata().await.default_error()
+    }
+
+    #[napi(catch_unwind)]
+    pub async fn update_config(&self, metadata: HashMap<String, String>) -> napi::Result<()> {
+        let inner = self.inner_ref()?;
+        inner
+            .update_config(metadata.into_iter())
+            .await
+            .default_error()
+    }
+
+    #[napi(catch_unwind)]
+    pub async fn delete_config_keys(&self, keys: Vec<String>) -> napi::Result<()> {
+        let inner = self.inner_ref()?;
+        let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+        inner.delete_config_keys(&key_refs).await.default_error()
+    }
+
+    #[napi(catch_unwind)]
     pub async fn optimize(
         &self,
         older_than_ms: Option<i64>,

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -27,7 +27,7 @@ from lancedb.merge import LanceMergeInsertBuilder
 from lancedb.embeddings import EmbeddingFunctionRegistry
 
 from ..query import LanceVectorQueryBuilder, LanceQueryBuilder
-from ..table import AsyncTable, IndexStatistics, Query, Table, Tags
+from ..table import AsyncTable, IndexStatistics, Query, Table, TableMetadata, Tags
 
 
 class RemoteTable(Table):
@@ -63,6 +63,20 @@ class RemoteTable(Table):
     @property
     def tags(self) -> Tags:
         return Tags(self._table)
+
+    @property
+    def metadata(self) -> TableMetadata:
+        """Table metadata management.
+
+        Table metadata allows storing arbitrary key-value information about
+        the table such as tags, descriptions, or configuration settings.
+
+        Returns
+        -------
+        TableMetadata
+            The metadata manager for managing table metadata.
+        """
+        return TableMetadata(self._table)
 
     @cached_property
     def embedding_functions(self) -> Dict[str, EmbeddingFunctionConfig]:


### PR DESCRIPTION
## Summary
Implements table metadata functionality allowing users to store and retrieve arbitrary key-value pairs for tables. This addresses the table metadata portion of issue #2542.

## Features
- **Local tables**: Get, insert, and delete metadata via Lance dataset config
- **Remote tables**: REST API endpoints for metadata operations  
- **Python bindings**: TableMetadata class with async get(), insert(), delete_keys()
- **TypeScript bindings**: TableMetadata class with async operations
- **Comprehensive tests** for both local and remote functionality

## API Design
- Uses `metadata` naming convention instead of `config` as specified in issue
- TypeScript API uses property access pattern: `table.metadata.get()`
- Consistent async interface across all language bindings

## Test Plan
- [x] Local table metadata operations
- [x] Remote table metadata operations via REST API
- [x] Python bindings integration tests
- [x] TypeScript bindings integration tests
- [x] Error handling and edge cases

🤖 Generated with [Claude Code](https://claude.ai/code)