### PR TITLE
chore: clippy::string_to_string has been replaced by implicit_clone

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,7 +19,7 @@ rustflags = [
     "-Wclippy::string_add_assign",
     "-Wclippy::string_add",
     "-Wclippy::string_lit_as_bytes",
-    "-Wclippy::string_to_string",
+    "-Wclippy::implicit_clone",
     "-Wclippy::use_self",
     "-Dclippy::cargo",
     "-Dclippy::dbg_macro",

--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -690,7 +690,7 @@ impl FTSQuery {
     }
 
     pub fn get_query(&self) -> String {
-        self.fts_query.query.query().to_owned()
+        self.fts_query.query.query().clone()
     }
 
     pub fn to_query_request(&self) -> PyQueryRequest {

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -475,7 +475,7 @@ impl ListingDatabase {
                     // this error is not lance::Error::DatasetNotFound, as the method
                     // `remove_dir_all` may be used to remove something not be a dataset
                     lance::Error::NotFound { .. } => Error::TableNotFound {
-                        name: name.to_owned(),
+                        name: name.clone(),
                         source: Box::new(err),
                     },
                     _ => Error::from(err),


### PR DESCRIPTION
clippy::string_to_string has been replaced by implicit_clone, so lancedb will raise a build error in Rust 1.91. This PR suppresses it.

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**