### PR TITLE
fix: add to_lance() and to_polars() stub methods for type-checkers

### DIFF
--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -693,7 +693,7 @@ class Table(ABC):
         """
         raise NotImplementedError
 
-    def to_polars(self, **kwargs) -> "pl.DataFrame:
+    def to_polars(self, **kwargs) -> "pl.DataFrame":
         """Return the table as a polars.DataFrame.
 
         Returns


### PR DESCRIPTION
Adds `Table.to_lance()` and `Table.to_polars()` methods (non-abstract methods, defaulting to `NotImplementedError`) so type checkers like mypy, pyright and ty don’t flag them as unknown attributes on `Table`. Not making these abstract methods should keep existing remote/other `Table` implementations instantiable.

This is non-breaking change to existing functionality and is purely for the purpose of pleasing static type-checkers like mypy, ty and pyright.

<img width="626" height="134" alt="image" src="https://github.com/user-attachments/assets/f4619bca-a882-432b-bd23-ae8f189ff9e3" />
