### PR TITLE
feat: support multi-tenant azure deployments in the remote client

### DIFF
--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -921,8 +921,15 @@ pub struct ConnectBuilder {
 }
 
 #[cfg(feature = "remote")]
-const ENV_VARS_TO_STORAGE_OPTS: [(&str, &str); 1] =
-    [("AZURE_STORAGE_ACCOUNT_NAME", "azure_storage_account_name")];
+const ENV_VARS_TO_STORAGE_OPTS: [(&str, &str); 4] = [
+    ("AZURE_STORAGE_ACCOUNT_NAME", "azure_storage_account_name"),
+    ("AZURE_TENANT_ID", "azure_tenant_id"),
+    ("AZURE_CLIENT_ID", "azure_client_id"),
+    (
+        "AZURE_FEDERATED_TOKEN_FILE",
+        "azure_federated_token_file",
+    ),
+];
 
 impl ConnectBuilder {
     /// Create a new [`ConnectOptions`] with the given database URI.

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -792,11 +792,21 @@ impl RemoteOptions {
     pub fn new(options: HashMap<String, String>) -> Self {
         Self(options)
     }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.0.get(key)
+    }
 }
 
 impl From<StorageOptions> for RemoteOptions {
     fn from(options: StorageOptions) -> Self {
-        let supported_opts = vec!["account_name", "azure_storage_account_name"];
+        let supported_opts = vec![
+            "account_name",
+            "azure_storage_account_name",
+            "azure_tenant_id",
+            "azure_client_id",
+            "azure_federated_token_file",
+        ];
         let mut filtered = HashMap::new();
         for opt in supported_opts {
             if let Some(v) = options.0.get(opt) {


### PR DESCRIPTION
This forwards an x-azure-tenant-id header to the remote server when supplied in storage_options. This makes it possible to have a server deployment that spans multiple Azure AD tenants.