### PR TITLE
fix: handle null type in _align_field_types for nullable struct fields

### DIFF
--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -329,7 +329,12 @@ def _align_field_types(
         target_field = next((f for f in target_fields if f.name == field.name), None)
         if target_field is None:
             raise ValueError(f"Field '{field.name}' not found in target schema")
-        if pa.types.is_struct(target_field.type):
+        if pa.types.is_null(field.type):
+            # Source field is all nulls (e.g. nullable struct column with no
+            # non-null values in this batch).  Use the target type directly
+            # since there is no source type structure to recurse into.
+            new_type = target_field.type
+        elif pa.types.is_struct(target_field.type):
             new_type = pa.struct(
                 _align_field_types(
                     field.type.fields,

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -340,7 +340,11 @@ def test_add_nullable_struct_with_none(mem_db: DBConnection):
         ]
     )
 
-    table = mem_db.create_table("test_nullable_struct", schema=schema)
+    table = mem_db.create_table(
+        "test_nullable_struct",
+        schema=schema,
+        storage_options=dict(new_table_data_storage_version="2.1"),
+    )
 
     # Adding a row with a non-null struct should work
     table.add([{"id": "1", "data": {"x": 1.0}}])


### PR DESCRIPTION
When you have a nullable struct column and insert a row where that column is `None`, pyarrow infers the column type as `null` instead of `struct`. The `_align_field_types` function then tries to access `.fields` on the null type, which blows up with `AttributeError: 'pyarrow.lib.DataType' object has no attribute 'fields'`.

The fix checks for null type before trying to recurse into the type's structure. If the source field is null, we just use the target type directly — there's nothing to align when all values are None anyway.

Added a test that reproduces the original crash from #2654.

Fixes #2654