### PR TITLE
feat: allow setting `train=False` and `name` on indices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,68 @@ Project layout:
 
 Common commands:
 
-* Check for compiler errors: `cargo check --features remote --tests --examples`
-* Run tests: `cargo test --features remote --tests`
-* Run specific test: `cargo test --features remote -p <package_name> --test <test_name>`
-* Lint: `cargo clippy --features remote --tests --examples`
+* Check for compiler errors: `cargo check --quiet --features remote --tests --examples`
+* Run tests: `cargo test --quiet --features remote --tests`
+* Run specific test: `cargo test --quiet --features remote -p <package_name> --test <test_name>`
+* Lint: `cargo clippy --quiet --features remote --tests --examples`
 * Format: `cargo fmt --all`
 
 Before committing changes, run formatting.
+
+## Coding tips
+
+* When writing Rust doctests for things that require a connection or table reference,
+  write them as a function instead of a fully executable test. This allows type checking
+  to run but avoids needing a full test environment. For example:
+    ```rust
+    /// ```
+    /// use lance_index::scalar::FullTextSearchQuery;
+    /// use lancedb::query::{QueryBase, ExecutableQuery};
+    ///
+    /// # use lancedb::Table;
+    /// # async fn query(table: &Table) -> Result<(), Box<dyn std::error::Error>> {
+    /// let results = table.query()
+    ///     .full_text_search(FullTextSearchQuery::new("hello world".into()))
+    ///     .execute()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ```
+
+## Example plan: adding a new method on Table
+
+Adding a new method involves first adding it to the Rust core, then exposing it
+in the Python and TypeScript bindings. There are both local and remote tables.
+Remote tables are implemented via a HTTP API and require the `remote` cargo
+feature flag to be enabled. Python has both sync and async methods.
+
+Rust core changes:
+
+1. Add method on `Table` struct in `rust/lancedb/src/table.rs` (calls `BaseTable` trait).
+2. Add method to `BaseTable` trait in `rust/lancedb/src/table.rs`.
+3. Implement new trait method on `NativeTable` in `rust/lancedb/src/table.rs`.
+    * Test with unit test in `rust/lancedb/src/table.rs`.
+4. Implement new trait method on `RemoteTable` in `rust/lancedb/src/remote/table.rs`.
+    * Test with unit test in `rust/lancedb/src/remote/table.rs` against mocked endpoint.
+
+Python bindings changes:
+
+1. Add PyO3 method binding in `python/src/table.rs`. Run `make develop` to compile bindings.
+2. Add types for PyO3 method in `python/python/lancedb/_lancedb.pyi`.
+3. Add method to `AsyncTable` class in `python/python/lancedb/table.py`.
+4. Add abstract method to `Table` abstract base class in `python/python/lancedb/table.py`.
+5. Add concrete sync method to `LanceTable` class in `python/python/lancedb/table.py`.
+    * Should use `LOOP.run()` to call the corresponding `AsyncTable` method.
+6. Add concrete sync method to `RemoteTable` class in `python/python/lancedb/remote/table.py`.
+7. Add unit test in `python/tests/test_table.py`.
+
+TypeScript bindings changes:
+
+1. Add napi-rs method binding on `Table` in `nodejs/src/table.rs`.
+2. Run `npm run build` to generate TypeScript definitions.
+3. Add typescript method on abstract class `Table` in `nodejs/src/table.ts`.
+4. Add concrete method on `LocalTable` class in `nodejs/src/native_table.ts`.
+    * Note: despite the name, this class is also used for remote tables.
+5. Add test in `nodejs/__test__/table.test.ts`.
+6. Run `npm run docs` to generate TypeScript documentation.

--- a/docs/src/js/classes/Session.md
+++ b/docs/src/js/classes/Session.md
@@ -9,7 +9,8 @@
 A session for managing caches and object stores across LanceDB operations.
 
 Sessions allow you to configure cache sizes for index and metadata caches,
-which can significantly impact performance for large datasets.
+which can significantly impact memory use and performance. They can
+also be re-used across multiple connections to share the same cache state.
 
 ## Constructors
 
@@ -24,8 +25,11 @@ Create a new session with custom cache sizes.
 # Parameters
 
 - `index_cache_size_bytes`: The size of the index cache in bytes.
+  Index data is stored in memory in this cache to speed up queries.
   Defaults to 6GB if not specified.
 - `metadata_cache_size_bytes`: The size of the metadata cache in bytes.
+  The metadata cache stores file metadata and schema information in memory.
+  This cache improves scan and write performance.
   Defaults to 1GB if not specified.
 
 #### Parameters

--- a/docs/src/js/interfaces/IndexOptions.md
+++ b/docs/src/js/interfaces/IndexOptions.md
@@ -26,6 +26,18 @@ will be used to determine the most useful kind of index to create.
 
 ***
 
+### name?
+
+```ts
+optional name: string;
+```
+
+Optional custom name for the index.
+
+If not provided, a default name will be generated based on the column name.
+
+***
+
 ### replace?
 
 ```ts
@@ -42,8 +54,27 @@ The default is true
 
 ***
 
+### train?
+
+```ts
+optional train: boolean;
+```
+
+Whether to train the index with existing data.
+
+If true (default), the index will be trained with existing data in the table.
+If false, the index will be created empty and populated as new data is added.
+
+Note: This option is only supported for scalar indices. Vector indices always train.
+
+***
+
 ### waitTimeoutSeconds?
 
 ```ts
 optional waitTimeoutSeconds: number;
 ```
+
+Timeout in seconds to wait for index creation to complete.
+
+If not specified, the method will return immediately after starting the index creation.

--- a/docs/src/js/interfaces/TimeoutConfig.md
+++ b/docs/src/js/interfaces/TimeoutConfig.md
@@ -44,3 +44,17 @@ optional readTimeout: number;
 The timeout for reading data from the server in seconds. Default is 300
 seconds (5 minutes). This can also be set via the environment variable
 `LANCE_CLIENT_READ_TIMEOUT`, as an integer number of seconds.
+
+***
+
+### timeout?
+
+```ts
+optional timeout: number;
+```
+
+The overall timeout for the entire request in seconds. This includes
+connection, send, and read time. If the entire request doesn't complete
+within this time, it will fail. Default is None (no overall timeout).
+This can also be set via the environment variable `LANCE_CLIENT_TIMEOUT`,
+as an integer number of seconds.

--- a/nodejs/lancedb/indices.ts
+++ b/nodejs/lancedb/indices.ts
@@ -700,5 +700,27 @@ export interface IndexOptions {
    */
   replace?: boolean;
 
+  /**
+   * Timeout in seconds to wait for index creation to complete.
+   *
+   * If not specified, the method will return immediately after starting the index creation.
+   */
   waitTimeoutSeconds?: number;
+
+  /**
+   * Optional custom name for the index.
+   *
+   * If not provided, a default name will be generated based on the column name.
+   */
+  name?: string;
+
+  /**
+   * Whether to train the index with existing data.
+   *
+   * If true (default), the index will be trained with existing data in the table.
+   * If false, the index will be created empty and populated as new data is added.
+   *
+   * Note: This option is only supported for scalar indices. Vector indices always train.
+   */
+  train?: boolean;
 }

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -647,6 +647,8 @@ export class LocalTable extends Table {
       column,
       options?.replace,
       options?.waitTimeoutSeconds,
+      options?.name,
+      options?.train,
     );
   }
 

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -114,6 +114,8 @@ impl Table {
         column: String,
         replace: Option<bool>,
         wait_timeout_s: Option<i64>,
+        name: Option<String>,
+        train: Option<bool>,
     ) -> napi::Result<()> {
         let lancedb_index = if let Some(index) = index {
             index.consume()?
@@ -127,6 +129,12 @@ impl Table {
         if let Some(timeout) = wait_timeout_s {
             builder =
                 builder.wait_timeout(std::time::Duration::from_secs(timeout.try_into().unwrap()));
+        }
+        if let Some(name) = name {
+            builder = builder.name(name);
+        }
+        if let Some(train) = train {
+            builder = builder.train(train);
         }
         builder.execute().await.default_error()
     }

--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -59,6 +59,10 @@ class Table:
         column: str,
         index: Union[IvfFlat, IvfPq, HnswPq, HnswSq, BTree, Bitmap, LabelList, FTS],
         replace: Optional[bool],
+        wait_timeout: Optional[object],
+        *,
+        name: Optional[str],
+        train: Optional[bool],
     ): ...
     async def list_versions(self) -> List[Dict[str, Any]]: ...
     async def version(self) -> int: ...

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -194,6 +194,8 @@ class RemoteTable(Table):
         wait_timeout: Optional[timedelta] = None,
         *,
         num_bits: int = 8,
+        name: Optional[str] = None,
+        train: bool = True,
     ):
         """Create an index on the table.
         Currently, the only parameters that matter are
@@ -270,7 +272,11 @@ class RemoteTable(Table):
 
         LOOP.run(
             self._table.create_index(
-                vector_column_name, config=config, wait_timeout=wait_timeout
+                vector_column_name,
+                config=config,
+                wait_timeout=wait_timeout,
+                name=name,
+                train=train,
             )
         )
 

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -687,6 +687,8 @@ class Table(ABC):
         sample_rate: int = 256,
         m: int = 20,
         ef_construction: int = 300,
+        name: Optional[str] = None,
+        train: bool = True,
     ):
         """Create an index on the table.
 
@@ -719,6 +721,11 @@ class Table(ABC):
             Only 4 and 8 are supported.
         wait_timeout: timedelta, optional
             The timeout to wait if indexing is asynchronous.
+        name: str, optional
+            The name of the index. If not provided, a default name will be generated.
+        train: bool, default True
+            Whether to train the index with existing data. Vector indices always train
+            with existing data.
         """
         raise NotImplementedError
 
@@ -1861,6 +1868,9 @@ class LanceTable(Table):
         sample_rate: int = 256,
         m: int = 20,
         ef_construction: int = 300,
+        *,
+        name: Optional[str] = None,
+        train: bool = True,
     ):
         """Create an index on the table."""
         if accelerator is not None:
@@ -1924,6 +1934,8 @@ class LanceTable(Table):
                 vector_column_name,
                 replace=replace,
                 config=config,
+                name=name,
+                train=train,
             )
         )
 
@@ -3183,6 +3195,8 @@ class AsyncTable:
             Union[IvfFlat, IvfPq, HnswPq, HnswSq, BTree, Bitmap, LabelList, FTS]
         ] = None,
         wait_timeout: Optional[timedelta] = None,
+        name: Optional[str] = None,
+        train: bool = True,
     ):
         """Create an index to speed up queries
 
@@ -3209,6 +3223,11 @@ class AsyncTable:
             creating an index object.
         wait_timeout: timedelta, optional
             The timeout to wait if indexing is asynchronous.
+        name: str, optional
+            The name of the index. If not provided, a default name will be generated.
+        train: bool, default True
+            Whether to train the index with existing data. Vector indices always train
+            with existing data.
         """
         if config is not None:
             if not isinstance(
@@ -3220,7 +3239,12 @@ class AsyncTable:
                 )
         try:
             await self._inner.create_index(
-                column, index=config, replace=replace, wait_timeout=wait_timeout
+                column,
+                index=config,
+                replace=replace,
+                wait_timeout=wait_timeout,
+                name=name,
+                train=train,
             )
         except ValueError as e:
             if "not support the requested language" in str(e):

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1725,7 +1725,7 @@ impl NativeTable {
                     );
                     Ok(Box::new(lance_idx_params))
                 } else if supported_btree_data_type(field.data_type()) {
-                    Ok(Box::new(ScalarIndexParams::from(ScalarIndexType::BTree)))
+                    Ok(Box::new(ScalarIndexParams::new(ScalarIndexType::BTree)))
                 } else {
                     return Err(Error::InvalidInput {
                         message: format!(
@@ -1738,17 +1738,15 @@ impl NativeTable {
             }
             Index::BTree(_) => {
                 Self::validate_index_type(field, "BTree", supported_btree_data_type)?;
-                Ok(Box::new(ScalarIndexParams::from(ScalarIndexType::BTree)))
+                Ok(Box::new(ScalarIndexParams::new(ScalarIndexType::BTree)))
             }
             Index::Bitmap(_) => {
                 Self::validate_index_type(field, "Bitmap", supported_bitmap_data_type)?;
-                Ok(Box::new(ScalarIndexParams::from(ScalarIndexType::Bitmap)))
+                Ok(Box::new(ScalarIndexParams::new(ScalarIndexType::Bitmap)))
             }
             Index::LabelList(_) => {
                 Self::validate_index_type(field, "LabelList", supported_label_list_data_type)?;
-                Ok(Box::new(ScalarIndexParams::from(
-                    ScalarIndexType::LabelList,
-                )))
+                Ok(Box::new(ScalarIndexParams::new(ScalarIndexType::LabelList)))
             }
             Index::FTS(fts_opts) => {
                 Self::validate_index_type(field, "FTS", supported_fts_data_type)?;

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1721,7 +1721,7 @@ impl NativeTable {
                         /*num_bits=*/ 8,
                         num_sub_vectors as usize,
                         lance_linalg::distance::MetricType::L2,
-                        50, // max_iterations
+                        /*max_iterations=*/ 50,
                     );
                     Ok(Box::new(lance_idx_params))
                 } else if supported_btree_data_type(field.data_type()) {


### PR DESCRIPTION
Enables two new parameters when building indices:

* `name`: Allows explicitly setting a name on the index. Default is `{col_name}_idx`.
* `train` (default `True`): When set to `False`, an empty index will be immediately created.

The upgrade of Lance means there are also additional behaviors from https://github.com/lancedb/lance/commit/cd76a993b8b65877135cb9cfb47448a761ac7f7b:

* When a scalar index is created on a Table, it will be kept around even if all rows are deleted or updated.
* Scalar indices can be created on empty tables. They will default to `train=False` if the table is empty.