### PR TITLE
feat: don't repartition for the sake of the metadata eraser

### DIFF
--- a/rust/lancedb/src/table/datafusion.rs
+++ b/rust/lancedb/src/table/datafusion.rs
@@ -494,7 +494,6 @@ pub mod tests {
         TestFixture::check_plan(
             plan,
             "MetadataEraserExec
-             RepartitionExec:...
              ProjectionExec:...
              LanceRead:...",
         )

--- a/rust/lancedb/src/table/datafusion.rs
+++ b/rust/lancedb/src/table/datafusion.rs
@@ -85,6 +85,14 @@ impl ExecutionPlan for MetadataEraserExec {
         vec![&self.input]
     }
 
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true; self.children().len()]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false; self.children().len()]
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,


### PR DESCRIPTION
The `MetadataEraserExec` is super lightweight and doesn't really justify partitioning.  I had a plan recently that was partitioning just for this node and that seems wasteful.