### PR TITLE
ci: fix publish failure notifications being skipped

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -42,7 +42,7 @@ jobs:
     name: Report Workflow Failure
     runs-on: ubuntu-latest
     needs: [build]
-    if: always() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+    if: always() && failure() && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -362,7 +362,7 @@ jobs:
     name: Report Workflow Failure
     runs-on: ubuntu-latest
     needs: [build-lancedb, test-lancedb, publish]
-    if: always() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+    if: always() && failure() && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -181,7 +181,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    if: always() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+    if: always() && failure() && startsWith(github.ref, 'refs/tags/python-v')
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/create-failure-issue


### PR DESCRIPTION
## Summary

The `report-failure` jobs in npm, cargo, and pypi publish workflows checked for
`release` or `workflow_dispatch` events, but these workflows are triggered by tag
pushes where `github.event_name` is `push`. The condition was never true, so failure
notifications were silently skipped.

- Use `startsWith(github.ref, 'refs/tags/...')` to match actual tag triggers
- Add `failure()` to only notify on actual failures

This matches the pattern already used by `java-publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)