### PR TITLE
chore: supports limit push down through MetadataEraserExec

### DIFF
--- a/rust/lancedb/src/table/datafusion.rs
+++ b/rust/lancedb/src/table/datafusion.rs
@@ -125,6 +125,10 @@ impl ExecutionPlan for MetadataEraserExec {
     fn partition_statistics(&self, partition: Option<usize>) -> DataFusionResult<Statistics> {
         self.input.partition_statistics(partition)
     }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
For limit to sucessfully push down to FilteredReadExec
https://github.com/lancedb/lance/pull/4795/