### PR TITLE
fix: add `name` to `IndexConfig` + fix type error in Python bindings

### DIFF
--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -91,6 +91,7 @@ class Tags:
     async def update(self, tag: str, version: int): ...
 
 class IndexConfig:
+    name: str
     index_type: str
     columns: List[str]
 

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -148,7 +148,7 @@ class RemoteTable(Table):
         column: str,
         *,
         replace: bool = False,
-        wait_timeout: timedelta = None,
+        wait_timeout: Optional[timedelta] = None,
         with_position: bool = False,
         # tokenizer configs:
         base_tokenizer: str = "simple",

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -114,7 +114,7 @@ class RemoteTable(Table):
         index_type: Literal["BTREE", "BITMAP", "LABEL_LIST", "scalar"] = "scalar",
         *,
         replace: bool = False,
-        wait_timeout: timedelta = None,
+        wait_timeout: Optional[timedelta] = None,
     ):
         """Creates a scalar index
         Parameters


### PR DESCRIPTION
Hello! I was upgrading our client and I noticed a few issues.

1. `name` in `IndexConfig` is not exposed in the python types (it exists on the type though https://github.com/lancedb/lancedb/blob/70d9b04ba595bc57d4a1e4ec5668a1a36608a2cd/python/src/index.rs#L183-L192)
2. `wait_timeout` on RemoteTable has a default value of `None` but the type is not optional. The linter on my side made this hard to workaround.