### PR TITLE
refactor!: deprecate mac x86 support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -97,12 +97,6 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - target: x86_64-apple-darwin
-            host: macos-latest
-            features: ","
-            pre_build: |-
-                brew install protobuf
-                rustup target add x86_64-apple-darwin
           - target: aarch64-apple-darwin
             host: macos-latest
             features: fp16kernels

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -64,8 +64,6 @@ jobs:
     strategy:
       matrix:
         config:
-          - target: x86_64-apple-darwin
-            runner: macos-15-large
           - target: aarch64-apple-darwin
             runner: warp-macos-14-arm64-6x
     env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -143,16 +143,9 @@ jobs:
       - name: Delete wheels
         run: rm -rf target/wheels
   platform:
-    name: "Mac: ${{ matrix.config.name }}"
+    name: "Mac"
     timeout-minutes: 30
-    strategy:
-      matrix:
-        config:
-          - name: x86
-            runner: macos-15-large
-          - name: Arm
-            runner: macos-14
-    runs-on: "${{ matrix.config.runner }}"
+    runs-on: macos-14
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
We have very low download stats for mac x86, and also latest github runners for mac are all arm, so it makes sense at this point to deprecate x86 support in general.