### PR TITLE
ci: fix python version for latest release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "lancedb-python"
-version = "0.27.0"
+version = "0.28.0-beta.0"
 dependencies = [
  "arrow",
  "async-trait",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lancedb-python"
-version = "0.27.0"
+version = "0.28.0-beta.0"
 edition.workspace = true
 description = "Python bindings for LanceDB"
 license.workspace = true


### PR DESCRIPTION
It was accidentally corrupted in https://github.com/lancedb/lancedb/pull/2972