### PR TITLE
ci: auto-publish lancedb java sdk

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -292,11 +292,12 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>ossrh</publishingServerId>
                             <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Avoid the need to manually approve an artifact release in Maven Central