### PR TITLE
fix: convert schema metadata to strings for JsonArrowSchema

### DIFF
--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -102,7 +102,9 @@ def _convert_pyarrow_schema_to_json(schema: pa.Schema) -> JsonArrowSchema:
     # decode binary metadata to strings for JSON
     meta = None
     if schema.metadata:
-        meta = {k.decode("utf-8"): v.decode("utf-8") for k, v in schema.metadata.items()}
+        meta = {
+            k.decode("utf-8"): v.decode("utf-8") for k, v in schema.metadata.items()
+        }
 
     return JsonArrowSchema(fields=fields, metadata=meta)
 


### PR DESCRIPTION
Fixes pydantic validation errors when creating materialized views with namespace.

```
>       return JsonArrowSchema(fields=fields, metadata=schema.metadata)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       pydantic_core._pydantic_core.ValidationError: 4 validation errors for JsonArrowSchema
E       metadata.b'geneva::view::query'
E         Input should be a valid string [type=string_type, input_value=b'{"base":{"vector_column...t-image:latest\\"}"}}]}', input_type=bytes]
E           For further information visit https://errors.pydantic.dev/2.12/v/string_type
```