### PR TITLE
fix(node): allow undefined/omitted values for nullable vector fields

### DIFF
--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -65,7 +65,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
 
     it("be displayable", async () => {
       expect(table.display()).toMatch(
-        /NativeTable\(some_table, uri=.*, read_consistency_interval=None\)/,
+        /NativeTable\(some_table, uri=.*, read_consistency_interval=None\)/
       );
       table.close();
       expect(table.display()).toBe("ClosedTable(some_table)");
@@ -195,7 +195,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
           new arrow.Field(
             "vector",
             new arrow.FixedSizeList(512, new arrow.Field("item", floatType)),
-            true,
+            true
           ),
         ]);
 
@@ -209,20 +209,19 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
         } catch (e) {
           expect(e).toBeUndefined();
         }
-      },
+      }
     );
 
-    // TODO: https://github.com/lancedb/lancedb/issues/1832
-    it.skip("should be able to omit nullable fields", async () => {
+    it("should be able to omit nullable fields", async () => {
       const db = await connect(tmpDir.name);
       const schema = new arrow.Schema([
         new arrow.Field(
           "vector",
           new arrow.FixedSizeList(
             2,
-            new arrow.Field("item", new arrow.Float64()),
+            new arrow.Field("item", new arrow.Float64())
           ),
-          true,
+          true
         ),
         new arrow.Field("item", new arrow.Utf8(), true),
         new arrow.Field("price", new arrow.Float64(), false),
@@ -272,7 +271,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
 
       const data2 = { x: null, id: "bar" };
       await expect(table.add([data2])).rejects.toThrow(
-        "declared as non-nullable but contains null values",
+        "declared as non-nullable but contains null values"
       );
 
       // But we can alter columns to make them nullable
@@ -331,7 +330,38 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
       const table = await db.createTable("my_table", data);
       expect(await table.countRows()).toEqual(2);
     });
-  },
+
+    it("should allow undefined and omitted nullable vector fields", async () => {
+      // Test for the bug: can't pass undefined or omit vector column
+      const db = await connect("memory://");
+      const schema = new arrow.Schema([
+        new arrow.Field(
+          "vector",
+          new arrow.FixedSizeList(
+            32,
+            new arrow.Field("item", new arrow.Float32(), true)
+          ),
+          true // nullable = true
+        ),
+      ]);
+      const table = await db.createEmptyTable("test_table", schema);
+
+      // Should not throw error for undefined value
+      await table.add([{ vector: undefined }]);
+
+      // Should not throw error for omitted field
+      await table.add([{}]);
+
+      // Should still work for null
+      await table.add([{ vector: null }]);
+
+      // Should still work for actual vector
+      const testVector = new Array(32).fill(0.5);
+      await table.add([{ vector: testVector }]);
+
+      expect(await table.countRows()).toEqual(4);
+    });
+  }
 );
 
 describe("merge insert", () => {
@@ -399,7 +429,7 @@ describe("merge insert", () => {
     // round trip to arrow and back to json to avoid comparing arrow objects to js object
     // biome-ignore lint/suspicious/noExplicitAny: test
     let res: any[] = JSON.parse(
-      JSON.stringify((await table.toArrow()).toArray()),
+      JSON.stringify((await table.toArrow()).toArray())
     );
     res = res.sort((a, b) => a.a - b.a);
 
@@ -421,7 +451,7 @@ describe("merge insert", () => {
     ];
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     let res: any[] = JSON.parse(
-      JSON.stringify((await table.toArrow()).toArray()),
+      JSON.stringify((await table.toArrow()).toArray())
     );
     res = res.sort((a, b) => a.a - b.a);
     expect(res).toEqual(expected);
@@ -445,7 +475,7 @@ describe("merge insert", () => {
     ];
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     let res: any[] = JSON.parse(
-      JSON.stringify((await table.toArrow()).toArray()),
+      JSON.stringify((await table.toArrow()).toArray())
     );
     res = res.sort((a, b) => a.a - b.a);
     expect(res).toEqual(expected);
@@ -469,7 +499,7 @@ describe("merge insert", () => {
 
     // biome-ignore lint/suspicious/noExplicitAny: test
     let res: any[] = JSON.parse(
-      JSON.stringify((await table.toArrow()).toArray()),
+      JSON.stringify((await table.toArrow()).toArray())
     );
     res = res.sort((a, b) => a.a - b.a);
     expect(res).toEqual(expected);
@@ -485,7 +515,7 @@ describe("merge insert", () => {
         .mergeInsert("a")
         .whenMatchedUpdateAll()
         .whenNotMatchedInsertAll()
-        .execute(newData, { timeoutMs: 0 }),
+        .execute(newData, { timeoutMs: 0 })
     ).rejects.toThrow("merge insert timed out");
   });
 });
@@ -515,7 +545,7 @@ describe("When creating an index", () => {
         })),
       {
         schema,
-      },
+      }
     );
     queryVec = data.toArray()[5].vec.toJSON();
     tbl = await db.createTable("test", data);
@@ -585,10 +615,10 @@ describe("When creating an index", () => {
     expect(rst.numRows).toBe(2);
 
     expect(() => tbl.query().nearestTo(queryVec).minimumNprobes(0)).toThrow(
-      "Invalid input, minimum_nprobes must be greater than 0",
+      "Invalid input, minimum_nprobes must be greater than 0"
     );
     expect(() => tbl.query().nearestTo(queryVec).maximumNprobes(5)).toThrow(
-      "Invalid input, maximum_nprobes must be greater than or equal to minimum_nprobes",
+      "Invalid input, maximum_nprobes must be greater than or equal to minimum_nprobes"
     );
 
     await tbl.dropIndex("vec_idx");
@@ -784,7 +814,7 @@ describe("When creating an index", () => {
     // Default is replace=true
     await tbl.createIndex("id");
     await expect(tbl.createIndex("id", { replace: false })).rejects.toThrow(
-      "already exists",
+      "already exists"
     );
     await tbl.createIndex("id", { replace: true });
   });
@@ -908,8 +938,8 @@ describe("When creating an index", () => {
               .fill(1)
               .map(() => Math.floor(Math.random() * 255)),
           })),
-        { schema: binarySchema },
-      ),
+        { schema: binarySchema }
+      )
     );
     await tbl.createIndex("vec", {
       config: Index.ivfFlat({ numPartitions: 10, distanceType: "hamming" }),
@@ -932,7 +962,7 @@ describe("When creating an index", () => {
       new Field("vec", new FixedSizeList(32, new Field("item", new Float32()))),
       new Field(
         "vec2",
-        new FixedSizeList(64, new Field("item", new Float32())),
+        new FixedSizeList(64, new Field("item", new Float32()))
       ),
     ]);
     const tbl = await db.createTable(
@@ -949,8 +979,8 @@ describe("When creating an index", () => {
               .fill(1)
               .map(() => Math.random()),
           })),
-        { schema },
-      ),
+        { schema }
+      )
     );
 
     // Only build index over v1
@@ -965,7 +995,7 @@ describe("When creating an index", () => {
       .nearestTo(
         Array(32)
           .fill(1)
-          .map(() => Math.random()),
+          .map(() => Math.random())
       )
       .toArrow();
     expect(rst.numRows).toBe(2);
@@ -978,12 +1008,12 @@ describe("When creating an index", () => {
         .nearestTo(
           Array(64)
             .fill(1)
-            .map(() => Math.random()),
+            .map(() => Math.random())
         )
         .column("vec")
-        .toArrow(),
+        .toArrow()
     ).rejects.toThrow(
-      /.* query dim\(64\) doesn't match the column vec vector dim\(32\).*/,
+      /.* query dim\(64\) doesn't match the column vec vector dim\(32\).*/
     );
 
     const query64 = Array(64)
@@ -1018,15 +1048,15 @@ describe("When querying a table", () => {
     await table.createIndex("text", { config: Index.fts() });
 
     await expect(
-      table.query().where("text != 'a'").toArray({ timeoutMs: 0 }),
+      table.query().where("text != 'a'").toArray({ timeoutMs: 0 })
     ).rejects.toThrow("Query timeout");
 
     await expect(
-      table.query().nearestTo([0.0, 0.0]).toArrow({ timeoutMs: 0 }),
+      table.query().nearestTo([0.0, 0.0]).toArrow({ timeoutMs: 0 })
     ).rejects.toThrow("Query timeout");
 
     await expect(
-      table.search("a", "fts").toArray({ timeoutMs: 0 }),
+      table.search("a", "fts").toArray({ timeoutMs: 0 })
     ).rejects.toThrow("Query timeout");
 
     await expect(
@@ -1034,7 +1064,7 @@ describe("When querying a table", () => {
         .query()
         .nearestToText("a")
         .nearestTo([0.0, 0.0])
-        .toArrow({ timeoutMs: 0 }),
+        .toArrow({ timeoutMs: 0 })
     ).rejects.toThrow("Query timeout");
   });
 });
@@ -1101,7 +1131,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float32(), true)),
-        true,
+        true
       ),
       new Field("price", new Float32(), false),
     ]);
@@ -1115,7 +1145,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float32(), true)),
-        true,
+        true
       ),
       new Field("price", new Float64(), false),
     ]);
@@ -1142,7 +1172,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float32(), true)),
-        true,
+        true
       ),
       new Field("price", new Float64(), true),
     ]);
@@ -1154,7 +1184,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float32(), true)),
-        true,
+        true
       ),
       new Field("price", new Float64(), true),
     ]);
@@ -1171,7 +1201,7 @@ describe("schema evolution", function () {
       new Field(
         "vector",
         new FixedSizeList(2, new Field("item", new Float64(), true)),
-        true,
+        true
       ),
       new Field("price", new Float64(), true),
     ]);
@@ -1221,15 +1251,15 @@ describe("schema evolution", function () {
       new arrow.List(new arrow.Field("item", new arrow.Float32(), true)),
       new arrow.FixedSizeList(
         2,
-        new arrow.Field("item", new arrow.Float64(), true),
+        new arrow.Field("item", new arrow.Float64(), true)
       ),
       new arrow.FixedSizeList(
         2,
-        new arrow.Field("item", new arrow.Float16(), true),
+        new arrow.Field("item", new arrow.Float16(), true)
       ),
       new arrow.FixedSizeList(
         2,
-        new arrow.Field("item", new arrow.Float32(), true),
+        new arrow.Field("item", new arrow.Float32(), true)
       ),
     ];
     const tableLists = await con.createTable("lists", [{ val: [2.1, 3.2] }], {
@@ -1237,7 +1267,7 @@ describe("schema evolution", function () {
         new Field(
           "val",
           new FixedSizeList(2, new arrow.Field("item", new Float32())),
-          true,
+          true
         ),
       ]),
     });
@@ -1285,7 +1315,7 @@ describe("when dealing with versioning", () => {
     expect(await table.countRows()).toBe(1);
     // Can't add data in time travel mode
     await expect(table.add([{ id: 3n, vector: [0.1, 0.2] }])).rejects.toThrow(
-      "table cannot be modified when a specific version is checked out",
+      "table cannot be modified when a specific version is checked out"
     );
     // Can go back to normal mode
     await table.checkoutLatest();
@@ -1302,7 +1332,7 @@ describe("when dealing with versioning", () => {
     expect(await table.countRows()).toBe(2);
     // Can't use restore if not checked out
     await expect(table.restore()).rejects.toThrow(
-      "checkout before running restore",
+      "checkout before running restore"
     );
   });
 });
@@ -1429,7 +1459,9 @@ describe("when optimizing a dataset", () => {
 
   it("delete unverified", async () => {
     const version = await table.version();
-    const versionFile = `${tmpDir.name}/${table.name}.lance/_versions/${version - 1}.manifest`;
+    const versionFile = `${tmpDir.name}/${table.name}.lance/_versions/${
+      version - 1
+    }.manifest`;
     fs.rmSync(versionFile);
 
     let stats = await table.optimize({ deleteUnverified: false });
@@ -1518,7 +1550,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
       const table = await db.createTable("test", data);
 
       expect(table.search("hello", "vector").toArray()).rejects.toThrow(
-        "No embedding functions are defined in the table",
+        "No embedding functions are defined in the table"
       );
     });
 
@@ -1610,7 +1642,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
 
       const results3 = await table
         .search(
-          new MatchQuery("hello world", "text", { operator: Operator.And }),
+          new MatchQuery("hello world", "text", { operator: Operator.And })
         )
         .toArray();
       expect(results3.length).toBe(1);
@@ -1693,7 +1725,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
 
       const prefixResults = await table
         .search(
-          new MatchQuery("foo", "text", { fuzziness: 3, prefixLength: 3 }),
+          new MatchQuery("foo", "text", { fuzziness: 3, prefixLength: 3 })
         )
         .toArray();
       expect(prefixResults.length).toBe(2);
@@ -1720,7 +1752,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
           new BooleanQuery([
             [Occur.Should, new MatchQuery("cat", "text")],
             [Occur.Should, new MatchQuery("dog", "text")],
-          ]),
+          ])
         )
         .toArray();
       expect(shouldResults.length).toBe(4);
@@ -1730,7 +1762,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
           new BooleanQuery([
             [Occur.Must, new MatchQuery("cat", "text")],
             [Occur.Must, new MatchQuery("dog", "text")],
-          ]),
+          ])
         )
         .toArray();
       expect(mustResults.length).toBe(2);
@@ -1740,7 +1772,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
           new BooleanQuery([
             [Occur.Must, new MatchQuery("cat", "text")],
             [Occur.MustNot, new MatchQuery("dog", "text")],
-          ]),
+          ])
         )
         .toArray();
       expect(mustNotResults.length).toBe(1);
@@ -1818,7 +1850,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
       expect(results.length).toBe(2);
       expect(results[0].text).toBe(data[1].text);
     });
-  },
+  }
 );
 
 describe("when calling explainPlan", () => {
@@ -1911,7 +1943,7 @@ describe("column name options", () => {
     for (let i = 0; i < 256; i++) {
       data.push({
         multivector: Array.from({ length: 10 }, () =>
-          Array(2).fill(Math.random()),
+          Array(2).fill(Math.random())
         ),
       });
     }
@@ -1922,9 +1954,9 @@ describe("column name options", () => {
           new List(
             new Field(
               "item",
-              new FixedSizeList(2, new Field("item", new Float32())),
-            ),
-          ),
+              new FixedSizeList(2, new Field("item", new Float32()))
+            )
+          )
         ),
       ]),
     });

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -374,7 +374,7 @@ export class MakeArrowTableOptions {
 export function makeArrowTable(
   data: Array<Record<string, unknown>>,
   options?: Partial<MakeArrowTableOptions>,
-  metadata?: Map<string, string>,
+  metadata?: Map<string, string>
 ): ArrowTable {
   const opt = new MakeArrowTableOptions(options !== undefined ? options : {});
   let schema: Schema | undefined = undefined;
@@ -383,7 +383,7 @@ export function makeArrowTable(
     schema = validateSchemaEmbeddings(
       schema as Schema,
       data,
-      options?.embeddingFunction,
+      options?.embeddingFunction
     );
   }
 
@@ -420,7 +420,7 @@ export function makeArrowTable(
 function inferSchema(
   data: Array<Record<string, unknown>>,
   schema: Schema | undefined,
-  opts: MakeArrowTableOptions,
+  opts: MakeArrowTableOptions
 ): Schema {
   // We will collect all fields we see in the data.
   const pathTree = new PathTree<DataType>();
@@ -433,7 +433,7 @@ function inferSchema(
           const field = getFieldForPath(schema, path);
           if (field === undefined) {
             throw new Error(
-              `Found field not in schema: ${path.join(".")} at row ${rowI}`,
+              `Found field not in schema: ${path.join(".")} at row ${rowI}`
             );
           } else {
             pathTree.set(path, field.type);
@@ -442,7 +442,7 @@ function inferSchema(
           const inferredType = inferType(value, path, opts);
           if (inferredType === undefined) {
             throw new Error(`Failed to infer data type for field ${path.join(
-              ".",
+              "."
             )} at row ${rowI}. \
                              Consider providing an explicit schema.`);
           }
@@ -478,7 +478,7 @@ function inferSchema(
   } else {
     function takeMatchingFields(
       fields: Field[],
-      pathTree: PathTree<DataType>,
+      pathTree: PathTree<DataType>
     ): Field[] {
       const outFields = [];
       for (const field of fields) {
@@ -488,11 +488,11 @@ function inferSchema(
             const struct = field.type as Struct;
             const children = takeMatchingFields(struct.children, value);
             outFields.push(
-              new Field(field.name, new Struct(children), field.nullable),
+              new Field(field.name, new Struct(children), field.nullable)
             );
           } else {
             outFields.push(
-              new Field(field.name, value as DataType, field.nullable),
+              new Field(field.name, value as DataType, field.nullable)
             );
           }
         }
@@ -506,7 +506,7 @@ function inferSchema(
 
 function* rowPathsAndValues(
   row: Record<string, unknown>,
-  basePath: string[] = [],
+  basePath: string[] = []
 ): Generator<[string[], unknown]> {
   for (const [key, value] of Object.entries(row)) {
     if (isObject(value)) {
@@ -535,7 +535,7 @@ function getFieldForPath(schema: Schema, path: string[]): Field | undefined {
   for (const key of path) {
     if (current instanceof Schema) {
       const field: Field | undefined = current.fields.find(
-        (f) => f.name === key,
+        (f) => f.name === key
       );
       if (field === undefined) {
         return undefined;
@@ -567,7 +567,7 @@ function getFieldForPath(schema: Schema, path: string[]): Field | undefined {
 function inferType(
   value: unknown,
   path: string[],
-  opts: MakeArrowTableOptions,
+  opts: MakeArrowTableOptions
 ): DataType | undefined {
   if (typeof value === "bigint") {
     return new Int64();
@@ -593,7 +593,7 @@ function inferType(
       const floatType = sanitizeType(opts.vectorColumns[path[0]].type);
       return new FixedSizeList(
         value.length,
-        new Field("item", floatType, true),
+        new Field("item", floatType, true)
       );
     }
     const valueType = inferType(value[0], path, opts);
@@ -668,7 +668,7 @@ class PathTree<V> {
 function transposeData(
   data: Record<string, unknown>[],
   field: Field,
-  path: string[] = [],
+  path: string[] = []
 ): Vector {
   if (field.type instanceof Struct) {
     const childFields = field.type.children;
@@ -710,7 +710,7 @@ function transposeData(
  */
 export function makeEmptyTable(
   schema: SchemaLike,
-  metadata?: Map<string, string>,
+  metadata?: Map<string, string>
 ): ArrowTable {
   return makeArrowTable([], { schema }, metadata);
 }
@@ -747,7 +747,7 @@ function makeListVector(lists: unknown[][]): Vector<unknown> {
 function makeVector(
   values: unknown[],
   type?: DataType,
-  stringAsDictionary?: boolean,
+  stringAsDictionary?: boolean
   // biome-ignore lint/suspicious/noExplicitAny: skip
 ): Vector<any> {
   if (type !== undefined) {
@@ -781,13 +781,13 @@ function makeVector(
   }
   if (values.length === 0) {
     throw Error(
-      "makeVector requires at least one value or the type must be specfied",
+      "makeVector requires at least one value or the type must be specfied"
     );
   }
   const sampleValue = values.find((val) => val !== null && val !== undefined);
   if (sampleValue === undefined) {
     throw Error(
-      "makeVector cannot infer the type if all values are null or undefined",
+      "makeVector cannot infer the type if all values are null or undefined"
     );
   }
   if (Array.isArray(sampleValue)) {
@@ -812,7 +812,7 @@ function makeVector(
 /** Helper function to apply embeddings from metadata to an input table */
 async function applyEmbeddingsFromMetadata(
   table: ArrowTable,
-  schema: Schema,
+  schema: Schema
 ): Promise<ArrowTable> {
   const registry = getRegistry();
   const functions = await registry.parseFunctions(schema.metadata);
@@ -821,7 +821,7 @@ async function applyEmbeddingsFromMetadata(
     table.schema.fields.map((field) => [
       field.name,
       table.getChild(field.name)!,
-    ]),
+    ])
   );
 
   for (const functionEntry of functions.values()) {
@@ -829,7 +829,7 @@ async function applyEmbeddingsFromMetadata(
     const destColumn = functionEntry.vectorColumn ?? "vector";
     if (sourceColumn === undefined) {
       throw new Error(
-        `Cannot apply embedding function because the source column '${functionEntry.sourceColumn}' was not present in the data`,
+        `Cannot apply embedding function because the source column '${functionEntry.sourceColumn}' was not present in the data`
       );
     }
 
@@ -845,16 +845,17 @@ async function applyEmbeddingsFromMetadata(
 
     if (table.batches.length > 1) {
       throw new Error(
-        "Internal error: `makeArrowTable` unexpectedly created a table with more than one batch",
+        "Internal error: `makeArrowTable` unexpectedly created a table with more than one batch"
       );
     }
     const values = sourceColumn.toArray();
 
-    const vectors =
-      await functionEntry.function.computeSourceEmbeddings(values);
+    const vectors = await functionEntry.function.computeSourceEmbeddings(
+      values
+    );
     if (vectors.length !== values.length) {
       throw new Error(
-        "Embedding function did not return an embedding for each input element",
+        "Embedding function did not return an embedding for each input element"
       );
     }
     let destType: DataType;
@@ -864,7 +865,7 @@ async function applyEmbeddingsFromMetadata(
     } else {
       throw new Error(
         "Expected FixedSizeList as datatype for vector field, instead got: " +
-          dtype,
+          dtype
       );
     }
     const vector = makeVector(vectors, destType);
@@ -887,7 +888,7 @@ async function applyEmbeddingsFromMetadata(
 async function applyEmbeddings<T>(
   table: ArrowTable,
   embeddings?: EmbeddingFunctionConfig,
-  schema?: SchemaLike,
+  schema?: SchemaLike
 ): Promise<ArrowTable> {
   if (schema !== undefined && schema !== null) {
     schema = sanitizeSchema(schema);
@@ -921,7 +922,7 @@ async function applyEmbeddings<T>(
     embeddings.function.embeddingDataType() ?? new Float32();
   if (sourceColumn === undefined) {
     throw new Error(
-      `Cannot apply embedding function because the source column '${embeddings.sourceColumn}' was not present in the data`,
+      `Cannot apply embedding function because the source column '${embeddings.sourceColumn}' was not present in the data`
     );
   }
 
@@ -942,12 +943,12 @@ async function applyEmbeddings<T>(
         newColumns[destColumn] = makeVector([], destField.type);
       } else {
         throw new Error(
-          `Attempt to apply embeddings to an empty table failed because schema was missing embedding column '${destColumn}'`,
+          `Attempt to apply embeddings to an empty table failed because schema was missing embedding column '${destColumn}'`
         );
       }
     } else {
       throw new Error(
-        "Attempt to apply embeddings to an empty table when the embeddings function does not specify `embeddingDimension`",
+        "Attempt to apply embeddings to an empty table when the embeddings function does not specify `embeddingDimension`"
       );
     }
   } else {
@@ -963,23 +964,23 @@ async function applyEmbeddings<T>(
         }
         return new ArrowTable(
           new Schema(newTable.schema.fields, schemaMetadata),
-          newTable.batches,
+          newTable.batches
         );
       }
     }
 
     if (table.batches.length > 1) {
       throw new Error(
-        "Internal error: `makeArrowTable` unexpectedly created a table with more than one batch",
+        "Internal error: `makeArrowTable` unexpectedly created a table with more than one batch"
       );
     }
     const values = sourceColumn.toArray();
     const vectors = await embeddings.function.computeSourceEmbeddings(
-      values as T[],
+      values as T[]
     );
     if (vectors.length !== values.length) {
       throw new Error(
-        "Embedding function did not return an embedding for each input element",
+        "Embedding function did not return an embedding for each input element"
       );
     }
     const destType = newVectorType(vectors[0].length, innerDestType);
@@ -990,7 +991,7 @@ async function applyEmbeddings<T>(
   if (schema != null) {
     if (schema.fields.find((f) => f.name === destColumn) === undefined) {
       throw new Error(
-        `When using embedding functions and specifying a schema the schema should include the embedding column but the column ${destColumn} was missing`,
+        `When using embedding functions and specifying a schema the schema should include the embedding column but the column ${destColumn} was missing`
       );
     }
     newTable = alignTable(newTable, schema as Schema);
@@ -998,7 +999,7 @@ async function applyEmbeddings<T>(
 
   newTable = new ArrowTable(
     new Schema(newTable.schema.fields, schemaMetadata),
-    newTable.batches,
+    newTable.batches
   );
 
   return newTable;
@@ -1025,7 +1026,7 @@ async function applyEmbeddings<T>(
 export async function convertToTable(
   data: Array<Record<string, unknown>>,
   embeddings?: EmbeddingFunctionConfig,
-  makeTableOptions?: Partial<MakeArrowTableOptions>,
+  makeTableOptions?: Partial<MakeArrowTableOptions>
 ): Promise<ArrowTable> {
   let processedData = data;
 
@@ -1037,7 +1038,7 @@ export async function convertToTable(
   ) {
     processedData = ensureNestedFieldsExist(
       data,
-      makeTableOptions.schema as Schema,
+      makeTableOptions.schema as Schema
     );
   }
 
@@ -1048,7 +1049,7 @@ export async function convertToTable(
 /** Creates the Arrow Type for a Vector column with dimension `dim` */
 export function newVectorType<T extends Float>(
   dim: number,
-  innerType: unknown,
+  innerType: unknown
 ): FixedSizeList<T> {
   // in Lance we always default to have the elements nullable, so we need to set it to true
   // otherwise we often get schema mismatches because the stored data always has schema with nullable elements
@@ -1066,7 +1067,7 @@ export function newVectorType<T extends Float>(
 export async function fromRecordsToBuffer(
   data: Array<Record<string, unknown>>,
   embeddings?: EmbeddingFunctionConfig,
-  schema?: Schema,
+  schema?: Schema
 ): Promise<Buffer> {
   if (schema !== undefined && schema !== null) {
     schema = sanitizeSchema(schema);
@@ -1086,7 +1087,7 @@ export async function fromRecordsToBuffer(
 export async function fromRecordsToStreamBuffer(
   data: Array<Record<string, unknown>>,
   embeddings?: EmbeddingFunctionConfig,
-  schema?: Schema,
+  schema?: Schema
 ): Promise<Buffer> {
   if (schema !== undefined && schema !== null) {
     schema = sanitizeSchema(schema);
@@ -1107,7 +1108,7 @@ export async function fromRecordsToStreamBuffer(
 export async function fromTableToBuffer(
   table: ArrowTable,
   embeddings?: EmbeddingFunctionConfig,
-  schema?: SchemaLike,
+  schema?: SchemaLike
 ): Promise<Buffer> {
   if (schema !== undefined && schema !== null) {
     schema = sanitizeSchema(schema);
@@ -1128,7 +1129,7 @@ export async function fromTableToBuffer(
 export async function fromDataToBuffer(
   data: Data,
   embeddings?: EmbeddingFunctionConfig,
-  schema?: Schema,
+  schema?: Schema
 ): Promise<Buffer> {
   if (schema !== undefined && schema !== null) {
     schema = sanitizeSchema(schema);
@@ -1156,7 +1157,7 @@ export async function fromDataToBuffer(
  * Returns null if the buffer does not contain a record batch
  */
 export async function fromBufferToRecordBatch(
-  data: Buffer,
+  data: Buffer
 ): Promise<RecordBatch | null> {
   const iter = await RecordBatchFileReader.readAll(Buffer.from(data)).next()
     .value;
@@ -1168,7 +1169,7 @@ export async function fromBufferToRecordBatch(
  * Create a buffer containing a single record batch
  */
 export async function fromRecordBatchToBuffer(
-  batch: RecordBatch,
+  batch: RecordBatch
 ): Promise<Buffer> {
   const writer = new RecordBatchFileWriter().writeAll([batch]);
   return Buffer.from(await writer.toUint8Array());
@@ -1185,7 +1186,7 @@ export async function fromRecordBatchToBuffer(
 export async function fromTableToStreamBuffer(
   table: ArrowTable,
   embeddings?: EmbeddingFunctionConfig,
-  schema?: SchemaLike,
+  schema?: SchemaLike
 ): Promise<Buffer> {
   const tableWithEmbeddings = await applyEmbeddings(table, embeddings, schema);
   const writer = RecordBatchStreamWriter.writeAll(tableWithEmbeddings);
@@ -1199,11 +1200,11 @@ function alignBatch(batch: RecordBatch, schema: Schema): RecordBatch {
   const alignedChildren = [];
   for (const field of schema.fields) {
     const indexInBatch = batch.schema.fields?.findIndex(
-      (f) => f.name === field.name,
+      (f) => f.name === field.name
     );
     if (indexInBatch < 0) {
       throw new Error(
-        `The column ${field.name} was not found in the Arrow Table`,
+        `The column ${field.name} was not found in the Arrow Table`
       );
     }
     alignedChildren.push(batch.data.children[indexInBatch]);
@@ -1222,7 +1223,7 @@ function alignBatch(batch: RecordBatch, schema: Schema): RecordBatch {
  */
 function alignTable(table: ArrowTable, schema: Schema): ArrowTable {
   const alignedBatches = table.batches.map((batch) =>
-    alignBatch(batch, schema),
+    alignBatch(batch, schema)
   );
   return new ArrowTable(schema, alignedBatches);
 }
@@ -1237,7 +1238,7 @@ export function createEmptyTable(schema: Schema): ArrowTable {
 function validateSchemaEmbeddings(
   schema: Schema,
   data: Array<Record<string, unknown>>,
-  embeddings: EmbeddingFunctionConfig | undefined,
+  embeddings: EmbeddingFunctionConfig | undefined
 ): Schema {
   const fields = [];
   const missingEmbeddingFields = [];
@@ -1251,19 +1252,24 @@ function validateSchemaEmbeddings(
     if (isFixedSizeList(field.type)) {
       field = sanitizeField(field);
       if (data.length !== 0 && data?.[0]?.[field.name] === undefined) {
-        if (schema.metadata.has("embedding_functions")) {
-          const embeddings = JSON.parse(
-            schema.metadata.get("embedding_functions")!,
-          );
-          if (
-            // biome-ignore lint/suspicious/noExplicitAny: we don't know the type of `f`
-            embeddings.find((f: any) => f["vectorColumn"] === field.name) ===
-            undefined
-          ) {
+        // If the field is nullable, allow undefined/omitted values
+        if (field.nullable) {
+          fields.push(field);
+        } else {
+          if (schema.metadata.has("embedding_functions")) {
+            const embeddings = JSON.parse(
+              schema.metadata.get("embedding_functions")!
+            );
+            if (
+              // biome-ignore lint/suspicious/noExplicitAny: we don't know the type of `f`
+              embeddings.find((f: any) => f["vectorColumn"] === field.name) ===
+              undefined
+            ) {
+              missingEmbeddingFields.push(field);
+            }
+          } else {
             missingEmbeddingFields.push(field);
           }
-        } else {
-          missingEmbeddingFields.push(field);
         }
       } else {
         fields.push(field);
@@ -1277,7 +1283,7 @@ function validateSchemaEmbeddings(
     throw new Error(
       `Table has embeddings: "${missingEmbeddingFields
         .map((f) => f.name)
-        .join(",")}", but no embedding function was provided`,
+        .join(",")}", but no embedding function was provided`
     );
   }
 
@@ -1290,7 +1296,7 @@ function validateSchemaEmbeddings(
  */
 export function ensureNestedFieldsExist(
   data: Array<Record<string, unknown>>,
-  schema: Schema,
+  schema: Schema
 ): Array<Record<string, unknown>> {
   return data.map((row) => {
     const completeRow: Record<string, unknown> = {};
@@ -1306,7 +1312,7 @@ export function ensureNestedFieldsExist(
           const nestedValue = row[field.name] as Record<string, unknown>;
           completeRow[field.name] = ensureStructFieldsExist(
             nestedValue,
-            field.type,
+            field.type
           );
         } else {
           // Non-struct field or null struct value
@@ -1328,7 +1334,7 @@ export function ensureNestedFieldsExist(
  */
 function ensureStructFieldsExist(
   data: Record<string, unknown>,
-  structType: Struct,
+  structType: Struct
 ): Record<string, unknown> {
   const completeStruct: Record<string, unknown> = {};
 
@@ -1342,7 +1348,7 @@ function ensureStructFieldsExist(
         // Recursively handle nested struct
         completeStruct[childField.name] = ensureStructFieldsExist(
           data[childField.name] as Record<string, unknown>,
-          childField.type,
+          childField.type
         );
       } else {
         // Non-struct field or null struct value
@@ -1493,7 +1499,7 @@ function fieldToJson(field: Field): JsonField {
 
 function alignTableToSchema(
   table: ArrowTable,
-  targetSchema: Schema,
+  targetSchema: Schema
 ): ArrowTable {
   const existingColumns = new Map<string, Vector>();
 
@@ -1524,7 +1530,7 @@ function createNullVector(field: Field, numRows: number): Vector {
     // For struct types, create a struct with null fields
     const structType = field.type as Struct;
     const childVectors = structType.children.map((childField) =>
-      createNullVector(childField, numRows),
+      createNullVector(childField, numRows)
     );
 
     // Create struct data


### PR DESCRIPTION
Fixes #2654

**Problem**: When a vector field is marked as nullable, users should be able to omit it or pass `undefined`, but this was throwing an error: "Table has embeddings: 'vector', but no embedding function was provided"

**Solution**: Modified `validateSchemaEmbeddings` to check `field.nullable` before treating `undefined` values as missing embedding fields.

**Changes**:
- Fixed validation logic in `nodejs/lancedb/arrow.ts`
- Enabled previously skipped test for nullable fields
- Added reproduction test case

**Behavior**:
- ✅ `{ vector: undefined }` now works for nullable fields
- ✅ `{}` (omitted field) now works for nullable fields  
- ✅ `{ vector: null }` still works (unchanged)
- ✅ Non-nullable fields still properly throw errors (unchanged)