### PR TITLE
feat: add `status` to `IndexConfig` and Python bindings

### DIFF
--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -93,6 +93,7 @@ class Tags:
 class IndexConfig:
     index_type: str
     columns: List[str]
+    status: str
 
 async def connect(
     uri: str,

--- a/python/src/index.rs
+++ b/python/src/index.rs
@@ -190,14 +190,16 @@ pub struct IndexConfig {
     pub columns: Vec<String>,
     /// Name of the index.
     pub name: String,
+    /// The status of the index
+    pub status: String,
 }
 
 #[pymethods]
 impl IndexConfig {
     pub fn __repr__(&self) -> String {
         format!(
-            "Index({}, columns={:?}, name=\"{}\")",
-            self.index_type, self.columns, self.name
+            "Index({}, columns={:?}, name=\"{}\", status=\"{}\")",
+            self.index_type, self.columns, self.name, self.status
         )
     }
 
@@ -208,6 +210,7 @@ impl IndexConfig {
             "index_type" => Ok(self.index_type.clone().into_pyobject(py)?.into_any()),
             "columns" => Ok(self.columns.clone().into_pyobject(py)?.into_any()),
             "name" | "index_name" => Ok(self.name.clone().into_pyobject(py)?.into_any()),
+            "status" => Ok(self.status.clone().into_pyobject(py)?.into_any()),
             _ => Err(PyKeyError::new_err(format!("Invalid key: {}", key))),
         }
     }
@@ -220,6 +223,7 @@ impl From<lancedb::index::IndexConfig> for IndexConfig {
             index_type,
             columns: value.columns,
             name: value.name,
+            status: value.status,
         }
     }
 }

--- a/rust/lancedb/src/index.rs
+++ b/rust/lancedb/src/index.rs
@@ -178,6 +178,8 @@ pub struct IndexConfig {
     /// Currently this is always a Vec of size 1.  In the future there may
     /// be more columns to represent composite indices.
     pub columns: Vec<String>,
+    /// The status of the index
+    pub status: String,
 }
 
 #[skip_serializing_none]

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -2633,6 +2633,11 @@ impl BaseTable for NativeTable {
                 return None;
             };
 
+            let Some(status) = stats.get("status").and_then(|v| v.as_str()) else {
+                log::warn!("Index statistics was missing 'status' field for index {} ({})", idx.name, idx.uuid);
+                return None;
+            };
+
             let index_type: crate::index::IndexType = match index_type.parse() {
                 Ok(index_type) => index_type,
                 Err(e) => {
@@ -2651,7 +2656,8 @@ impl BaseTable for NativeTable {
             }
 
             let name = idx.name.clone();
-            Some(IndexConfig { index_type, columns, name })
+            let status = status.to_string();
+            Some(IndexConfig { index_type, columns, name, status })
         }).collect::<Vec<_>>().await;
 
         Ok(results.into_iter().flatten().collect())


### PR DESCRIPTION
In our code we were making a direct http call and reading this value. It would be nice to expose it here but we can pretty easily work around not having this if you all don't want to change your API for this.