### PR TITLE
fix: federated database should not pass namesapce to listing database

### DIFF
--- a/rust/lancedb/src/database/namespace.rs
+++ b/rust/lancedb/src/database/namespace.rs
@@ -261,7 +261,7 @@ impl Database for LanceNamespaceDatabase {
                     return listing_db
                         .open_table(OpenTableRequest {
                             name: request.name.clone(),
-                            namespace: request.namespace.clone(),
+                            namespace: vec![],
                             index_cache_size: None,
                             lance_read_params: None,
                         })
@@ -305,7 +305,14 @@ impl Database for LanceNamespaceDatabase {
             )
             .await?;
 
-        listing_db.create_table(request).await
+        let create_request = DbCreateTableRequest {
+            name: request.name,
+            namespace: vec![],
+            data: request.data,
+            mode: request.mode,
+            write_options: request.write_options,
+        };
+        listing_db.create_table(create_request).await
     }
 
     async fn open_table(&self, request: OpenTableRequest) -> Result<Arc<dyn BaseTable>> {
@@ -332,7 +339,13 @@ impl Database for LanceNamespaceDatabase {
             .create_listing_database(&request.name, &location, response.storage_options)
             .await?;
 
-        listing_db.open_table(request).await
+        let open_request = OpenTableRequest {
+            name: request.name.clone(),
+            namespace: vec![],
+            index_cache_size: request.index_cache_size,
+            lance_read_params: request.lance_read_params,
+        };
+        listing_db.open_table(open_request).await
     }
 
     async fn clone_table(&self, _request: CloneTableRequest) -> Result<Arc<dyn BaseTable>> {


### PR DESCRIPTION
Fixes error that when converting a federated database operation to a listing database operation, the namespace parameter is no longer correct and should be dropped.

Note that with the testing infra we have today, we don't have a good way to test these changes. I will do a quick follow up on https://github.com/lancedb/lancedb/issues/2701 but would be great to get this in first to resolve the related issues.