### PR TITLE
fix: include _rowid in hash and calculated split projections

### DIFF
--- a/python/python/tests/test_permutation.py
+++ b/python/python/tests/test_permutation.py
@@ -438,8 +438,16 @@ def test_filter_with_splits(mem_db):
     row_count = permutation_tbl.count_rows()
     assert row_count == 67
 
+    # Permutation table only contains row_id and split_id
     data = permutation_tbl.search(None).to_arrow().to_pydict()
-    categories = data["category"]
+    assert "row_id" in data
+    assert "split_id" in data
+    assert set(data["split_id"]) == {0, 1}
+
+    # Verify filtered rows are from categories A or B via the original table
+    row_ids = data["row_id"]
+    original_data = tbl.search(None).to_arrow().to_pydict()
+    categories = [original_data["category"][row_id] for row_id in row_ids]
 
     # All categories should be A or B
     assert all(cat in ["A", "B"] for cat in categories)


### PR DESCRIPTION
## Summary

- Fixed permutation tests failing with `Unable to get field named "_rowid"` error
- The issue was introduced by commit 9be28448f which changed the permutation builder to explicitly select only `ROW_ID`, but the `project()` method in `Splitter` for Hash and Calculated split strategies was replacing this selection instead of adding to it
- Also fixed a test (`test_filter_with_splits`) that incorrectly expected the permutation table to contain the original table's columns

## Changes

1. **rust/lancedb/src/dataloader/permutation/split.rs**:
   - For `Hash` strategy: append `ROW_ID` to the list of hash columns
   - For `Calculated` strategy: include `ROW_ID` in the dynamic selection

2. **python/tests/test_permutation.py**:
   - Fixed `test_filter_with_splits` to correctly access columns - permutation tables only contain `row_id` and `split_id`, not the original table's columns

## Test plan

- [x] All 22 Rust permutation tests pass
- [x] All 46 Python permutation tests pass
- [x] All 269 lancedb Rust tests pass
- [x] Rust clippy and fmt pass
- [x] Python ruff check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)