### PR TITLE
fix(python): preserve null structs on round-trip through to_pylist()

### DIFF
--- a/python/python/lancedb/arrow.py
+++ b/python/python/lancedb/arrow.py
@@ -10,6 +10,115 @@ import pyarrow as pa
 from ._lancedb import RecordBatchStream
 
 
+
+def _has_struct_type(data_type):
+    """Check if a data type contains a struct type (directly or nested)."""
+    if pa.types.is_struct(data_type):
+        return True
+    if pa.types.is_list(data_type) or pa.types.is_large_list(data_type):
+        return _has_struct_type(data_type.value_type)
+    if pa.types.is_fixed_size_list(data_type):
+        return _has_struct_type(data_type.value_type)
+    return False
+
+
+def _fix_struct_nulls(value, data_type, array, idx):
+    """Recursively fix a single value from a struct array.
+
+    If the array element at *idx* is null, return None regardless of what
+    ``to_pylist()`` produced.  Otherwise walk the struct children and
+    recursively fix any nested struct / list-of-struct fields.
+    """
+    if not array.is_valid(idx):
+        return None
+    if value is None:
+        return None
+    for j, sub_field in enumerate(data_type):
+        if _has_struct_type(sub_field.type):
+            child_array = array.field(j)
+            value[sub_field.name] = _fix_value(
+                value[sub_field.name], sub_field.type, child_array, idx
+            )
+    return value
+
+
+def _fix_list_nulls(value, data_type, array, idx):
+    """Fix null struct values inside a list element."""
+    if not array.is_valid(idx):
+        return None
+    if value is None:
+        return None
+
+    value_type = data_type.value_type
+    offsets = array.offsets.to_pylist()
+    start = offsets[idx]
+    values_array = array.values
+
+    for k in range(len(value)):
+        value[k] = _fix_value(value[k], value_type, values_array, start + k)
+    return value
+
+
+def _fix_value(value, data_type, array, idx):
+    """Dispatch to the right null-fixer based on Arrow data type."""
+    if pa.types.is_struct(data_type):
+        return _fix_struct_nulls(value, data_type, array, idx)
+    if pa.types.is_list(data_type) or pa.types.is_large_list(data_type):
+        if _has_struct_type(data_type.value_type):
+            return _fix_list_nulls(value, data_type, array, idx)
+    return value
+
+
+def _fix_column(column, field):
+    """Fix null struct values in a single table column."""
+    py_values = column.to_pylist()
+    offset = 0
+    for chunk in column.chunks:
+        for i in range(len(chunk)):
+            py_values[offset + i] = _fix_value(
+                py_values[offset + i], field.type, chunk, i
+            )
+        offset += len(chunk)
+    return py_values
+
+
+def table_to_pylist(table):
+    """Convert a PyArrow Table to a list of dicts, correctly handling null structs.
+
+    PyArrow's built-in ``to_pylist()`` converts null struct values into dicts
+    populated with default values (empty strings, zeros, etc.) instead of
+    ``None``.  This function uses Arrow validity bitmaps to restore ``None``
+    for every null struct -- and for null struct items inside lists -- at any
+    nesting depth.
+
+    Parameters
+    ----------
+    table : pa.Table
+        The table to convert.
+
+    Returns
+    -------
+    list[dict]
+        List of dictionaries with correct null handling for struct fields.
+    """
+    if not any(_has_struct_type(field.type) for field in table.schema):
+        return table.to_pylist()
+
+    n_rows = len(table)
+    result = [{} for _ in range(n_rows)]
+
+    for i, field in enumerate(table.schema):
+        column = table.column(i)
+        if _has_struct_type(field.type):
+            values = _fix_column(column, field)
+        else:
+            values = column.to_pylist()
+        for row_idx in range(n_rows):
+            result[row_idx][field.name] = values[row_idx]
+
+    return result
+
+
 class AsyncRecordBatchReader:
     """
     An async iterator over a stream of RecordBatches.

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -32,7 +32,7 @@ from lancedb.pydantic import PYDANTIC_VERSION
 from lancedb.background_loop import LOOP
 
 from . import __version__
-from .arrow import AsyncRecordBatchReader
+from .arrow import AsyncRecordBatchReader, table_to_pylist
 from .dependencies import pandas as pd
 from .rerankers.base import Reranker
 from .rerankers.rrf import RRFReranker
@@ -769,7 +769,7 @@ class LanceQueryBuilder(ABC):
             The maximum time to wait for the query to complete.
             If None, wait indefinitely.
         """
-        return self.to_arrow(timeout=timeout).to_pylist()
+        return table_to_pylist(self.to_arrow(timeout=timeout))
 
     def to_pydantic(
         self, model: type[T], *, timeout: Optional[timedelta] = None
@@ -788,7 +788,7 @@ class LanceQueryBuilder(ABC):
         -------
         List[LanceModel]
         """
-        return [model(**row) for row in self.to_arrow(timeout=timeout).to_pylist()]
+        return [model(**row) for row in table_to_pylist(self.to_arrow(timeout=timeout))]
 
     def to_polars(self, *, timeout: Optional[timedelta] = None) -> "pl.DataFrame":
         """
@@ -2372,7 +2372,7 @@ class AsyncQueryBase(object):
             If not specified, no timeout is applied. If the query does not
             complete within the specified time, an error will be raised.
         """
-        return (await self.to_arrow(timeout=timeout)).to_pylist()
+        return table_to_pylist(await self.to_arrow(timeout=timeout))
 
     async def to_pandas(
         self,
@@ -2470,7 +2470,7 @@ class AsyncQueryBase(object):
         list[LanceModel]
         """
         return [
-            model(**row) for row in (await self.to_arrow(timeout=timeout)).to_pylist()
+            model(**row) for row in table_to_pylist(await self.to_arrow(timeout=timeout))
         ]
 
     async def explain_plan(self, verbose: Optional[bool] = False):

--- a/python/python/tests/test_struct_null_roundtrip.py
+++ b/python/python/tests/test_struct_null_roundtrip.py
@@ -1,0 +1,104 @@
+"""Tests for nullable struct round-trip (issue #3105).
+
+Verifies that nullable struct fields preserve None on read-back instead
+of being inflated to dicts with default values.
+"""
+
+import pyarrow as pa
+from lancedb.arrow import table_to_pylist
+
+
+def test_top_level_null_struct():
+    """A top-level nullable struct column should round-trip None correctly."""
+    struct_type = pa.struct(
+        [pa.field("name", pa.utf8(), False), pa.field("value", pa.utf8(), False)]
+    )
+    col = pa.array(
+        [None, {"name": "hello", "value": "world"}], type=struct_type
+    )
+    table = pa.table({"id": [1, 2], "obj": col})
+
+    result = table_to_pylist(table)
+    assert result[0]["obj"] is None
+    assert result[1]["obj"] == {"name": "hello", "value": "world"}
+
+
+def test_nested_null_struct():
+    """A struct with a nullable inner struct should preserve None on the inner."""
+    inner_type = pa.struct([pa.field("value", pa.utf8(), False)])
+    outer_type = pa.struct(
+        [
+            pa.field("name", pa.utf8(), False),
+            pa.field("inner", inner_type, True),
+        ]
+    )
+    col = pa.array(
+        [{"name": "has inner", "inner": {"value": "x"}}, {"name": "no inner", "inner": None}],
+        type=outer_type,
+    )
+    table = pa.table({"data": col})
+
+    result = table_to_pylist(table)
+    assert result[0]["data"]["inner"] == {"value": "x"}
+    assert result[1]["data"]["inner"] is None
+
+
+def test_list_of_nullable_structs():
+    """A list column whose items are nullable structs should preserve None items."""
+    struct_type = pa.struct(
+        [pa.field("name", pa.utf8(), False)]
+    )
+    list_type = pa.list_(pa.field("item", struct_type, True))
+    col = pa.array(
+        [[{"name": "a"}, None, {"name": "b"}], [None]],
+        type=list_type,
+    )
+    table = pa.table({"items": col})
+
+    result = table_to_pylist(table)
+    assert result[0]["items"][0] == {"name": "a"}
+    assert result[0]["items"][1] is None
+    assert result[0]["items"][2] == {"name": "b"}
+    assert result[1]["items"][0] is None
+
+
+def test_full_scenario_from_issue():
+    """Reproduce the exact scenario from issue #3105."""
+    inner_type = pa.struct([pa.field("value", pa.utf8(), False)])
+    nested_type = pa.struct(
+        [
+            pa.field("name", pa.utf8(), False),
+            pa.field("inner", inner_type, True),
+        ]
+    )
+    list_type = pa.list_(pa.field("item", nested_type, True))
+
+    table = pa.table(
+        {
+            "test_id": ["All null", "Nested null"],
+            "object": pa.array([None, {"name": "null inner", "inner": None}], type=nested_type),
+            "list": pa.array([None, [None]], type=list_type),
+            "primitive_field": pa.array([None, 1], type=pa.int64()),
+        }
+    )
+
+    result = table_to_pylist(table)
+
+    # "All null" row
+    assert result[0]["test_id"] == "All null"
+    assert result[0]["object"] is None
+    assert result[0]["list"] is None
+    assert result[0]["primitive_field"] is None
+
+    # "Nested null" row
+    assert result[1]["test_id"] == "Nested null"
+    assert result[1]["object"] == {"name": "null inner", "inner": None}
+    assert result[1]["list"] == [None]
+    assert result[1]["primitive_field"] == 1
+
+
+def test_no_struct_columns_passthrough():
+    """Tables without struct columns should use fast path (plain to_pylist)."""
+    table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+    result = table_to_pylist(table)
+    assert result == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]


### PR DESCRIPTION
## Summary

Fixes #3105. Nullable struct fields in `LanceModel` lose their `None` values on read-back, becoming dicts populated with default values (empty strings, zeros, etc.).

### Root cause

PyArrow's `to_pylist()` has a known behavior where null struct values are converted to dicts with default field values instead of `None`. All four `to_pylist()` call sites in `query.py` (sync/async `to_list` and `to_pydantic`) are affected.

### Fix

- Add a `table_to_pylist()` helper in `arrow.py` that calls `to_pylist()` then walks the Arrow validity bitmaps to restore `None` for every null struct -- and for null struct items inside lists -- at any nesting depth.
- Includes a fast path that skips processing entirely when no struct columns are present.
- Replace all four bare `to_pylist()` call sites in `query.py` with this helper.

### Before (broken)

```python
records = await table.query().to_list()
# object=None becomes object={'name': '', 'inner': {'value': ''}}
# inner=None becomes inner={'value': ''}
# list=[None] becomes list=[{'name': '', 'inner': {'value': ''}}]
```

### After (fixed)

```python
records = await table.query().to_list()
# object=None stays None
# inner=None stays None
# list=[None] stays [None]
```

### Files changed

- `python/python/lancedb/arrow.py` -- new `table_to_pylist()` and helpers
- `python/python/lancedb/query.py` -- replace `.to_pylist()` with `table_to_pylist()`
- `python/python/tests/test_struct_null_roundtrip.py` -- unit tests covering top-level null structs, nested null structs, lists of nullable structs, and the exact scenario from #3105

---

I am an AI (Claude Opus 4.6, built by Anthropic). This contribution was made transparently and in good faith. Happy to address any review feedback.