### PR TITLE
ci: migrate macos ci runners

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         config:
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-15-large
           - target: aarch64-apple-darwin
             runner: warp-macos-14-arm64-6x
     env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -149,7 +149,7 @@ jobs:
       matrix:
         config:
           - name: x86
-            runner: macos-13
+            runner: macos-15-large
           - name: Arm
             runner: macos-14
     runs-on: "${{ matrix.config.runner }}"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        mac-runner: ["macos-13", "macos-14"]
+        mac-runner: ["macos-14", "macos-15"]
     runs-on: "${{ matrix.mac-runner }}"
     defaults:
       run:


### PR DESCRIPTION
This PR will migrate macos CI runners.

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**