### PR TITLE
chore: fix clippy when remote flag is not set

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,8 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Run clippy
         run: cargo clippy --profile ci --workspace --tests --all-features -- -D warnings
+      - name: Run clippy (without remote feature)
+        run: cargo clippy --profile ci --workspace --tests -- -D warnings
 
   build-no-lock:
     runs-on: ubuntu-24.04

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -892,6 +892,7 @@ pub struct ConnectBuilder {
     embedding_registry: Option<Arc<dyn EmbeddingRegistry>>,
 }
 
+#[cfg(feature = "remote")]
 const ENV_VARS_TO_STORAGE_OPTS: [(&str, &str); 1] =
     [("AZURE_STORAGE_ACCOUNT_NAME", "azure_storage_account_name")];
 


### PR DESCRIPTION
Also add a step in CI to ensure this does not happen in the future