### PR TITLE
ci: migrate codex to API key based

### DIFF
--- a/.github/workflows/codex-update-lance-dependency.yml
+++ b/.github/workflows/codex-update-lance-dependency.yml
@@ -63,27 +63,18 @@ jobs:
           git config user.name "lancedb automation"
           git config user.email "robot@lancedb.com"
 
-      - name: Configure Codex authentication
-        env:
-          CODEX_TOKEN_B64: ${{ secrets.CODEX_TOKEN }}
-        run: |
-          if [ -z "${CODEX_TOKEN_B64}" ]; then
-            echo "Repository secret CODEX_TOKEN is not defined; skipping Codex execution."
-            exit 1
-          fi
-          mkdir -p ~/.codex
-          echo "${CODEX_TOKEN_B64}" | base64 --decode > ~/.codex/auth.json
-
       - name: Run Codex to update Lance dependency
         env:
           TAG: ${{ inputs.tag }}
           GITHUB_TOKEN: ${{ secrets.ROBOT_TOKEN }}
           GH_TOKEN: ${{ secrets.ROBOT_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.CODEX_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${TAG#refs/tags/}"
           VERSION="${VERSION#v}"
           BRANCH_NAME="codex/update-lance-${VERSION//[^a-zA-Z0-9]/-}"
+
           cat <<EOF >/tmp/codex-prompt.txt
           You are running inside the lancedb repository on a GitHub Actions runner. Update the Lance dependency to version ${VERSION} and prepare a pull request for maintainers to review.
 
@@ -104,4 +95,6 @@ jobs:
           - Do not merge the PR.
           - If any command fails, diagnose and fix the issue instead of aborting.
           EOF
+
+          printenv OPENAI_API_KEY | codex login --with-api-key
           codex --config shell_environment_policy.ignore_default_excludes=true exec --dangerously-bypass-approvals-and-sandbox "$(cat /tmp/codex-prompt.txt)"


### PR DESCRIPTION
Removed Codex authentication steps and added OPENAI_API_KEY environment variable for Codex execution.