### PR TITLE
chore: migrate Gemini embeddings to use `google-genai` SDK

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -83,7 +83,7 @@ embeddings = [
     "colpali-engine>=0.3.10",
     "huggingface_hub",
     "InstructorEmbedding",
-    "google.generativeai",
+    "google-genai",
     "boto3>=1.28.57",
     "awscli>=1.29.57",
     "botocore>=1.31.57",

--- a/python/python/lancedb/embeddings/gemini_text.py
+++ b/python/python/lancedb/embeddings/gemini_text.py
@@ -140,5 +140,5 @@ class GeminiText(TextEmbeddingFunction):
                     # Include header as per goo.gle/gemini-partners
                     "x-goog-api-client": f"lancedb/{__version__}",
                 }
-            }
+            },
         )


### PR DESCRIPTION
As the `google-generativeai` SDK is deprecated, it will emit warnings and will not have support for all models going forward, so moving to our new SDK will ensure some forward-compatibility for your users.

I used this [test script here](https://gist.github.com/markmcd/d83ce548561ca043fe274dd98a0cde7a) to validate everything works.

This also adds support for batching embeddings over a single API request.