### PR TITLE
feat: implement head() for remote tables

### DIFF
--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -652,6 +652,17 @@ class RemoteTable(Table):
             "migrate_v2_manifest_paths() is not supported on the LanceDB Cloud"
         )
 
+    def head(self, n=5) -> pa.Table:
+        """
+        Return the first `n` rows of the table.
+
+        Parameters
+        ----------
+        n: int, default 5
+            The number of rows to return.
+        """
+        return LOOP.run(self._table.query().limit(n).to_arrow())
+
 
 def add_index(tbl: pa.Table, i: int) -> pa.Table:
     return tbl.add_column(

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -546,6 +546,22 @@ def query_test_table(query_handler, *, server_version=Version("0.1.0")):
         yield table
 
 
+def test_head():
+    def handler(body):
+        assert body == {
+            "k": 5,
+            "prefilter": True,
+            "vector": [],
+            "version": None,
+        }
+
+        return pa.table({"id": [1, 2, 3]})
+
+    with query_test_table(handler) as table:
+        data = table.head(5)
+        assert data == pa.table({"id": [1, 2, 3]})
+
+
 def test_query_sync_minimal():
     def handler(body):
         assert body == {


### PR DESCRIPTION
Implemnent the head() function for RemoteTable.