### PR TITLE
fix: support `exist_ok` in `RemoteDBConnection.create_table`

### DIFF
--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -417,8 +417,8 @@ class RemoteDBConnection(DBConnection):
             The mode to use when creating the table.
             Can be either "create", "overwrite", or "exist_ok".
         exist_ok: bool, default False
-            If True, return the existing table if it already exists. This
-            is equivalent to using mode="exist_ok".
+            If exist_ok is True, and mode is None or "create", mode will be changed
+            to "exist_ok".
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
             One of "error", "drop", "fill".
@@ -491,12 +491,9 @@ class RemoteDBConnection(DBConnection):
 
         """
         if exist_ok:
-            if mode is not None and mode != "exist_ok":
-                raise ValueError(
-                    f"You cannot set a mode argument of {mode} when setting "
-                    "exist_ok to True."
-                )
-            else:
+            if mode == "create":
+                mode = "exist_ok"
+            elif not mode:
                 mode = "exist_ok"
         if namespace is None:
             namespace = []


### PR DESCRIPTION
RemoteDBConnection should support passing exist_ok to create_table, just like LanceDBConnection (the non-remote form) does. It can support this by passing 'exist_ok' as the mode parameter.