### PR TITLE
feat: add `name` parameter to remaining Python create index calls

### DIFF
--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -115,6 +115,7 @@ class RemoteTable(Table):
         *,
         replace: bool = False,
         wait_timeout: timedelta = None,
+        name: Optional[str] = None,
     ):
         """Creates a scalar index
         Parameters
@@ -139,7 +140,11 @@ class RemoteTable(Table):
 
         LOOP.run(
             self._table.create_index(
-                column, config=config, replace=replace, wait_timeout=wait_timeout
+                column,
+                config=config,
+                replace=replace,
+                wait_timeout=wait_timeout,
+                name=name,
             )
         )
 
@@ -161,6 +166,7 @@ class RemoteTable(Table):
         ngram_min_length: int = 3,
         ngram_max_length: int = 3,
         prefix_only: bool = False,
+        name: Optional[str] = None,
     ):
         config = FTS(
             with_position=with_position,
@@ -177,7 +183,11 @@ class RemoteTable(Table):
         )
         LOOP.run(
             self._table.create_index(
-                column, config=config, replace=replace, wait_timeout=wait_timeout
+                column,
+                config=config,
+                replace=replace,
+                wait_timeout=wait_timeout,
+                name=name,
             )
         )
 

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -783,6 +783,7 @@ class Table(ABC):
         replace: bool = True,
         index_type: ScalarIndexType = "BTREE",
         wait_timeout: Optional[timedelta] = None,
+        name: Optional[str] = None,
     ):
         """Create a scalar index on a column.
 
@@ -797,6 +798,8 @@ class Table(ABC):
             The type of index to create.
         wait_timeout: timedelta, optional
             The timeout to wait if indexing is asynchronous.
+        name: str, optional
+            The name of the index. If not provided, a default name will be generated.
         Examples
         --------
 
@@ -859,6 +862,7 @@ class Table(ABC):
         ngram_max_length: int = 3,
         prefix_only: bool = False,
         wait_timeout: Optional[timedelta] = None,
+        name: Optional[str] = None,
     ):
         """Create a full-text search index on the table.
 
@@ -923,6 +927,8 @@ class Table(ABC):
             Whether to only index the prefix of the token for ngram tokenizer.
         wait_timeout: timedelta, optional
             The timeout to wait if indexing is asynchronous.
+        name: str, optional
+            The name of the index. If not provided, a default name will be generated.
         """
         raise NotImplementedError
 
@@ -2102,6 +2108,7 @@ class LanceTable(Table):
         *,
         replace: bool = True,
         index_type: ScalarIndexType = "BTREE",
+        name: Optional[str] = None,
     ):
         if index_type == "BTREE":
             config = BTree()
@@ -2112,7 +2119,7 @@ class LanceTable(Table):
         else:
             raise ValueError(f"Unknown index type {index_type}")
         return LOOP.run(
-            self._table.create_index(column, replace=replace, config=config)
+            self._table.create_index(column, replace=replace, config=config, name=name)
         )
 
     def create_fts_index(
@@ -2136,6 +2143,7 @@ class LanceTable(Table):
         ngram_min_length: int = 3,
         ngram_max_length: int = 3,
         prefix_only: bool = False,
+        name: Optional[str] = None,
     ):
         if not use_tantivy:
             if not isinstance(field_names, str):
@@ -2173,6 +2181,7 @@ class LanceTable(Table):
                     field_names,
                     replace=replace,
                     config=config,
+                    name=name,
                 )
             )
             return

--- a/python/python/tests/test_fts.py
+++ b/python/python/tests/test_fts.py
@@ -157,7 +157,16 @@ def test_create_index_with_stemming(tmp_path, table):
 def test_create_inverted_index(table, use_tantivy, with_position):
     if use_tantivy and not with_position:
         pytest.skip("we don't support building a tantivy index without position")
-    table.create_fts_index("text", use_tantivy=use_tantivy, with_position=with_position)
+    table.create_fts_index(
+        "text",
+        use_tantivy=use_tantivy,
+        with_position=with_position,
+        name="custom_fts_index",
+    )
+    if not use_tantivy:
+        indices = table.list_indices()
+        fts_indices = [i for i in indices if i.index_type == "FTS"]
+        assert any(i.name == "custom_fts_index" for i in fts_indices)
 
 
 def test_populate_index(tmp_path, table):

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -1274,11 +1274,13 @@ def test_create_scalar_index(mem_db: DBConnection):
         "my_table",
         data=test_data,
     )
+    # Test with default name
     table.create_scalar_index("x")
     indices = table.list_indices()
     assert len(indices) == 1
     scalar_index = indices[0]
     assert scalar_index.index_type == "BTree"
+    assert scalar_index.name == "x_idx"  # Default name
 
     # Confirm that prefiltering still works with the scalar index column
     results = table.search().where("x = 'c'").to_arrow()
@@ -1291,6 +1293,14 @@ def test_create_scalar_index(mem_db: DBConnection):
     table.drop_index(scalar_index.name)
     indices = table.list_indices()
     assert len(indices) == 0
+
+    # Test with custom name
+    table.create_scalar_index("y", name="custom_y_index")
+    indices = table.list_indices()
+    assert len(indices) == 1
+    scalar_index = indices[0]
+    assert scalar_index.index_type == "BTree"
+    assert scalar_index.name == "custom_y_index"
 
 
 def test_empty_query(mem_db: DBConnection):


### PR DESCRIPTION
## Summary
This PR adds the missing `name` parameter to `create_scalar_index` and `create_fts_index` methods in the Python SDK, which was inadvertently omitted when it was added to `create_index` in PR #2586.

## Changes
- Add `name: Optional[str] = None` parameter to abstract `Table.create_scalar_index` and `Table.create_fts_index` methods
- Update `LanceTable` implementation to accept and pass the `name` parameter to the underlying Rust layer
- Update `RemoteTable` implementation to accept and pass the `name` parameter
- Enhanced tests to verify custom index names work correctly for both scalar and FTS indices
- When `name` is not provided, default names are generated (e.g., `{column}_idx`)

## Test plan
- [x] Added test cases for custom names in scalar index creation
- [x] Added test cases for custom names in FTS index creation  
- [x] Verified existing tests continue to pass
- [x] Code formatting and linting checks pass

This ensures API consistency across all index creation methods in the LanceDB Python SDK.

Fixes #2616

🤖 Generated with [Claude Code](https://claude.ai/code)