### PR TITLE
feat: add parity between fast_search keyword argument between vector and FTS searches

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -606,6 +606,7 @@ class LanceQueryBuilder(ABC):
                 query,
                 ordering_field_name=ordering_field_name,
                 fts_columns=fts_columns,
+                fast_search=fast_search,
             )
 
         if isinstance(query, list):
@@ -1456,13 +1457,14 @@ class LanceFtsQueryBuilder(LanceQueryBuilder):
         query: str | FullTextQuery,
         ordering_field_name: Optional[str] = None,
         fts_columns: Optional[Union[str, List[str]]] = None,
+        fast_search: bool = None,
     ):
         super().__init__(table)
         self._query = query
         self._phrase_query = False
         self.ordering_field_name = ordering_field_name
         self._reranker = None
-        self._fast_search = None
+        self._fast_search = fast_search
         if isinstance(fts_columns, str):
             fts_columns = [fts_columns]
         self._fts_columns = fts_columns

--- a/python/python/tests/test_fts.py
+++ b/python/python/tests/test_fts.py
@@ -27,6 +27,7 @@ from lancedb.query import (
     PhraseQuery,
     BooleanQuery,
     Occur,
+    LanceFtsQueryBuilder,
 )
 import numpy as np
 import pyarrow as pa
@@ -919,6 +920,10 @@ def test_fts_fast_search(table):
     assert query.fast_search is True
     assert query.limit == 5
     assert query.columns == ["text"]
+
+    # fast_search should be enabled by keyword argument too
+    query = LanceFtsQueryBuilder(table, "xyz", fast_search=True).to_query_object()
+    assert query.fast_search is True
 
     # Verify it executes without error and skips unindexed data
     results = table.search("xyz", query_type="fts").fast_search().limit(5).to_list()


### PR DESCRIPTION
We don't necessarily need to do this, but one user was confused having used `fast_search=True` as a keyword argument for vector searches, but being unable to do so for FTS, even after the most recent changes. I think this is the only discrepancy in where that is possible.