### PR TITLE
refactor(python)!: simplify reranker API to compute_scores/needs_columns

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -34,9 +34,104 @@ from lancedb.background_loop import LOOP
 from . import __version__
 from .arrow import AsyncRecordBatchReader
 from .dependencies import pandas as pd
-from .rerankers.base import Reranker
+from .rerankers.base import Reranker, VectorResult, FtsResult, RerankableResult
 from .rerankers.rrf import RRFReranker
 from .rerankers.util import check_reranker_result
+
+
+def _apply_reranker(
+    reranker: Reranker,
+    query: str,
+    result_sets: List[Tuple[pa.Table, str]],
+    return_score: str = "relevance",
+) -> pa.Table:
+    """Apply a reranker using the new ``compute_scores`` API.
+
+    Parameters
+    ----------
+    reranker : Reranker
+        The reranker instance.
+    query : str
+        The search query string.
+    result_sets : list of (pa.Table, str)
+        Each element is ``(table, kind)`` where *kind* is ``"vector"``
+        or ``"fts"``.
+    return_score : str
+        ``"relevance"`` to drop ``_distance``/``_score``, or ``"all"``
+        to keep them.
+
+    Returns
+    -------
+    pa.Table
+        Merged, scored, sorted, and projected result table.
+    """
+    # Wrap raw tables in typed result objects
+    wrapped: List[RerankableResult] = []
+    for table, kind in result_sets:
+        if kind == "vector":
+            wrapped.append(VectorResult(data=table))
+        else:
+            wrapped.append(FtsResult(data=table))
+
+    # Handle all-empty case
+    if all(len(r.data) == 0 for r in wrapped):
+        empty = result_sets[0][0]
+        return empty.append_column(
+            "_relevance_score", pa.array([], type=pa.float32())
+        )
+
+    # Filter out empty tables before passing to reranker
+    non_empty = [r for r in wrapped if len(r.data) > 0]
+
+    # Project down to only the columns the reranker needs (projection pushdown).
+    # We keep the original tables for the final result, but pass filtered
+    # copies to compute_scores so the reranker sees less data.
+    needed_cols = set(reranker.needs_columns()) | {"_rowid"}
+    filtered = []
+    for r in non_empty:
+        cols_to_keep = [c for c in r.data.column_names if c in needed_cols]
+        filtered.append(type(r)(data=r.data.select(cols_to_keep)))
+    score_arrays = reranker.compute_scores(query, filtered)
+
+    # Attach scores to each non-empty table
+    scored_tables = []
+    for result, scores in zip(non_empty, score_arrays):
+        tbl = result.data.append_column("_relevance_score", scores)
+        scored_tables.append(tbl)
+
+    # Merge if multiple
+    if len(scored_tables) == 1:
+        combined = scored_tables[0]
+    else:
+        concat_args = {"promote_options": "default"}
+        from packaging.version import Version
+
+        if Version(pa.__version__).major <= 13:
+            concat_args = {"promote": True}
+        combined = pa.concat_tables(scored_tables, **concat_args)
+
+    # Deduplicate by _rowid if present
+    if "_rowid" in combined.column_names:
+        combined = reranker._deduplicate(combined)
+
+    # Sort descending by relevance
+    combined = combined.sort_by([("_relevance_score", "descending")])
+
+    # Project columns based on return_score
+    if return_score == "relevance":
+        for col in ["_distance", "_score"]:
+            if col in combined.column_names:
+                combined = combined.drop_columns([col])
+    elif return_score == "all":
+        # Ensure _distance and _score columns exist even when one result set
+        # was empty (e.g. FTS returned 0 rows → no _score column).
+        for col in ["_distance", "_score"]:
+            if col not in combined.column_names:
+                combined = combined.append_column(
+                    col, pa.nulls(len(combined), type=pa.float32())
+                )
+
+    return combined
 from .util import flatten_columns
 from lancedb._lancedb import fts_query_to_json
 from typing_extensions import Annotated
@@ -1345,7 +1440,12 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
         )
         if self._reranker is not None:
             rs_table = result_set.read_all()
-            result_set = self._reranker.rerank_vector(self._str_query, rs_table)
+            result_set = _apply_reranker(
+                self._reranker,
+                self._str_query,
+                [(rs_table, "vector")],
+                return_score=self._reranker.score,
+            )
             check_reranker_result(result_set)
             # convert result_set back to RecordBatchReader
             result_set = pa.RecordBatchReader.from_batches(
@@ -1522,7 +1622,12 @@ class LanceFtsQueryBuilder(LanceQueryBuilder):
         results = self._table._execute_query(query, timeout=timeout)
         results = results.read_all()
         if self._reranker is not None:
-            results = self._reranker.rerank_fts(self._query, results)
+            results = _apply_reranker(
+                self._reranker,
+                self._query,
+                [(results, "fts")],
+                return_score=self._reranker.score,
+            )
             check_reranker_result(results)
         return results
 
@@ -1612,7 +1717,12 @@ class LanceFtsQueryBuilder(LanceQueryBuilder):
             output_tbl = output_tbl.append_column("_rowid", row_ids)
 
         if self._reranker is not None:
-            output_tbl = self._reranker.rerank_fts(self._query, output_tbl)
+            output_tbl = _apply_reranker(
+                self._reranker,
+                self._query,
+                [(output_tbl, "fts")],
+                return_score=self._reranker.score,
+            )
         return output_tbl
 
     def rerank(self, reranker: Reranker) -> LanceFtsQueryBuilder:
@@ -1811,7 +1921,22 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
                 LanceHybridQueryBuilder._normalize_scores(original_scores),
             )
 
-        results = reranker.rerank_hybrid(fts_query, vector_results, fts_results)
+        result_sets = []
+        if vector_results.num_rows > 0:
+            result_sets.append((vector_results, "vector"))
+        if fts_results.num_rows > 0:
+            result_sets.append((fts_results, "fts"))
+        if len(result_sets) == 0:
+            results = vector_results.append_column(
+                "_relevance_score", pa.array([], type=pa.float32())
+            )
+        else:
+            results = _apply_reranker(
+                reranker,
+                fts_query,
+                result_sets,
+                return_score=reranker.score,
+            )
 
         check_reranker_result(results)
 
@@ -2804,7 +2929,12 @@ class AsyncFTSQuery(AsyncStandardQuery):
         reader = await super().to_batches(timeout=timeout)
         results = pa.Table.from_batches(await reader.read_all(), reader.schema)
         if self._reranker:
-            results = self._reranker.rerank_fts(self.get_query(), results)
+            results = _apply_reranker(
+                self._reranker,
+                self.get_query(),
+                [(results, "fts")],
+                return_score=self._reranker.score,
+            )
         return AsyncRecordBatchReader(results, max_batch_length=max_batch_length)
 
 
@@ -3061,7 +3191,12 @@ class AsyncVectorQuery(AsyncStandardQuery, AsyncVectorQueryBase):
         reader = await super().to_batches(timeout=timeout)
         results = pa.Table.from_batches(await reader.read_all(), reader.schema)
         if self._reranker:
-            results = self._reranker.rerank_vector(self._query_string, results)
+            results = _apply_reranker(
+                self._reranker,
+                self._query_string,
+                [(results, "vector")],
+                return_score=self._reranker.score,
+            )
         return AsyncRecordBatchReader(results, max_batch_length=max_batch_length)
 
 

--- a/python/python/lancedb/rerankers/__init__.py
+++ b/python/python/lancedb/rerankers/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-from .base import Reranker
+from .base import Reranker, RerankableResult, FtsResult, VectorResult
 from .cohere import CohereReranker
 from .colbert import ColbertReranker
 from .cross_encoder import CrossEncoderReranker
@@ -15,6 +15,9 @@ from .voyageai import VoyageAIReranker
 
 __all__ = [
     "Reranker",
+    "RerankableResult",
+    "FtsResult",
+    "VectorResult",
     "CrossEncoderReranker",
     "CohereReranker",
     "LinearCombinationReranker",

--- a/python/python/lancedb/rerankers/cohere.py
+++ b/python/python/lancedb/rerankers/cohere.py
@@ -5,12 +5,12 @@
 import os
 from packaging.version import Version
 from functools import cached_property
-from typing import Union
+from typing import List, Union
 
 import pyarrow as pa
 
 from ..util import attempt_import_or_raise
-from .base import Reranker
+from .base import Reranker, RerankableResult
 
 
 class CohereReranker(Reranker):
@@ -64,55 +64,43 @@ class CohereReranker(Reranker):
             )
         return cohere.Client(os.environ.get("COHERE_API_KEY") or self.api_key)
 
-    def _rerank(self, result_set: pa.Table, query: str):
-        result_set = self._handle_empty_results(result_set)
-        if len(result_set) == 0:
-            return result_set
-        docs = result_set[self.column].to_pylist()
+    def needs_columns(self):
+        return [self.column]
+
+    def compute_scores(
+        self,
+        query: str,
+        results: List[RerankableResult],
+    ) -> List[pa.Array]:
+        tables = [r.data for r in results]
+        merged = pa.concat_tables(tables, **self._concat_tables_args)
+        if "_rowid" in merged.column_names:
+            merged = self._deduplicate(merged)
+
+        if len(merged) == 0:
+            return [pa.array([], type=pa.float32()) for _ in results]
+
+        docs = merged[self.column].to_pylist()
         response = self._client.rerank(
             query=query,
             documents=docs,
             top_n=self.top_n,
             model=self.model_name,
         )
-        results = (
-            response.results
-        )  # returns list (text, idx, relevance) attributes sorted descending by score
-        indices, scores = list(
-            zip(*[(result.index, result.relevance_score) for result in results])
-        )  # tuples
-        result_set = result_set.take(list(indices))
-        # add the scores
-        result_set = result_set.append_column(
-            "_relevance_score", pa.array(scores, type=pa.float32())
-        )
+        # Build scores aligned to input order (API may return fewer via top_n)
+        merged_scores = [0.0] * len(docs)
+        for r in response.results:
+            merged_scores[r.index] = r.relevance_score
 
-        return result_set
+        # Map back by text content
+        text_to_score = {
+            doc: score for doc, score in zip(docs, merged_scores)
+        }
 
-    def rerank_hybrid(
-        self,
-        query: str,
-        vector_results: pa.Table,
-        fts_results: pa.Table,
-    ):
-        if self.score == "all":
-            combined_results = self._merge_and_keep_scores(vector_results, fts_results)
-        else:
-            combined_results = self.merge_results(vector_results, fts_results)
-        combined_results = self._rerank(combined_results, query)
-        if self.score == "relevance":
-            combined_results = self._keep_relevance_score(combined_results)
+        score_arrays = []
+        for result in results:
+            texts = result.data[self.column].to_pylist()
+            scores = [text_to_score.get(t, 0.0) for t in texts]
+            score_arrays.append(pa.array(scores, type=pa.float32()))
 
-        return combined_results
-
-    def rerank_vector(self, query: str, vector_results: pa.Table):
-        vector_results = self._rerank(vector_results, query)
-        if self.score == "relevance":
-            vector_results = vector_results.drop_columns(["_distance"])
-        return vector_results
-
-    def rerank_fts(self, query: str, fts_results: pa.Table):
-        fts_results = self._rerank(fts_results, query)
-        if self.score == "relevance":
-            fts_results = fts_results.drop_columns(["_score"])
-        return fts_results
+        return score_arrays

--- a/python/python/lancedb/rerankers/jinaai.py
+++ b/python/python/lancedb/rerankers/jinaai.py
@@ -4,11 +4,11 @@
 
 import os
 from functools import cached_property
-from typing import Union
+from typing import List, Union
 
 import pyarrow as pa
 
-from .base import Reranker
+from .base import Reranker, RerankableResult
 
 API_URL = "https://api.jina.ai/v1/rerank"
 
@@ -64,12 +64,24 @@ class JinaReranker(Reranker):
         )
         return self._session
 
-    def _rerank(self, result_set: pa.Table, query: str):
-        result_set = self._handle_empty_results(result_set)
-        if len(result_set) == 0:
-            return result_set
-        docs = result_set[self.column].to_pylist()
-        response = self._client.post(  # type: ignore
+    def needs_columns(self):
+        return [self.column]
+
+    def compute_scores(
+        self,
+        query: str,
+        results: List[RerankableResult],
+    ) -> List[pa.Array]:
+        tables = [r.data for r in results]
+        merged = pa.concat_tables(tables, **self._concat_tables_args)
+        if "_rowid" in merged.column_names:
+            merged = self._deduplicate(merged)
+
+        if len(merged) == 0:
+            return [pa.array([], type=pa.float32()) for _ in results]
+
+        docs = merged[self.column].to_pylist()
+        response = self._client.post(
             API_URL,
             json={
                 "query": query,
@@ -81,43 +93,19 @@ class JinaReranker(Reranker):
         if "results" not in response:
             raise RuntimeError(response["detail"])
 
-        results = response["results"]
+        # Build scores aligned to merged order (API may return fewer via top_n)
+        merged_scores = [0.0] * len(docs)
+        for r in response["results"]:
+            merged_scores[r["index"]] = r["relevance_score"]
 
-        indices, scores = list(
-            zip(*[(result["index"], result["relevance_score"]) for result in results])
-        )  # tuples
-        result_set = result_set.take(list(indices))
-        # add the scores
-        result_set = result_set.append_column(
-            "_relevance_score", pa.array(scores, type=pa.float32())
-        )
+        text_to_score = {
+            doc: score for doc, score in zip(docs, merged_scores)
+        }
 
-        return result_set
+        score_arrays = []
+        for result in results:
+            texts = result.data[self.column].to_pylist()
+            scores = [text_to_score.get(t, 0.0) for t in texts]
+            score_arrays.append(pa.array(scores, type=pa.float32()))
 
-    def rerank_hybrid(
-        self,
-        query: str,
-        vector_results: pa.Table,
-        fts_results: pa.Table,
-    ):
-        if self.score == "all":
-            combined_results = self._merge_and_keep_scores(vector_results, fts_results)
-        else:
-            combined_results = self.merge_results(vector_results, fts_results)
-        combined_results = self._rerank(combined_results, query)
-        if self.score == "relevance":
-            combined_results = self._keep_relevance_score(combined_results)
-
-        return combined_results
-
-    def rerank_vector(self, query: str, vector_results: pa.Table):
-        vector_results = self._rerank(vector_results, query)
-        if self.score == "relevance":
-            vector_results = vector_results.drop_columns(["_distance"])
-        return vector_results
-
-    def rerank_fts(self, query: str, fts_results: pa.Table):
-        fts_results = self._rerank(fts_results, query)
-        if self.score == "relevance":
-            fts_results = fts_results.drop_columns(["_score"])
-        return fts_results
+        return score_arrays

--- a/python/python/lancedb/rerankers/mrr.py
+++ b/python/python/lancedb/rerankers/mrr.py
@@ -2,15 +2,12 @@
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 
-from typing import Union, List, TYPE_CHECKING
+from typing import List
+
 import pyarrow as pa
-import numpy as np
 
 from collections import defaultdict
-from .base import Reranker
-
-if TYPE_CHECKING:
-    from ..table import LanceVectorQueryBuilder
+from .base import Reranker, RerankableResult, VectorResult, FtsResult
 
 
 class MRRReranker(Reranker):
@@ -60,116 +57,49 @@ class MRRReranker(Reranker):
             f"weight_fts={self.weight_fts})"
         )
 
-    def rerank_hybrid(
+    def needs_columns(self):
+        return ["_rowid"]
+
+    def compute_scores(
         self,
-        query: str,  # noqa: F821
-        vector_results: pa.Table,
-        fts_results: pa.Table,
-    ):
-        vector_ids = vector_results["_rowid"].to_pylist() if vector_results else []
-        fts_ids = fts_results["_rowid"].to_pylist() if fts_results else []
+        query: str,
+        results: List[RerankableResult],
+    ) -> List[pa.Array]:
+        # Determine weights per result set
+        # For hybrid (1 vector + 1 fts): use configured weights
+        # For multi-vector (all VectorResult): equal weights across all
+        num_results = len(results)
 
-        # Maps result_id to list of (type, reciprocal_rank)
-        mrr_score_map = defaultdict(list)
+        has_vector = any(isinstance(r, VectorResult) for r in results)
+        has_fts = any(isinstance(r, FtsResult) for r in results)
+        is_hybrid = has_vector and has_fts
 
-        if vector_ids:
-            for rank, result_id in enumerate(vector_ids, 1):
-                reciprocal_rank = 1.0 / rank
-                mrr_score_map[result_id].append(("vector", reciprocal_rank))
+        # Calculate weighted reciprocal rank per rowid
+        mrr_score_map = defaultdict(float)
 
-        if fts_ids:
-            for rank, result_id in enumerate(fts_ids, 1):
-                reciprocal_rank = 1.0 / rank
-                mrr_score_map[result_id].append(("fts", reciprocal_rank))
+        if is_hybrid:
+            for result in results:
+                weight = (
+                    self.weight_vector
+                    if isinstance(result, VectorResult)
+                    else self.weight_fts
+                )
+                row_ids = result.data["_rowid"].to_pylist()
+                for rank, row_id in enumerate(row_ids, 1):
+                    mrr_score_map[row_id] += weight * (1.0 / rank)
+        else:
+            # Multi-vector or single: equal weight per result set
+            weight = 1.0 / num_results if num_results > 0 else 1.0
+            for result in results:
+                row_ids = result.data["_rowid"].to_pylist()
+                for rank, row_id in enumerate(row_ids, 1):
+                    mrr_score_map[row_id] += weight * (1.0 / rank)
 
-        final_mrr_scores = {}
-        for result_id, scores in mrr_score_map.items():
-            vector_rr = 0.0
-            fts_rr = 0.0
+        # Build score arrays aligned to each input result set
+        score_arrays = []
+        for result in results:
+            row_ids = result.data["_rowid"].to_pylist()
+            scores = [mrr_score_map[rid] for rid in row_ids]
+            score_arrays.append(pa.array(scores, type=pa.float32()))
 
-            for score_type, reciprocal_rank in scores:
-                if score_type == "vector":
-                    vector_rr = reciprocal_rank
-                elif score_type == "fts":
-                    fts_rr = reciprocal_rank
-
-            # If a document doesn't appear, its reciprocal rank is 0
-            weighted_mrr = self.weight_vector * vector_rr + self.weight_fts * fts_rr
-            final_mrr_scores[result_id] = weighted_mrr
-
-        combined_results = self.merge_results(vector_results, fts_results)
-        combined_row_ids = combined_results["_rowid"].to_pylist()
-        relevance_scores = [final_mrr_scores[row_id] for row_id in combined_row_ids]
-        combined_results = combined_results.append_column(
-            "_relevance_score", pa.array(relevance_scores, type=pa.float32())
-        )
-        combined_results = combined_results.sort_by(
-            [("_relevance_score", "descending")]
-        )
-
-        if self.score == "relevance":
-            combined_results = self._keep_relevance_score(combined_results)
-
-        return combined_results
-
-    def rerank_multivector(
-        self,
-        vector_results: Union[List[pa.Table], List["LanceVectorQueryBuilder"]],
-        query: str = None,
-        deduplicate: bool = True,  # noqa: F821
-    ):
-        """
-        Reranks the results from multiple vector searches using MRR algorithm.
-        Each vector search result is treated as a separate ranking system,
-        and MRR calculates the mean of reciprocal ranks across all systems.
-        This cannot reuse rerank_hybrid because MRR semantics require treating
-        each vector result as a separate ranking system.
-        """
-        if not all(isinstance(v, type(vector_results[0])) for v in vector_results):
-            raise ValueError(
-                "All elements in vector_results should be of the same type"
-            )
-
-        # avoid circular import
-        if type(vector_results[0]).__name__ == "LanceVectorQueryBuilder":
-            vector_results = [result.to_arrow() for result in vector_results]
-        elif not isinstance(vector_results[0], pa.Table):
-            raise ValueError(
-                "vector_results should be a list of pa.Table or LanceVectorQueryBuilder"
-            )
-
-        if not all("_rowid" in result.column_names for result in vector_results):
-            raise ValueError(
-                "'_rowid' is required for deduplication. \
-                    add _rowid to search results like this: \
-                    `search().with_row_id(True)`"
-            )
-
-        mrr_score_map = defaultdict(list)
-
-        for result_table in vector_results:
-            result_ids = result_table["_rowid"].to_pylist()
-            for rank, result_id in enumerate(result_ids, 1):
-                reciprocal_rank = 1.0 / rank
-                mrr_score_map[result_id].append(reciprocal_rank)
-
-        final_mrr_scores = {}
-        for result_id, reciprocal_ranks in mrr_score_map.items():
-            mean_rr = np.mean(reciprocal_ranks)
-            final_mrr_scores[result_id] = mean_rr
-
-        combined = pa.concat_tables(vector_results, **self._concat_tables_args)
-        combined = self._deduplicate(combined)
-
-        combined_row_ids = combined["_rowid"].to_pylist()
-
-        relevance_scores = [final_mrr_scores[row_id] for row_id in combined_row_ids]
-        combined = combined.append_column(
-            "_relevance_score", pa.array(relevance_scores, type=pa.float32())
-        )
-        combined = combined.sort_by([("_relevance_score", "descending")])
-
-        if self.score == "relevance":
-            combined = self._keep_relevance_score(combined)
-
-        return combined
+        return score_arrays

--- a/python/python/lancedb/rerankers/rrf.py
+++ b/python/python/lancedb/rerankers/rrf.py
@@ -2,14 +2,12 @@
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 
-from typing import Union, List, TYPE_CHECKING
+from typing import List
+
 import pyarrow as pa
 
 from collections import defaultdict
-from .base import Reranker
-
-if TYPE_CHECKING:
-    from ..table import LanceVectorQueryBuilder
+from .base import Reranker, RerankableResult
 
 
 class RRFReranker(Reranker):
@@ -39,73 +37,26 @@ class RRFReranker(Reranker):
     def __str__(self):
         return f"RRFReranker(K={self.K})"
 
-    def rerank_hybrid(
+    def needs_columns(self):
+        return ["_rowid"]
+
+    def compute_scores(
         self,
-        query: str,  # noqa: F821
-        vector_results: pa.Table,
-        fts_results: pa.Table,
-    ):
-        vector_ids = vector_results["_rowid"].to_pylist() if vector_results else []
-        fts_ids = fts_results["_rowid"].to_pylist() if fts_results else []
+        query: str,
+        results: List[RerankableResult],
+    ) -> List[pa.Array]:
+        # Calculate RRF score per rowid across all result sets
         rrf_score_map = defaultdict(float)
+        for result in results:
+            row_ids = result.data["_rowid"].to_pylist()
+            for rank, row_id in enumerate(row_ids, 1):
+                rrf_score_map[row_id] += 1 / (rank + self.K)
 
-        # Calculate RRF score of each result
-        for ids in [vector_ids, fts_ids]:
-            for i, result_id in enumerate(ids, 1):
-                rrf_score_map[result_id] += 1 / (i + self.K)
+        # Build score arrays aligned to each input result set
+        score_arrays = []
+        for result in results:
+            row_ids = result.data["_rowid"].to_pylist()
+            scores = [rrf_score_map[rid] for rid in row_ids]
+            score_arrays.append(pa.array(scores, type=pa.float32()))
 
-        # Sort the results based on RRF score
-        combined_results = self.merge_results(vector_results, fts_results)
-        combined_row_ids = combined_results["_rowid"].to_pylist()
-        relevance_scores = [rrf_score_map[row_id] for row_id in combined_row_ids]
-        combined_results = combined_results.append_column(
-            "_relevance_score", pa.array(relevance_scores, type=pa.float32())
-        )
-        combined_results = combined_results.sort_by(
-            [("_relevance_score", "descending")]
-        )
-
-        if self.score == "relevance":
-            combined_results = self._keep_relevance_score(combined_results)
-
-        return combined_results
-
-    def rerank_multivector(
-        self,
-        vector_results: Union[List[pa.Table], List["LanceVectorQueryBuilder"]],
-        query: str = None,
-        deduplicate: bool = True,  # noqa: F821 # TODO: automatically deduplicates
-    ):
-        """
-        Overridden method to rerank the results from multiple vector searches.
-        This leverages the RRF hybrid reranking algorithm to combine the
-        results from multiple vector searches as it doesn't support reranking
-        vector results individually.
-        """
-        # Make sure all elements are of the same type
-        if not all(isinstance(v, type(vector_results[0])) for v in vector_results):
-            raise ValueError(
-                "All elements in vector_results should be of the same type"
-            )
-
-        # avoid circular import
-        if type(vector_results[0]).__name__ == "LanceVectorQueryBuilder":
-            vector_results = [result.to_arrow() for result in vector_results]
-        elif not isinstance(vector_results[0], pa.Table):
-            raise ValueError(
-                "vector_results should be a list of pa.Table or LanceVectorQueryBuilder"
-            )
-
-        # _rowid is required for RRF reranking
-        if not all("_rowid" in result.column_names for result in vector_results):
-            raise ValueError(
-                "'_rowid' is required for deduplication. \
-                    add _rowid to search results like this: \
-                    `search().with_row_id(True)`"
-            )
-
-        combined = pa.concat_tables(vector_results, **self._concat_tables_args)
-        empty_table = pa.Table.from_arrays([], names=[])
-        reranked = self.rerank_hybrid(query, combined, empty_table)
-
-        return reranked
+        return score_arrays

--- a/python/python/lancedb/rerankers/util.py
+++ b/python/python/lancedb/rerankers/util.py
@@ -2,19 +2,49 @@
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 
+from typing import List
+
 import pyarrow as pa
 
 
 def check_reranker_result(result):
+    """Validate the final result table from a reranker."""
     if not isinstance(result, pa.Table):  # Enforce type
         raise TypeError(
-            f"rerank_hybrid must return a pyarrow.Table, got {type(result)}"
+            f"reranker must return a pyarrow.Table, got {type(result)}"
         )
 
-    # Enforce that `_relevance_score` column is present in the result of every
-    # rerank_hybrid method
+    # Enforce that `_relevance_score` column is present
     if "_relevance_score" not in result.column_names:
         raise ValueError(
-            "rerank_hybrid must return a pyarrow.Table with a column"
+            "reranker must return a pyarrow.Table with a column "
             "named `_relevance_score`"
         )
+
+
+def check_compute_scores_result(
+    score_arrays: List[pa.Array], num_results: int
+):
+    """Validate the return value of ``compute_scores``.
+
+    Parameters
+    ----------
+    score_arrays : List[pa.Array]
+        The arrays returned by ``compute_scores``.
+    num_results : int
+        The number of result sets that were passed to ``compute_scores``.
+    """
+    if not isinstance(score_arrays, list):
+        raise TypeError(
+            f"compute_scores must return a list of pa.Array, got {type(score_arrays)}"
+        )
+    if len(score_arrays) != num_results:
+        raise ValueError(
+            f"compute_scores returned {len(score_arrays)} arrays "
+            f"but {num_results} result sets were provided"
+        )
+    for i, arr in enumerate(score_arrays):
+        if not isinstance(arr, pa.Array):
+            raise TypeError(
+                f"compute_scores[{i}] must be a pa.Array, got {type(arr)}"
+            )

--- a/python/python/tests/test_rerankers.py
+++ b/python/python/tests/test_rerankers.py
@@ -23,6 +23,8 @@ from lancedb.rerankers import (
     AnswerdotaiRerankers,
     VoyageAIReranker,
     MRRReranker,
+    FtsResult,
+    VectorResult,
 )
 from lancedb.table import LanceTable
 
@@ -191,22 +193,6 @@ def _run_test_reranker(reranker, table, query, query_vector, schema):
         ascending_relevance_err
     )
 
-    # Multi-vector search setting
-    rs1 = table.search(query, vector_column_name="vector").limit(10).with_row_id(True)
-    rs2 = (
-        table.search(query, vector_column_name="meta_vector")
-        .limit(10)
-        .with_row_id(True)
-    )
-    result = reranker.rerank_multivector([rs1, rs2], query)
-    assert len(result) == 20
-    result_deduped = reranker.rerank_multivector(
-        [rs1, rs2, rs1], query, deduplicate=True
-    )
-    assert len(result_deduped) <= 20
-    result_arrow = reranker.rerank_multivector([rs1.to_arrow(), rs2.to_arrow()], query)
-    assert len(result) == 20 and result == result_arrow
-
 
 def _run_test_hybrid_reranker(reranker, tmp_path, use_tantivy):
     table, schema = get_test_table(tmp_path, use_tantivy)
@@ -305,7 +291,14 @@ def test_linear_combination(tmp_path, use_tantivy):
         }
     )
 
-    combined_results = reranker.merge_results(vector_results, fts_results, 1.0)
+    from lancedb.query import _apply_reranker
+
+    combined_results = _apply_reranker(
+        reranker,
+        "",
+        [(vector_results, "vector"), (fts_results, "fts")],
+        return_score="relevance",
+    )
     assert len(combined_results) == 6
     assert "_rowid" in combined_results.column_names
     assert "_text" in combined_results.column_names
@@ -326,28 +319,6 @@ def test_rrf_reranker(tmp_path, use_tantivy):
 def test_mrr_reranker(tmp_path, use_tantivy):
     reranker = MRRReranker()
     _run_test_hybrid_reranker(reranker, tmp_path, use_tantivy)
-
-    # Test multi-vector part
-    table, schema = get_test_table(tmp_path, use_tantivy)
-    query = "single player experience"
-    rs1 = table.search(query, vector_column_name="vector").limit(10).with_row_id(True)
-    rs2 = (
-        table.search(query, vector_column_name="meta_vector")
-        .limit(10)
-        .with_row_id(True)
-    )
-    result = reranker.rerank_multivector([rs1, rs2])
-    assert "_relevance_score" in result.column_names
-    assert len(result) <= 20
-
-    if len(result) > 1:
-        assert np.all(np.diff(result.column("_relevance_score").to_numpy()) <= 0), (
-            "The _relevance_score should be descending."
-        )
-
-    # Test with duplicate results
-    result_deduped = reranker.rerank_multivector([rs1, rs2, rs1])
-    assert len(result_deduped) == len(result)
 
 
 def test_rrf_reranker_distance():
@@ -545,3 +516,130 @@ def test_cross_encoder_reranker_return_all(tmp_path, use_tantivy):
     assert "_relevance_score" in result.column_names
     assert "_score" in result.column_names
     assert "_distance" in result.column_names
+
+
+# ---------------------------------------------------------------
+# Tests for the new compute_scores API
+# ---------------------------------------------------------------
+
+
+def test_compute_scores_rrf():
+    """Test RRFReranker.compute_scores directly."""
+    reranker = RRFReranker(K=60)
+
+    vector_table = pa.table(
+        {"_rowid": [0, 1, 2], "text": ["a", "b", "c"], "_distance": [0.1, 0.2, 0.3]}
+    )
+    fts_table = pa.table(
+        {"_rowid": [1, 2, 3], "text": ["b", "c", "d"], "_score": [0.9, 0.8, 0.7]}
+    )
+
+    results = [VectorResult(data=vector_table), FtsResult(data=fts_table)]
+    score_arrays = reranker.compute_scores("test query", results)
+
+    # Should return one array per input
+    assert len(score_arrays) == 2
+    assert len(score_arrays[0]) == 3  # aligned to vector_table
+    assert len(score_arrays[1]) == 3  # aligned to fts_table
+    assert score_arrays[0].type == pa.float32()
+    assert score_arrays[1].type == pa.float32()
+
+    # Row 1 appears in both sets so its score should be higher than row 0 or row 3
+    # Row 1 is rank 2 in vector (score: 1/(2+60)) and rank 1 in fts (score: 1/(1+60))
+    row1_vector_score = score_arrays[0][1].as_py()
+    row0_vector_score = score_arrays[0][0].as_py()
+    assert row1_vector_score > row0_vector_score
+
+
+def test_compute_scores_rrf_single_vector():
+    """Test RRFReranker.compute_scores with single vector input."""
+    reranker = RRFReranker(K=60)
+
+    vector_table = pa.table(
+        {"_rowid": [0, 1, 2], "text": ["a", "b", "c"], "_distance": [0.1, 0.2, 0.3]}
+    )
+
+    results = [VectorResult(data=vector_table)]
+    score_arrays = reranker.compute_scores("test query", results)
+
+    assert len(score_arrays) == 1
+    assert len(score_arrays[0]) == 3
+    # First result (rank 1) should have highest score
+    assert score_arrays[0][0].as_py() > score_arrays[0][1].as_py()
+
+
+def test_compute_scores_linear_combination():
+    """Test LinearCombinationReranker.compute_scores directly."""
+    reranker = LinearCombinationReranker(weight=0.7, fill=1.0)
+
+    vector_table = pa.table(
+        {"_rowid": [0, 1, 2], "_distance": [0.1, 0.2, 0.3], "text": ["a", "b", "c"]}
+    )
+    fts_table = pa.table(
+        {"_rowid": [1, 2, 3], "_score": [0.9, 0.8, 0.7], "text": ["b", "c", "d"]}
+    )
+
+    results = [VectorResult(data=vector_table), FtsResult(data=fts_table)]
+    score_arrays = reranker.compute_scores("test query", results)
+
+    assert len(score_arrays) == 2
+    assert len(score_arrays[0]) == 3
+    assert len(score_arrays[1]) == 3
+    assert score_arrays[0].type == pa.float32()
+
+    # Row 1 has both distance and score; row 0 has only distance (uses fill for fts)
+    # Both should produce valid float scores
+    for arr in score_arrays:
+        for i in range(len(arr)):
+            assert arr[i].as_py() is not None
+
+
+def test_compute_scores_mrr():
+    """Test MRRReranker.compute_scores directly."""
+    reranker = MRRReranker(weight_vector=0.5, weight_fts=0.5)
+
+    vector_table = pa.table(
+        {"_rowid": [0, 1, 2], "text": ["a", "b", "c"], "_distance": [0.1, 0.2, 0.3]}
+    )
+    fts_table = pa.table(
+        {"_rowid": [1, 2, 3], "text": ["b", "c", "d"], "_score": [0.9, 0.8, 0.7]}
+    )
+
+    results = [VectorResult(data=vector_table), FtsResult(data=fts_table)]
+    score_arrays = reranker.compute_scores("test query", results)
+
+    assert len(score_arrays) == 2
+    assert len(score_arrays[0]) == 3
+    assert len(score_arrays[1]) == 3
+    assert score_arrays[0].type == pa.float32()
+
+
+def test_compute_scores_mrr_multivector():
+    """Test MRRReranker.compute_scores with multiple vector inputs."""
+    reranker = MRRReranker()
+
+    vec1 = pa.table({"_rowid": [0, 1, 2], "text": ["a", "b", "c"]})
+    vec2 = pa.table({"_rowid": [1, 2, 3], "text": ["b", "c", "d"]})
+
+    results = [VectorResult(data=vec1), VectorResult(data=vec2)]
+    score_arrays = reranker.compute_scores("test query", results)
+
+    assert len(score_arrays) == 2
+    # Row 1 appears in both: should have higher score than row 0 (only in vec1)
+    row1_score = score_arrays[0][1].as_py()  # row 1 in vec1
+    row0_score = score_arrays[0][0].as_py()  # row 0 in vec1
+    assert row1_score > row0_score
+
+
+def test_compute_scores_empty():
+    """Test compute_scores with empty input."""
+    reranker = RRFReranker()
+
+    empty_table = pa.table({"_rowid": pa.array([], type=pa.int64())})
+    results = [VectorResult(data=empty_table)]
+    score_arrays = reranker.compute_scores("test query", results)
+
+    assert len(score_arrays) == 1
+    assert len(score_arrays[0]) == 0
+
+


### PR DESCRIPTION
## Summary

Resolves #3017

Refactors the reranker API so that rerankers are **only responsible for computing relevance scores**, and no longer manage column projections, merging, deduplication, or sorting.

- **New `compute_scores(query, List[RerankableResult]) -> List[pa.Array]`** — each reranker returns one float32 score array per input result set
- **New `needs_columns() -> List[Literal[...]]`** — declarative column requirements enabling projection pushdown
- **New typed wrappers** — `RerankableResult`, `FtsResult`, `VectorResult` with `data: pa.Table`
- **New `_apply_reranker()` pipeline helper** in `query.py` — centralizes wrapping, projection pushdown, scoring, merging, deduplication, sorting, and column projection
- All 6 reranker call sites (sync/async vector, FTS, hybrid) now use `_apply_reranker()` directly
- All 10 rerankers updated: RRF, LinearCombination, MRR, CrossEncoder, Answerdotai (+Colbert), Cohere, OpenAI, Jina, VoyageAI
- Removed deprecated methods: `rerank_hybrid`, `rerank_vector`, `rerank_fts`, `rerank_multivector`, `merge_results`, `_handle_empty_results`, `_keep_relevance_score`, `_merge_and_keep_scores`, `_has_new_api`

**BREAKING CHANGE:** Reranker subclasses must now implement `compute_scores()` instead of `rerank_hybrid`/`rerank_vector`/`rerank_fts`.

## Test plan

- [x] All reranker unit tests pass (13 passed, 1 skipped for torch)
- [x] All hybrid query tests pass (9 passed)
- [x] All query tests pass (53 passed, 1 skipped)
- [x] New `compute_scores` tests cover: RRF, RRF single-vector, LinearCombination, MRR, MRR multivector, empty results
- [ ] CI passes on all platforms