### PR TITLE
ci(nodejs): add repository field to package.json for npm provenance

### DIFF
--- a/nodejs/npm/darwin-arm64/package.json
+++ b/nodejs/npm/darwin-arm64/package.json
@@ -8,5 +8,9 @@
 	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/lancedb/lancedb"
 	}
 }

--- a/nodejs/npm/linux-arm64-gnu/package.json
+++ b/nodejs/npm/linux-arm64-gnu/package.json
@@ -9,5 +9,9 @@
 	"engines": {
 		"node": ">= 18"
 	},
-	"libc": ["glibc"]
+	"libc": ["glibc"],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/lancedb/lancedb"
+	}
 }

--- a/nodejs/npm/linux-arm64-musl/package.json
+++ b/nodejs/npm/linux-arm64-musl/package.json
@@ -9,5 +9,9 @@
 	"engines": {
 		"node": ">= 18"
 	},
-	"libc": ["musl"]
+	"libc": ["musl"],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/lancedb/lancedb"
+	}
 }

--- a/nodejs/npm/linux-x64-gnu/package.json
+++ b/nodejs/npm/linux-x64-gnu/package.json
@@ -9,5 +9,9 @@
 	"engines": {
 		"node": ">= 18"
 	},
-	"libc": ["glibc"]
+	"libc": ["glibc"],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/lancedb/lancedb"
+	}
 }

--- a/nodejs/npm/linux-x64-musl/package.json
+++ b/nodejs/npm/linux-x64-musl/package.json
@@ -9,5 +9,9 @@
 	"engines": {
 		"node": ">= 18"
 	},
-	"libc": ["musl"]
+	"libc": ["musl"],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/lancedb/lancedb"
+	}
 }

--- a/nodejs/npm/win32-arm64-msvc/package.json
+++ b/nodejs/npm/win32-arm64-msvc/package.json
@@ -14,5 +14,9 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lancedb/lancedb"
   }
 }

--- a/nodejs/npm/win32-x64-msvc/package.json
+++ b/nodejs/npm/win32-x64-msvc/package.json
@@ -8,5 +8,9 @@
 	"license": "Apache-2.0",
 	"engines": {
 		"node": ">= 18"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/lancedb/lancedb"
 	}
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -36,6 +36,10 @@
     }
   },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lancedb/lancedb"
+  },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.33.0",
     "@aws-sdk/client-kms": "^3.33.0",


### PR DESCRIPTION
## Summary

- Added `repository` field to all nodejs package.json files (main package + 7 platform-specific packages)
- This fixes the npm publish E422 error where sigstore provenance verification fails because the repository.url was empty

## Root Cause

Failing CI: https://github.com/lancedb/lancedb/actions/runs/21770794768/job/62821570260

npm's sigstore provenance verification requires the `repository.url` field in package.json to match the GitHub repository URL from the provenance bundle. The platform-specific packages (`@lancedb/lancedb-darwin-arm64`, etc.) were missing this field entirely, causing the publish to fail with:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle: 
Failed to validate repository information: package.json: "repository.url" is "", 
expected to match "https://github.com/lancedb/lancedb" from provenance
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)