### PR TITLE
docs: add meth/func names to mkdocstrings

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -52,14 +52,21 @@ plugins:
           options:
             docstring_style: numpy
             heading_level: 3
-            show_source: true
-            show_symbol_type_in_heading: true
             show_signature_annotations: true
             show_root_heading: true
+            show_docstring_examples: true
+            show_docstring_attributes: false
+            show_docstring_other_parameters: true
+            show_symbol_type_heading: true
+            show_labels: false
+            show_if_no_docstring: true
+            show_source: false
             members_order: source
             docstring_section_style: list
             signature_crossrefs: true
             separate_signature: true
+            filters:
+              - "!^_"
           import:
             # for cross references
             - https://arrow.apache.org/docs/objects.inv
@@ -113,7 +120,7 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - markdown.extensions.toc:
-      toc_depth: 3
+      toc_depth: 4
       permalink: true
       permalink_title: Anchor link to this section
 


### PR DESCRIPTION
LanceDB's SDK API docs do not currently show method names under any given object, and this makes it harder to quickly understand and find relevant method names for a given class. Geneva docs show the available methods in the right navigation.

This PR standardizes the appearance of the LanceDB SDK API in the docs to be more similar to Geneva's.
<img width="1386" height="792" alt="image" src="https://github.com/user-attachments/assets/30816591-d6d5-495d-886d-e234beeb6059" />

<img width="897" height="540" alt="image" src="https://github.com/user-attachments/assets/d5491b6b-c7bf-4d3b-8b15-1a1a7700e7c9" />
