### PR TITLE
fix: allow permutation reader to be used with remote tables

### DIFF
--- a/python/src/permutation.rs
+++ b/python/src/permutation.rs
@@ -239,6 +239,21 @@ impl PyPermutationReader {
             .collect::<PyResult<Vec<_>>>()?;
         Ok(Select::dynamic(&selection))
     }
+
+    fn table_from_py<'a>(table: Bound<'a, PyAny>) -> PyResult<Bound<'a, Table>> {
+        if table.hasattr("_inner")? {
+            Ok(table.getattr("_inner")?.downcast_into::<Table>()?)
+        } else if table.hasattr("_table")? {
+            Ok(table
+                .getattr("_table")?
+                .getattr("_inner")?
+                .downcast_into::<Table>()?)
+        } else {
+            Err(PyRuntimeError::new_err(
+                "Provided table does not appear to be a Table or RemoteTable instance",
+            ))
+        }
+    }
 }
 
 #[pymethods]
@@ -250,10 +265,8 @@ impl PyPermutationReader {
         permutation_table: Option<Bound<'py, PyAny>>,
         split: u64,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let base_table = base_table.getattr("_inner")?.downcast_into::<Table>()?;
-        let permutation_table = permutation_table
-            .map(|p| PyResult::Ok(p.getattr("_inner")?.downcast_into::<Table>()?))
-            .transpose()?;
+        let base_table = Self::table_from_py(base_table)?;
+        let permutation_table = permutation_table.map(Self::table_from_py).transpose()?;
 
         let base_table = base_table.borrow().inner_ref()?.base_table().clone();
         let permutation_table = permutation_table


### PR DESCRIPTION
There were two issues:

1. The python code needs to get access to the underlying rust table to setup the permutation reader and the attributes involved in this differ between the python local table and remote table objects.
~~2. The remote table was sending projection dictionaries as arrays of tuples and (on LanceDB cloud at least) it does not appear this is how rest servers are setup to receive them.~~ (this is now fixed as #3023)

~~Leaving as draft as this is built on https://github.com/lancedb/lancedb/pull/3016~~