### PR TITLE
fix(python): cancel remote queries on sync API interruption

### DIFF
--- a/python/python/lancedb/background_loop.py
+++ b/python/python/lancedb/background_loop.py
@@ -22,7 +22,12 @@ class BackgroundEventLoop:
         self.thread.start()
 
     def run(self, future):
-        return asyncio.run_coroutine_threadsafe(future, self.loop).result()
+        concurrent_future = asyncio.run_coroutine_threadsafe(future, self.loop)
+        try:
+            return concurrent_future.result()
+        except BaseException:
+            concurrent_future.cancel()
+            raise
 
 
 LOOP = BackgroundEventLoop()


### PR DESCRIPTION
Fixes #2898 

Problem:
Sync API cancellations didn’t stop remote query coroutines, so requests could continue after interrupt.

Changes:
- Cancel run_coroutine_threadsafe futures on any BaseException in the sync background loop
- Update cancellation test to avoid starting a real background thread and cover GeneratorExit

