### PR TITLE
feat: enable huggingface feature by default

### DIFF
--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -104,11 +104,16 @@ test-log = "0.2"
 
 
 [features]
-default = ["aws", "gcs", "azure", "dynamodb", "oss"]
+default = ["aws", "gcs", "azure", "dynamodb", "oss", "huggingface"]
 aws = ["lance/aws", "lance-io/aws", "lance-namespace-impls/dir-aws"]
 oss = ["lance/oss", "lance-io/oss", "lance-namespace-impls/dir-oss"]
 gcs = ["lance/gcp", "lance-io/gcp", "lance-namespace-impls/dir-gcp"]
 azure = ["lance/azure", "lance-io/azure", "lance-namespace-impls/dir-azure"]
+huggingface = [
+    "lance/huggingface",
+    "lance-io/huggingface",
+    "lance-namespace-impls/dir-huggingface",
+]
 dynamodb = ["lance/dynamodb", "aws"]
 remote = ["dep:reqwest", "dep:http", "lance-namespace-impls/rest", "lance-namespace-impls/rest-adapter"]
 fp16kernels = ["lance-linalg/fp16kernels"]


### PR DESCRIPTION
Close https://github.com/lancedb/lancedb/issues/2909

Enable hf feature by default so our python users can use `hf://xxxx` directly.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**