### PR TITLE
feat(python): expose fast_search in synchronous API (Fixes #2612)

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -1428,6 +1428,19 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
         self._bypass_vector_index = True
         return self
 
+    def fast_search(self) -> LanceVectorQueryBuilder:
+        """
+        Skip a flat search of unindexed data. This will improve
+        search performance but search results will not include unindexed data.
+
+        Returns
+        -------
+        LanceVectorQueryBuilder
+            The LanceVectorQueryBuilder object.
+        """
+        self._fast_search = True
+        return self
+
 
 class LanceFtsQueryBuilder(LanceQueryBuilder):
     """A builder for full text search for LanceDB."""


### PR DESCRIPTION
Fixes #2612

This PR exposes the private _fast_search attribute via a public fast_search() method in the synchronous LanceVectorQueryBuilder.

Previously, enabling fast search in the sync API required accessing a private member (query._fast_search = True). This change aligns the synchronous API with the Async and Remote APIs, allowing for cleaner, more Pythonic method chaining.

Changes:
Added fast_search() method to LanceVectorQueryBuilder in python/python/lancedb/query.py.
Added a unit test verifying the flag works with high-dimensional data (2560 dims) and chaining.
Example Usage:

Before:

```
query = table.search(vector)
query._fast_search = True  # Private attribute usage
results = query.limit(10).to_pandas()
```

After:

```
results = (
    table.search(vector)
    .fast_search()
    .limit(10)
    .to_pandas()
)
```

Verification:
I have added a test case (test_fast_search_high_dimension) that replicates the scenario described in the issue (2560 dimensions, cosine distance) to ensure the pipeline constructs the query correctly without errors.

Checklist:

- [ ]  I have added tests to cover my changes.
- [ ]  All new and existing tests passed.
- [ ]  Documentation has been updated (inline docstrings).