### PR TITLE
fix: don't expect all offsets to fit in one batch in permutation reader

### DIFF
--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -202,7 +202,6 @@ impl<S: HttpSend + 'static> Tags for RemoteTags<'_, S> {
 }
 
 pub struct RemoteTable<S: HttpSend = Sender> {
-    #[allow(dead_code)]
     client: RestfulLanceDbClient<S>,
     name: String,
     namespace: Vec<String>,


### PR DESCRIPTION
This would cause takes against large permutations to fail