### PR TITLE
fix: avoid holding RwLock during async I/O in DatasetConsistencyWrapper

### DIFF
--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -205,7 +205,7 @@ impl DatasetConsistencyWrapper {
         let need_reload = if is_latest {
             dataset.latest_version_id().await? != current_version
         } else {
-            target_version.map_or(false, |v| current_version != v)
+            target_version.is_some_and(|v| current_version != v)
         };
         if !need_reload {
             return Ok(());


### PR DESCRIPTION
## Summary

`DatasetConsistencyWrapper` methods (`reload`, `as_latest`, `as_time_travel`) performed async I/O operations (`checkout_latest`, `checkout_version`, `latest_version_id`) while holding the `RwLock`. Under contention this blocks the tokio event loop — we observed **30+ minute stalls** in a Node.js application (via napi-rs bindings) where a `db.search()` call blocked the entire event loop after an embedding write.

The fix follows the pattern already established in `insert.rs:188` (*"Don't hold the lock over an await point"*):

1. **Read lock** — clone the `Dataset` and capture parameters (fast, no I/O)
2. **No lock** — perform async I/O on the cloned dataset
3. **Write lock** — update state with the new dataset (fast, only memory ops)

This also removes the now-unused `DatasetRef` methods (`reload`, `need_reload`, `as_latest`, `as_time_travel`) whose logic has been moved into `DatasetConsistencyWrapper`.

## Discovery Context

- Node.js application using LanceDB 0.23.0 via `@lancedb/lancedb`
- 30-minute gap in Docker logs: embedding write completed, then complete silence until next heartbeat
- Container was running (0 restarts, system healthy) — the event loop was simply blocked
- Gap occurred right after `table.add()` → next operation was `db.search()` for duplicate checking
- NAPI bindings are correct (async). Root cause is in Rust core.

## Changes

- **`DatasetConsistencyWrapper::reload()`** — clone dataset under read lock, check `latest_version_id()` and `checkout_version()` outside lock, update state under write lock
- **`DatasetConsistencyWrapper::as_latest()`** — same pattern: clone under read lock, I/O outside, update under write lock with re-check
- **`DatasetConsistencyWrapper::as_time_travel()`** — same pattern with early return if version matches
- **Removed unused `DatasetRef` methods** — `reload`, `need_reload`, `as_latest`, `as_time_travel`

## Test plan

- [ ] Existing test `test_iops_open_strong_consistency` passes
- [ ] `cargo test --features remote -p lancedb`
- [ ] `cargo clippy --features remote --tests`
- [ ] Concurrent read/write stress test (if applicable)

🤖 Calculon (feat. [Claude Opus 4.6](https://claude.com/claude-code))