### PR TITLE
fix: return single row from Permutation.__getitem__ instead of batch

### DIFF
--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -768,7 +768,10 @@ class Permutation:
         """
         Returns a single row from the permutation by offset
         """
-        return self.__getitems__([index])
+        result = self.__getitems__([index])
+        if isinstance(result, list) and len(result) == 1:
+            return result[0]
+        return result
 
     def __getitems__(self, indices: list[int]) -> Any:
         """


### PR DESCRIPTION
## Summary

Fixes #2996.

`Permutation.__getitem__` delegates to `__getitems__([index])`, which applies the transform function to a single-row batch and returns the full result. With the default `arrow2python` transform, this means `__getitem__` returns `[{"col": val}]` (a list containing one dict) instead of `{"col": val}` (the dict itself).

This breaks `torch.utils.data.DataLoader`, which calls `__getitem__` per index and expects a single item back — not a wrapped list.

## Fix

Extract the single element when `__getitems__` returns a one-element list:

```python
def __getitem__(self, index: int) -> Any:
    result = self.__getitems__([index])
    if isinstance(result, list) and len(result) == 1:
        return result[0]
    return result
```

The `isinstance` + length check keeps it safe for transforms that return non-list types (e.g. `arrow2arrow` returns a `RecordBatch`, `arrow2pandas` returns a `DataFrame`) — those pass through unchanged.

## Test plan

- Verified the fix against the minimal repro from the issue (torch DataLoader collate_fn receives individual dicts instead of `None`s)
- Confirmed `__getitems__` behavior is unchanged (still returns batches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)