### PR TITLE
feat!: support multi-level namespace

### DIFF
--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -158,6 +158,15 @@ export abstract class Connection {
    * List all the table names in this database.
    *
    * Tables will be returned in lexicographical order.
+   * @param {Partial<TableNamesOptions>} options - options to control the
+   * paging / start point (backwards compatibility)
+   *
+   */
+  abstract tableNames(options?: Partial<TableNamesOptions>): Promise<string[]>;
+  /**
+   * List all the table names in this database.
+   *
+   * Tables will be returned in lexicographical order.
    * @param {string[]} namespace - The namespace to list tables from (defaults to root namespace)
    * @param {Partial<TableNamesOptions>} options - options to control the
    * paging / start point
@@ -284,13 +293,27 @@ export class LocalConnection extends Connection {
   }
 
   async tableNames(
-    namespace?: string[],
+    namespaceOrOptions?: string[] | Partial<TableNamesOptions>,
     options?: Partial<TableNamesOptions>,
   ): Promise<string[]> {
+    // Detect if first argument is namespace array or options object
+    let namespace: string[] | undefined;
+    let tableNamesOptions: Partial<TableNamesOptions> | undefined;
+
+    if (Array.isArray(namespaceOrOptions)) {
+      // First argument is namespace array
+      namespace = namespaceOrOptions;
+      tableNamesOptions = options;
+    } else {
+      // First argument is options object (backwards compatibility)
+      namespace = undefined;
+      tableNamesOptions = namespaceOrOptions;
+    }
+
     return this.inner.tableNames(
       namespace ?? [],
-      options?.startAfter,
-      options?.limit,
+      tableNamesOptions?.startAfter,
+      tableNamesOptions?.limit,
     );
   }
 

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -328,7 +328,7 @@ export class LocalConnection extends Connection {
     const data = dataOrNamespace as Record<string, unknown>[] | TableLike;
     const namespace = namespaceOrOptions as string[] | undefined;
     const createOptions = options;
-    
+
     return this._createTableImpl(name, data, namespace, createOptions);
   }
 

--- a/nodejs/src/remote.rs
+++ b/nodejs/src/remote.rs
@@ -76,6 +76,7 @@ pub struct ClientConfig {
     pub retry_config: Option<RetryConfig>,
     pub timeout_config: Option<TimeoutConfig>,
     pub extra_headers: Option<HashMap<String, String>>,
+    pub id_delimiter: Option<String>,
 }
 
 impl From<TimeoutConfig> for lancedb::remote::TimeoutConfig {
@@ -115,6 +116,7 @@ impl From<ClientConfig> for lancedb::remote::ClientConfig {
             retry_config: config.retry_config.map(Into::into).unwrap_or_default(),
             timeout_config: config.timeout_config.map(Into::into).unwrap_or_default(),
             extra_headers: config.extra_headers.unwrap_or_default(),
+            id_delimiter: config.id_delimiter,
         }
     }
 }

--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -21,14 +21,28 @@ class Session:
 
 class Connection(object):
     uri: str
+    async def is_open(self): ...
+    async def close(self): ...
+    async def list_namespaces(
+        self,
+        namespace: List[str],
+        page_token: Optional[str],
+        limit: Optional[int],
+    ) -> List[str]: ...
+    async def create_namespace(self, namespace: List[str]) -> None: ...
+    async def drop_namespace(self, namespace: List[str]) -> None: ...
     async def table_names(
-        self, start_after: Optional[str], limit: Optional[int]
+        self,
+        namespace: List[str],
+        start_after: Optional[str],
+        limit: Optional[int],
     ) -> list[str]: ...
     async def create_table(
         self,
         name: str,
         mode: str,
         data: pa.RecordBatchReader,
+        namespace: List[str] = [],
         storage_options: Optional[Dict[str, str]] = None,
     ) -> Table: ...
     async def create_empty_table(
@@ -36,10 +50,25 @@ class Connection(object):
         name: str,
         mode: str,
         schema: pa.Schema,
+        namespace: List[str] = [],
         storage_options: Optional[Dict[str, str]] = None,
     ) -> Table: ...
-    async def rename_table(self, old_name: str, new_name: str) -> None: ...
-    async def drop_table(self, name: str) -> None: ...
+    async def open_table(
+        self,
+        name: str,
+        namespace: List[str] = [],
+        storage_options: Optional[Dict[str, str]] = None,
+        index_cache_size: Optional[int] = None,
+    ) -> Table: ...
+    async def rename_table(
+        self,
+        cur_name: str,
+        new_name: str,
+        cur_namespace: List[str] = [],
+        new_namespace: List[str] = [],
+    ) -> None: ...
+    async def drop_table(self, name: str, namespace: List[str] = []) -> None: ...
+    async def drop_all_tables(self, namespace: List[str] = []) -> None: ...
 
 class Table:
     def name(self) -> str: ...

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -142,12 +142,7 @@ class LanceNamespaceDBConnection(DBConnection):
         page_token: Optional[str] = None,
         limit: int = 10,
     ) -> Iterable[str]:
-        # Use namespace to list tables
-        # TODO: this is a bug in lance-namespace
-        #  needs to be removed after fix
-        request = ListTablesRequest(
-            id=None if not namespace else namespace, page_token=page_token, limit=limit
-        )
+        request = ListTablesRequest(id=namespace, page_token=page_token, limit=limit)
         response = self._ns.list_tables(request)
         return response.tables if response.tables else []
 
@@ -295,10 +290,8 @@ class LanceNamespaceDBConnection(DBConnection):
         Iterable[str]
             Names of child namespaces.
         """
-        # TODO: this is a bug in lance-namespace
-        #  needs to be removed after fix
         request = ListNamespacesRequest(
-            id=None if not namespace else namespace, page_token=page_token, limit=limit
+            id=namespace, page_token=page_token, limit=limit
         )
         response = self._ns.list_namespaces(request)
         return response.namespaces if response.namespaces else []

--- a/python/python/lancedb/remote/__init__.py
+++ b/python/python/lancedb/remote/__init__.py
@@ -118,6 +118,7 @@ class ClientConfig:
     retry_config: RetryConfig = field(default_factory=RetryConfig)
     timeout_config: Optional[TimeoutConfig] = field(default_factory=TimeoutConfig)
     extra_headers: Optional[dict] = None
+    id_delimiter: Optional[str] = None
 
     def __post_init__(self):
         if isinstance(self.retry_config, dict):

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -1646,13 +1646,16 @@ class LanceTable(Table):
         connection: "LanceDBConnection",
         name: str,
         *,
+        namespace: List[str] = [],
         storage_options: Optional[Dict[str, str]] = None,
         index_cache_size: Optional[int] = None,
     ):
         self._conn = connection
+        self._namespace = namespace
         self._table = LOOP.run(
             connection._conn.open_table(
                 name,
+                namespace=namespace,
                 storage_options=storage_options,
                 index_cache_size=index_cache_size,
             )
@@ -1663,8 +1666,8 @@ class LanceTable(Table):
         return self._table.name
 
     @classmethod
-    def open(cls, db, name, **kwargs):
-        tbl = cls(db, name, **kwargs)
+    def open(cls, db, name, *, namespace: List[str] = [], **kwargs):
+        tbl = cls(db, name, namespace=namespace, **kwargs)
 
         # check the dataset exists
         try:
@@ -2485,6 +2488,7 @@ class LanceTable(Table):
         fill_value: float = 0.0,
         embedding_functions: Optional[List[EmbeddingFunctionConfig]] = None,
         *,
+        namespace: List[str] = [],
         storage_options: Optional[Dict[str, str | bool]] = None,
         data_storage_version: Optional[str] = None,
         enable_v2_manifest_paths: Optional[bool] = None,
@@ -2544,6 +2548,7 @@ class LanceTable(Table):
         """
         self = cls.__new__(cls)
         self._conn = db
+        self._namespace = namespace
 
         if data_storage_version is not None:
             warnings.warn(
@@ -2576,6 +2581,7 @@ class LanceTable(Table):
                 on_bad_vectors=on_bad_vectors,
                 fill_value=fill_value,
                 embedding_functions=embedding_functions,
+                namespace=namespace,
                 storage_options=storage_options,
             )
         )

--- a/python/python/tests/test_namespace.py
+++ b/python/python/tests/test_namespace.py
@@ -23,6 +23,12 @@ from lance_namespace_urllib3_client.models import (
     CreateTableResponse,
     DropTableRequest,
     DropTableResponse,
+    ListNamespacesRequest,
+    ListNamespacesResponse,
+    CreateNamespaceRequest,
+    CreateNamespaceResponse,
+    DropNamespaceRequest,
+    DropNamespaceResponse,
 )
 
 
@@ -31,6 +37,8 @@ class TempNamespace(LanceNamespace):
 
     # Class-level storage to persist table registry across instances
     _global_registry: Dict[str, Dict[str, str]] = {}
+    # Class-level storage for namespaces (supporting 1-level namespace)
+    _global_namespaces: Dict[str, set] = {}
 
     def __init__(self, **properties):
         """Initialize the test namespace.
@@ -44,20 +52,48 @@ class TempNamespace(LanceNamespace):
         root = self.config.root
         if root not in self._global_registry:
             self._global_registry[root] = {}
+        if root not in self._global_namespaces:
+            self._global_namespaces[root] = set()
         self.tables = self._global_registry[root]  # Reference to shared registry
+        self.namespaces = self._global_namespaces[
+            root
+        ]  # Reference to shared namespaces
 
     def list_tables(self, request: ListTablesRequest) -> ListTablesResponse:
         """List all tables in the namespace."""
-        # For simplicity, ignore namespace ID validation
-        tables = list(self.tables.keys())
+        if request.id is None:
+            # List all tables in root namespace
+            tables = [name for name in self.tables.keys() if "." not in name]
+        else:
+            # List tables in specific namespace (1-level only)
+            if len(request.id) == 1:
+                namespace_name = request.id[0]
+                prefix = f"{namespace_name}."
+                tables = [
+                    name[len(prefix) :]
+                    for name in self.tables.keys()
+                    if name.startswith(prefix)
+                ]
+            else:
+                # Multi-level namespaces not supported
+                raise ValueError("Only 1-level namespaces are supported")
         return ListTablesResponse(tables=tables)
 
     def describe_table(self, request: DescribeTableRequest) -> DescribeTableResponse:
         """Describe a table by returning its location."""
-        if not request.id or len(request.id) != 1:
+        if not request.id:
             raise ValueError("Invalid table ID")
 
-        table_name = request.id[0]
+        if len(request.id) == 1:
+            # Root namespace table
+            table_name = request.id[0]
+        elif len(request.id) == 2:
+            # Namespaced table (1-level namespace)
+            namespace_name, table_name = request.id
+            table_name = f"{namespace_name}.{table_name}"
+        else:
+            raise ValueError("Only 1-level namespaces are supported")
+
         if table_name not in self.tables:
             raise RuntimeError(f"Table does not exist: {table_name}")
 
@@ -68,10 +104,22 @@ class TempNamespace(LanceNamespace):
         self, request: CreateTableRequest, request_data: bytes
     ) -> CreateTableResponse:
         """Create a table in the namespace."""
-        if not request.id or len(request.id) != 1:
+        if not request.id:
             raise ValueError("Invalid table ID")
 
-        table_name = request.id[0]
+        if len(request.id) == 1:
+            # Root namespace table
+            table_name = request.id[0]
+            table_uri = f"{self.config.root}/{table_name}.lance"
+        elif len(request.id) == 2:
+            # Namespaced table (1-level namespace)
+            namespace_name, base_table_name = request.id
+            # Add namespace to our namespace set
+            self.namespaces.add(namespace_name)
+            table_name = f"{namespace_name}.{base_table_name}"
+            table_uri = f"{self.config.root}/{namespace_name}/{base_table_name}.lance"
+        else:
+            raise ValueError("Only 1-level namespaces are supported")
 
         # Check if table already exists
         if table_name in self.tables:
@@ -81,13 +129,14 @@ class TempNamespace(LanceNamespace):
             else:
                 raise RuntimeError(f"Table already exists: {table_name}")
 
-        # Generate table URI based on root directory
-        table_uri = f"{self.config.root}/{table_name}.lance"
-
         # Parse the Arrow IPC stream to get the schema and create the actual table
         import pyarrow.ipc as ipc
         import io
         import lance
+        import os
+
+        # Create directory if needed for namespaced tables
+        os.makedirs(os.path.dirname(table_uri), exist_ok=True)
 
         # Read the IPC stream
         reader = ipc.open_stream(io.BytesIO(request_data))
@@ -103,10 +152,19 @@ class TempNamespace(LanceNamespace):
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:
         """Drop a table from the namespace."""
-        if not request.id or len(request.id) != 1:
+        if not request.id:
             raise ValueError("Invalid table ID")
 
-        table_name = request.id[0]
+        if len(request.id) == 1:
+            # Root namespace table
+            table_name = request.id[0]
+        elif len(request.id) == 2:
+            # Namespaced table (1-level namespace)
+            namespace_name, base_table_name = request.id
+            table_name = f"{namespace_name}.{base_table_name}"
+        else:
+            raise ValueError("Only 1-level namespaces are supported")
+
         if table_name not in self.tables:
             raise RuntimeError(f"Table does not exist: {table_name}")
 
@@ -152,6 +210,78 @@ class TempNamespace(LanceNamespace):
         del self.tables[table_name]
         return DeregisterTableResponse()
 
+    def list_namespaces(self, request: ListNamespacesRequest) -> ListNamespacesResponse:
+        """List child namespaces."""
+        if request.id is None:
+            # List root-level namespaces
+            namespaces = list(self.namespaces)
+        elif len(request.id) == 1:
+            # For 1-level namespace, there are no child namespaces
+            namespaces = []
+        else:
+            raise ValueError("Only 1-level namespaces are supported")
+
+        return ListNamespacesResponse(namespaces=namespaces)
+
+    def create_namespace(
+        self, request: CreateNamespaceRequest
+    ) -> CreateNamespaceResponse:
+        """Create a namespace."""
+        if not request.id:
+            raise ValueError("Invalid namespace ID")
+
+        if len(request.id) == 1:
+            # Create 1-level namespace
+            namespace_name = request.id[0]
+            self.namespaces.add(namespace_name)
+
+            # Create directory for the namespace
+            import os
+
+            namespace_dir = f"{self.config.root}/{namespace_name}"
+            os.makedirs(namespace_dir, exist_ok=True)
+        else:
+            raise ValueError("Only 1-level namespaces are supported")
+
+        return CreateNamespaceResponse()
+
+    def drop_namespace(self, request: DropNamespaceRequest) -> DropNamespaceResponse:
+        """Drop a namespace."""
+        if not request.id:
+            raise ValueError("Invalid namespace ID")
+
+        if len(request.id) == 1:
+            # Drop 1-level namespace
+            namespace_name = request.id[0]
+
+            if namespace_name not in self.namespaces:
+                raise RuntimeError(f"Namespace does not exist: {namespace_name}")
+
+            # Check if namespace has any tables
+            prefix = f"{namespace_name}."
+            tables_in_namespace = [
+                name for name in self.tables.keys() if name.startswith(prefix)
+            ]
+            if tables_in_namespace:
+                raise RuntimeError(
+                    f"Cannot drop namespace '{namespace_name}': contains tables"
+                )
+
+            # Remove namespace
+            self.namespaces.remove(namespace_name)
+
+            # Remove directory
+            import shutil
+            import os
+
+            namespace_dir = f"{self.config.root}/{namespace_name}"
+            if os.path.exists(namespace_dir):
+                shutil.rmtree(namespace_dir, ignore_errors=True)
+        else:
+            raise ValueError("Only 1-level namespaces are supported")
+
+        return DropNamespaceResponse()
+
 
 class TempNamespaceConfig:
     """Configuration for TestNamespace."""
@@ -187,12 +317,16 @@ class TestNamespaceConnection:
         # Clear the TestNamespace registry for this test
         if self.temp_dir in TempNamespace._global_registry:
             TempNamespace._global_registry[self.temp_dir].clear()
+        if self.temp_dir in TempNamespace._global_namespaces:
+            TempNamespace._global_namespaces[self.temp_dir].clear()
 
     def teardown_method(self):
         """Clean up test fixtures."""
         # Clear the TestNamespace registry
         if self.temp_dir in TempNamespace._global_registry:
             del TempNamespace._global_registry[self.temp_dir]
+        if self.temp_dir in TempNamespace._global_namespaces:
+            del TempNamespace._global_namespaces[self.temp_dir]
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_connect_namespace_test(self):
@@ -412,3 +546,78 @@ class TestNamespaceConnection:
             ]
         )
         db.create_table("test_table", schema=schema, storage_options=table_opts)
+
+    def test_namespace_operations(self):
+        """Test namespace management operations."""
+        db = lancedb.connect_namespace("temp", {"root": self.temp_dir})
+
+        # Initially no namespaces
+        assert len(list(db.list_namespaces())) == 0
+
+        # Create a namespace
+        db.create_namespace(["test_namespace"])
+
+        # Verify namespace exists
+        namespaces = list(db.list_namespaces())
+        assert "test_namespace" in namespaces
+        assert len(namespaces) == 1
+
+        # Create table in namespace
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int64()),
+                pa.field("vector", pa.list_(pa.float32(), 2)),
+            ]
+        )
+        table = db.create_table(
+            "test_table", schema=schema, namespace=["test_namespace"]
+        )
+        assert table is not None
+
+        # Verify table exists in namespace
+        tables_in_namespace = list(db.table_names(namespace=["test_namespace"]))
+        assert "test_table" in tables_in_namespace
+        assert len(tables_in_namespace) == 1
+
+        # Open table from namespace
+        table = db.open_table("test_table", namespace=["test_namespace"])
+        assert table is not None
+        assert table.name == "test_table"
+
+        # Drop table from namespace
+        db.drop_table("test_table", namespace=["test_namespace"])
+
+        # Verify table no longer exists in namespace
+        tables_in_namespace = list(db.table_names(namespace=["test_namespace"]))
+        assert len(tables_in_namespace) == 0
+
+        # Drop namespace
+        db.drop_namespace(["test_namespace"])
+
+        # Verify namespace no longer exists
+        namespaces = list(db.list_namespaces())
+        assert len(namespaces) == 0
+
+    def test_namespace_with_tables_cannot_be_dropped(self):
+        """Test that namespaces containing tables cannot be dropped."""
+        db = lancedb.connect_namespace("temp", {"root": self.temp_dir})
+
+        # Create namespace and table
+        db.create_namespace(["test_namespace"])
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int64()),
+                pa.field("vector", pa.list_(pa.float32(), 2)),
+            ]
+        )
+        db.create_table("test_table", schema=schema, namespace=["test_namespace"])
+
+        # Try to drop namespace with tables - should fail
+        with pytest.raises(RuntimeError, match="contains tables"):
+            db.drop_namespace(["test_namespace"])
+
+        # Drop table first
+        db.drop_table("test_table", namespace=["test_namespace"])
+
+        # Now dropping namespace should work
+        db.drop_namespace(["test_namespace"])

--- a/python/python/tests/test_namespace.py
+++ b/python/python/tests/test_namespace.py
@@ -61,7 +61,7 @@ class TempNamespace(LanceNamespace):
 
     def list_tables(self, request: ListTablesRequest) -> ListTablesResponse:
         """List all tables in the namespace."""
-        if request.id is None:
+        if not request.id:
             # List all tables in root namespace
             tables = [name for name in self.tables.keys() if "." not in name]
         else:
@@ -212,7 +212,7 @@ class TempNamespace(LanceNamespace):
 
     def list_namespaces(self, request: ListNamespacesRequest) -> ListNamespacesResponse:
         """List child namespaces."""
-        if request.id is None:
+        if not request.id:
             # List root-level namespaces
             namespaces = list(self.namespaces)
         elif len(request.id) == 1:

--- a/rust/lancedb/examples/simple.rs
+++ b/rust/lancedb/examples/simple.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     // --8<-- [end:delete]
 
     // --8<-- [start:drop_table]
-    db.drop_table("my_table").await.unwrap();
+    db.drop_table("my_table", None).await.unwrap();
     // --8<-- [end:drop_table]
     Ok(())
 }

--- a/rust/lancedb/examples/simple.rs
+++ b/rust/lancedb/examples/simple.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     // --8<-- [end:delete]
 
     // --8<-- [start:drop_table]
-    db.drop_table("my_table", None).await.unwrap();
+    db.drop_table("my_table", &[]).await.unwrap();
     // --8<-- [end:drop_table]
     Ok(())
 }

--- a/rust/lancedb/src/catalog/listing.rs
+++ b/rust/lancedb/src/catalog/listing.rs
@@ -379,6 +379,7 @@ mod tests {
             data: CreateTableData::Empty(TableDefinition::new_from_schema(dummy_schema)),
             mode: Default::default(),
             write_options: Default::default(),
+            namespace: vec![],
         })
         .await
         .unwrap();
@@ -414,6 +415,7 @@ mod tests {
             data: CreateTableData::Empty(TableDefinition::new_from_schema(dummy_schema)),
             mode: Default::default(),
             write_options: Default::default(),
+            namespace: vec![],
         })
         .await
         .unwrap();

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -299,10 +299,12 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
                 self.client.clone(),
                 table.clone(),
                 request.namespace.clone(),
-                table_identifier,
+                table_identifier.clone(),
                 version.clone(),
             ));
-            self.table_cache.insert(table.clone(), remote_table).await;
+            self.table_cache
+                .insert(table_identifier, remote_table)
+                .await;
         }
         Ok(tables)
     }

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -265,7 +265,7 @@ fn build_namespace_identifier(namespace: &[String], delimiter: &str) -> String {
     }
 }
 
-/// Build a secure cache key using binary encoding with length prefixes.
+/// Build a secure cache key using length prefixes.
 /// This format is completely unambiguous regardless of delimiter or content.
 /// Format: [u32_len][namespace1][u32_len][namespace2]...[u32_len][table_name]
 /// Returns a hex-encoded string for use as a cache key.

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -509,6 +509,10 @@ pub trait BaseTable: std::fmt::Display + std::fmt::Debug + Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
     /// Get the name of the table.
     fn name(&self) -> &str;
+    /// Get the namespace of the table.
+    fn namespace(&self) -> &[String];
+    /// Get the id of the table
+    fn id(&self) -> &str;
     /// Get the arrow [Schema] of the table.
     async fn schema(&self) -> Result<SchemaRef>;
     /// Count the number of rows in this table.
@@ -2004,6 +2008,16 @@ impl BaseTable for NativeTable {
     }
 
     fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn namespace(&self) -> &[String] {
+        // Native tables don't support namespaces yet, return empty slice for root namespace
+        &[]
+    }
+
+    fn id(&self) -> &str {
+        // For native tables, id is same as name since no namespace support
         self.name.as_str()
     }
 

--- a/rust/lancedb/tests/object_store_test.rs
+++ b/rust/lancedb/tests/object_store_test.rs
@@ -130,7 +130,7 @@ async fn test_minio_lifecycle() -> Result<()> {
     let data = RecordBatchIterator::new(vec![Ok(data.clone())], data.schema());
     table.add(data).execute().await?;
 
-    db.drop_table("test_table").await?;
+    db.drop_table("test_table", &[]).await?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds support of multi-level namespace in a LanceDB database, according to the Lance Namespace spec.

This allows users to create namespace inside a database connection, perform create, drop, list, list_tables in a namespace. (other operations like update, describe will be in a follow-up PR)

The 3 types of database connections behave like the following:
1 Local database connections will continue to have just a flat list of tables for backwards compatibility.
2. Remote database connections will make REST API calls according to the APIs in the Lance Namespace spec. 
3. Lance Namespace connections will invoke the corresponding operations against the specific namespace implementation which could have different behaviors regarding these APIs.

All the table APIs now take identifier instead of name, for example `/v1/table/{name}/create` is now `/v1/table/{id}/create`. If a table is directly in the root namespace, the API call is identical. If the table is in a namespace, then the full table ID should be used, with `$` as the default delimiter (`.` is a special character and creates issues with URL parsing so `$` is used), for example `/v1/table/ns1$table1/create`. If a different parameter needs to be passed in, user can configure the `id_delimiter` in client config and that becomes a query parameter, for example `/v1/table/ns1__table1/create?delimiter=__`

The Python and Typescript APIs are kept backwards compatible, but the following Rust APIs are not:
1. `Connection::drop_table(&self, name: impl AsRef<str>) -> Result<()>` is now `Connection::drop_table(&self, name: impl AsRef<str>, namespace: &[String]) -> Result<()>`
2. `Connection::drop_all_tables(&self) -> Result<()>` is now `Connection::drop_all_tables(&self, name: impl AsRef<str>) -> Result<()>`