### PR TITLE
docs: remove incorrect "LanceDb Cloud only" from table_names params

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -210,10 +210,8 @@ class DBConnection(EnforceOverrides):
         page_token: str, optional
             The token to use for pagination. If not present, start from the beginning.
             Typically, this token is last table name from the previous page.
-            Only supported by LanceDb Cloud.
         limit: int, default 10
             The size of the page to return.
-            Only supported by LanceDb Cloud.
 
         Returns
         -------


### PR DESCRIPTION
The page_token and limit parameters for table_names() are supported by both local storage and LanceDB Cloud, not just Cloud as the docstring incorrectly stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)