### PR TITLE
docs: update readme quickstart link (under how to install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ LanceDB is a central location where developers can build, train and analyze thei
 
 ## **How to Install**:
 
-Follow the [Quickstart](https://lancedb.github.io/lancedb/basic/) doc to set up LanceDB locally. 
+Follow the [Quickstart](https://lancedb.com/docs/quickstart/) doc to set up LanceDB locally. 
 
 **API & SDK:** We also support Python, Typescript and Rust SDKs
 


### PR DESCRIPTION
Quickstart link should be https://lancedb.com/docs/quickstart/

Fixes #2779 