### PR TITLE
fix: make cloud features optional (#2567)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["database-implementations"]
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-lance = { "version" = "=0.33.0", "features" = ["dynamodb"] }
-lance-io = "=0.33.0"
+lance = { "version" = "=0.33.0", default-features = false, "features" = ["dynamodb"] }
+lance-io = { "version" = "=0.33.0", default-features = false }
 lance-index = "=0.33.0"
 lance-linalg = "=0.33.0"
 lance-table = "=0.33.0"

--- a/java/core/lancedb-jni/Cargo.toml
+++ b/java/core/lancedb-jni/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-lancedb = { path = "../../../rust/lancedb" }
+lancedb = { path = "../../../rust/lancedb", default-features = false }
 lance = { workspace = true }
 arrow = { workspace = true, features = ["ffi"] }
 arrow-schema.workspace = true
@@ -25,3 +25,6 @@ snafu.workspace = true
 lazy_static.workspace = true
 serde = { version = "^1" }
 serde_json = { version = "1" }
+
+[features]
+default = ["lancedb/default"]

--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -18,7 +18,7 @@ arrow-array.workspace = true
 arrow-schema.workspace = true
 env_logger.workspace = true
 futures.workspace = true
-lancedb = { path = "../rust/lancedb" }
+lancedb = { path = "../rust/lancedb", default-features = false }
 napi = { version = "2.16.8", default-features = false, features = [
     "napi9",
     "async"
@@ -36,6 +36,6 @@ aws-lc-rs = "=1.13.0"
 napi-build = "2.1"
 
 [features]
-default = ["remote"]
+default = ["remote", "lancedb/default"]
 fp16kernels = ["lancedb/fp16kernels"]
 remote = ["lancedb/remote"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -33,6 +33,6 @@ pyo3-build-config = { version = "0.24", features = [
 ] }
 
 [features]
-default = ["remote"]
+default = ["remote", "lancedb/default"]
 fp16kernels = ["lancedb/fp16kernels"]
 remote = ["lancedb/remote"]

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -97,7 +97,12 @@ rstest = "0.23.0"
 
 
 [features]
-default = []
+default = ["aws", "gcs", "azure", "dynamodb", "oss"]
+aws = ["lance/aws", "lance-io/aws"]
+oss = ["lance/oss", "lance-io/oss"]
+gcs = ["lance/gcp", "lance-io/gcp"]
+azure = ["lance/azure", "lance-io/azure"]
+dynamodb = ["lance/dynamodb", "aws"]
 remote = ["dep:reqwest", "dep:http", "dep:rand", "dep:uuid"]
 fp16kernels = ["lance-linalg/fp16kernels"]
 s3-test = []

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use arrow_array::RecordBatchReader;
 use arrow_schema::{Field, SchemaRef};
 use lance::dataset::ReadParams;
+#[cfg(feature = "aws")]
 use object_store::aws::AwsCredential;
 
 use crate::arrow::{IntoArrow, IntoArrowStream, SendableRecordBatchStream};
@@ -749,6 +750,7 @@ impl ConnectBuilder {
     }
 
     /// [`AwsCredential`] to use when connecting to S3.
+    #[cfg(feature = "aws")]
     #[deprecated(note = "Pass through storage_options instead")]
     pub fn aws_creds(mut self, aws_creds: AwsCredential) -> Self {
         self.request


### PR DESCRIPTION
This shrinks the size of a local embedded build that can disable all the default features. When combined with https://github.com/lancedb/lance/pull/4362 and the dependencies are updated to point to the fix, this resolves #2567 fully.

Verified by patching the workspace to redirect to my clone of lance with the PR applied.
```
cargo tree -p lancedb -e no-build -e no-dev --no-default-features -i aws-config | less
```

The reason that lance itself needs to change too is that many dependencies within that project depend on lance-io/default and lancedb depends on them which transitively ends up enabling the cloud regardless. The PR in lance removes the dependency on lance-io/default from all sibling crates.