### PR TITLE
fix: use SPDX-compliant license name for nodejs packages

### DIFF
--- a/nodejs/examples/package-lock.json
+++ b/nodejs/examples/package-lock.json
@@ -30,7 +30,7 @@
         "x64",
         "arm64"
       ],
-      "license": "Apache 2.0",
+      "license": "Apache-2.0",
       "os": [
         "darwin",
         "linux",

--- a/nodejs/npm/darwin-arm64/package.json
+++ b/nodejs/npm/darwin-arm64/package.json
@@ -5,7 +5,7 @@
 	"cpu": ["arm64"],
 	"main": "lancedb.darwin-arm64.node",
 	"files": ["lancedb.darwin-arm64.node"],
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
 	}

--- a/nodejs/npm/darwin-x64/package.json
+++ b/nodejs/npm/darwin-x64/package.json
@@ -5,7 +5,7 @@
 	"cpu": ["x64"],
 	"main": "lancedb.darwin-x64.node",
 	"files": ["lancedb.darwin-x64.node"],
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
 	}

--- a/nodejs/npm/linux-arm64-gnu/package.json
+++ b/nodejs/npm/linux-arm64-gnu/package.json
@@ -5,7 +5,7 @@
 	"cpu": ["arm64"],
 	"main": "lancedb.linux-arm64-gnu.node",
 	"files": ["lancedb.linux-arm64-gnu.node"],
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
 	},

--- a/nodejs/npm/linux-arm64-musl/package.json
+++ b/nodejs/npm/linux-arm64-musl/package.json
@@ -5,7 +5,7 @@
 	"cpu": ["arm64"],
 	"main": "lancedb.linux-arm64-musl.node",
 	"files": ["lancedb.linux-arm64-musl.node"],
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
 	},

--- a/nodejs/npm/linux-x64-gnu/package.json
+++ b/nodejs/npm/linux-x64-gnu/package.json
@@ -5,7 +5,7 @@
 	"cpu": ["x64"],
 	"main": "lancedb.linux-x64-gnu.node",
 	"files": ["lancedb.linux-x64-gnu.node"],
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
 	},

--- a/nodejs/npm/linux-x64-musl/package.json
+++ b/nodejs/npm/linux-x64-musl/package.json
@@ -5,7 +5,7 @@
 	"cpu": ["x64"],
 	"main": "lancedb.linux-x64-musl.node",
 	"files": ["lancedb.linux-x64-musl.node"],
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
 	},

--- a/nodejs/npm/win32-arm64-msvc/package.json
+++ b/nodejs/npm/win32-arm64-msvc/package.json
@@ -11,7 +11,7 @@
   "files": [
     "lancedb.win32-arm64-msvc.node"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">= 18"
   }

--- a/nodejs/npm/win32-x64-msvc/package.json
+++ b/nodejs/npm/win32-x64-msvc/package.json
@@ -5,7 +5,7 @@
 	"cpu": ["x64"],
 	"main": "lancedb.win32-x64-msvc.node",
 	"files": ["lancedb.win32-x64-msvc.node"],
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
 	}

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -11,7 +11,7 @@
         "x64",
         "arm64"
       ],
-      "license": "Apache 2.0",
+      "license": "Apache-2.0",
       "os": [
         "darwin",
         "linux",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -36,7 +36,7 @@
       ]
     }
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.33.0",
     "@aws-sdk/client-kms": "^3.33.0",


### PR DESCRIPTION
Update license field from `Apache 2.0` to be `Apache-2.0` for all Node.js packages.

This was causing GitHub's Dependency Review license check to fail with:
> The validity of the licenses of the dependencies below could not be determined. Ensure that they are valid SPDX licenses