### PR TITLE
fix: allow permutation reader to work with remote tables as well

### DIFF
--- a/python/src/permutation.rs
+++ b/python/src/permutation.rs
@@ -23,10 +23,25 @@ use pyo3::{
 };
 use pyo3_async_runtimes::tokio::future_into_py;
 
+fn table_from_py<'a>(table: Bound<'a, PyAny>) -> PyResult<Bound<'a, Table>> {
+    if table.hasattr("_inner")? {
+        Ok(table.getattr("_inner")?.downcast_into::<Table>()?)
+    } else if table.hasattr("_table")? {
+        Ok(table
+            .getattr("_table")?
+            .getattr("_inner")?
+            .downcast_into::<Table>()?)
+    } else {
+        Err(PyRuntimeError::new_err(
+            "Provided table does not appear to be a Table or RemoteTable instance",
+        ))
+    }
+}
+
 /// Create a permutation builder for the given table
 #[pyo3::pyfunction]
 pub fn async_permutation_builder(table: Bound<'_, PyAny>) -> PyResult<PyAsyncPermutationBuilder> {
-    let table = table.getattr("_inner")?.downcast_into::<Table>()?;
+    let table = table_from_py(table)?;
     let inner_table = table.borrow().inner_ref()?.clone();
     let inner_builder = LancePermutationBuilder::new(inner_table);
 
@@ -239,21 +254,6 @@ impl PyPermutationReader {
             .collect::<PyResult<Vec<_>>>()?;
         Ok(Select::dynamic(&selection))
     }
-
-    fn table_from_py<'a>(table: Bound<'a, PyAny>) -> PyResult<Bound<'a, Table>> {
-        if table.hasattr("_inner")? {
-            Ok(table.getattr("_inner")?.downcast_into::<Table>()?)
-        } else if table.hasattr("_table")? {
-            Ok(table
-                .getattr("_table")?
-                .getattr("_inner")?
-                .downcast_into::<Table>()?)
-        } else {
-            Err(PyRuntimeError::new_err(
-                "Provided table does not appear to be a Table or RemoteTable instance",
-            ))
-        }
-    }
 }
 
 #[pymethods]
@@ -265,8 +265,8 @@ impl PyPermutationReader {
         permutation_table: Option<Bound<'py, PyAny>>,
         split: u64,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let base_table = Self::table_from_py(base_table)?;
-        let permutation_table = permutation_table.map(Self::table_from_py).transpose()?;
+        let base_table = table_from_py(base_table)?;
+        let permutation_table = permutation_table.map(table_from_py).transpose()?;
 
         let base_table = base_table.borrow().inner_ref()?.base_table().clone();
         let permutation_table = permutation_table


### PR DESCRIPTION
Fixed one more spot that was relying on `_inner`.