### PR TITLE
chore: unify component README titles

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -1,4 +1,4 @@
-# LanceDB Java SDK
+# LanceDB Java Enterprise Client
 
 ## Configuration and Initialization
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,4 @@
-# LanceDB
+# LanceDB Python SDK
 
 A Python library for [LanceDB](https://github.com/lancedb/lancedb).
 

--- a/rust/lancedb/README.md
+++ b/rust/lancedb/README.md
@@ -1,4 +1,4 @@
-# LanceDB Rust
+# LanceDB Rust SDK
 
 <a href="https://crates.io/crates/vectordb">![img](https://img.shields.io/crates/v/vectordb)</a>
 <a href="https://docs.rs/vectordb/latest/vectordb/">![Docs.rs](https://img.shields.io/docsrs/vectordb)</a>


### PR DESCRIPTION
## Summary
- align component README titles with current naming direction
- use `SDK` for full-featured language clients
- use `Enterprise Client` for the Java namespace API client README title

## Changes
- `python/README.md`: `# LanceDB` -> `# LanceDB Python SDK`
- `rust/lancedb/README.md`: `# LanceDB Rust` -> `# LanceDB Rust SDK`
- `java/README.md`: `# LanceDB Java SDK` -> `# LanceDB Java Enterprise Client`

## Notes
- no behavior or API changes
- no tests were run (docs/title-only changes)
