### PR TITLE
feat(nodejs): exponential backoff retry for embedding fns

### DIFF
--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -15,6 +15,7 @@ import {
   Utf8,
 } from "../lancedb/arrow";
 import { EmbeddingFunction, LanceSchema } from "../lancedb/embedding";
+import { retryWithExponentialBackoff } from "../lancedb/embedding/embedding_function";
 import { getRegistry, register } from "../lancedb/embedding/registry";
 
 const testOpenAIInteg = process.env.OPENAI_API_KEY == null ? test.skip : test;
@@ -427,4 +428,78 @@ describe("embedding functions", () => {
       expect(stringSchema3).toEqual(stringExpectedSchema);
     },
   );
+});
+
+describe("retryWithExponentialBackoff", () => {
+  it("should return immediately on success", async () => {
+    const result = await retryWithExponentialBackoff(async () => 42, {
+      maxRetries: 3,
+    });
+    expect(result).toBe(42);
+  });
+
+  it("should retry and eventually succeed", async () => {
+    let calls = 0;
+    const result = await retryWithExponentialBackoff(
+      async () => {
+        calls += 1;
+        if (calls < 3) {
+          throw new Error("transient failure");
+        }
+        return "ok";
+      },
+      { maxRetries: 5, initialDelay: 0.001, jitter: false },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  it("should throw after exceeding maxRetries", async () => {
+    await expect(
+      retryWithExponentialBackoff(
+        async () => {
+          throw new Error("always fails");
+        },
+        { maxRetries: 2, initialDelay: 0.001, jitter: false },
+      ),
+    ).rejects.toThrow("Maximum number of retries (2) exceeded.");
+  });
+
+  it("should not retry on AuthenticationError", async () => {
+    class AuthenticationError extends Error {
+      constructor() {
+        super("Invalid API key");
+        Object.defineProperty(this, "constructor", {
+          value: { name: "AuthenticationError" },
+        });
+      }
+    }
+    let calls = 0;
+    await expect(
+      retryWithExponentialBackoff(
+        async () => {
+          calls += 1;
+          throw new AuthenticationError();
+        },
+        { maxRetries: 5, initialDelay: 0.001 },
+      ),
+    ).rejects.toThrow("Invalid API key");
+    expect(calls).toBe(1);
+  });
+
+  it("should not retry on 401/403 status codes", async () => {
+    let calls = 0;
+    const error = new Error("Forbidden") as Error & { status: number };
+    error.status = 403;
+    await expect(
+      retryWithExponentialBackoff(
+        async () => {
+          calls += 1;
+          throw error;
+        },
+        { maxRetries: 5, initialDelay: 0.001 },
+      ),
+    ).rejects.toThrow("Forbidden");
+    expect(calls).toBe(1);
+  });
 });

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -923,7 +923,7 @@ async function applyEmbeddingsFromMetadata(
     const values = sourceColumn.toArray();
 
     const vectors =
-      await functionEntry.function.computeSourceEmbeddings(values);
+      await functionEntry.function.computeSourceEmbeddingsWithRetry(values);
     if (vectors.length !== values.length) {
       throw new Error(
         "Embedding function did not return an embedding for each input element",
@@ -1056,7 +1056,7 @@ async function applyEmbeddings<T>(
       );
     }
     const values = sourceColumn.toArray();
-    const vectors = await embeddings.function.computeSourceEmbeddings(
+    const vectors = await embeddings.function.computeSourceEmbeddingsWithRetry(
       values as T[],
     );
     if (vectors.length !== values.length) {

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
+import { setTimeout } from "node:timers/promises";
 import "reflect-metadata";
 import {
   DataType,
@@ -16,6 +17,86 @@ import {
 } from "../arrow";
 import { sanitizeType } from "../sanitize";
 import { getRegistry } from "./registry";
+
+/**
+ * Options for {@link retryWithExponentialBackoff}.
+ */
+export interface RetryOptions {
+  /** Initial delay in seconds before the first retry. Defaults to 1. */
+  initialDelay?: number;
+  /** Base for the exponential backoff multiplier. Defaults to 2. */
+  exponentialBase?: number;
+  /** Whether to add random jitter to the delay. Defaults to true. */
+  jitter?: boolean;
+  /** Maximum number of retries. Set to 0 to disable retries. Defaults to 7. */
+  maxRetries?: number;
+}
+
+function isNonRetryableError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const err = error as Record<string, unknown>;
+
+  if (err.constructor?.name === "AuthenticationError") {
+    return true;
+  }
+  if (typeof err.status_code === "number") {
+    return err.status_code === 401 || err.status_code === 403;
+  }
+  if (typeof err.status === "number") {
+    return err.status === 401 || err.status === 403;
+  }
+  return false;
+}
+
+/**
+ * Retry an async function with exponential backoff.
+ *
+ * Non-retryable errors (authentication failures, 401/403 status codes) are
+ * rethrown immediately without consuming retries.
+ *
+ * @param fn    - The async function to retry.
+ * @param options - Optional {@link RetryOptions} to configure retry behavior.
+ * @returns The resolved value of `fn`.
+ */
+export async function retryWithExponentialBackoff<R>(
+  fn: () => Promise<R>,
+  options?: RetryOptions,
+): Promise<R> {
+  const {
+    initialDelay = 1,
+    exponentialBase = 2,
+    jitter = true,
+    maxRetries = 7,
+  } = options ?? {};
+
+  let numRetries = 0;
+  let delay = initialDelay;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (e) {
+      // Don't retry on authentication errors (e.g., OpenAI 401)
+      // These are permanent failures that won't be fixed by retrying
+      if (isNonRetryableError(e)) throw e;
+
+      numRetries += 1;
+      if (numRetries > maxRetries) {
+        throw new Error(`Maximum number of retries (${maxRetries}) exceeded.`, {
+          cause: e,
+        });
+      }
+      delay *= exponentialBase * (1 + (jitter ? Math.random() : 0));
+      console.warn(
+        `Embedding retry ${numRetries}/${maxRetries} after error: ${e}. ` +
+          `Retrying in ${delay.toFixed(1)}s...`,
+      );
+      await setTimeout(delay * 1000);
+    }
+  }
+}
 
 /**
  * Options for a given embedding function
@@ -61,6 +142,12 @@ export abstract class EmbeddingFunction<
    */
   // biome-ignore lint/style/useNamingConvention: we want to keep the name as it is
   readonly TOptions!: M;
+
+  /**
+   * Maximum number of retries for embedding API calls.
+   * Set to 0 to disable retries. Defaults to 7.
+   */
+  maxRetries = 7;
 
   #config: Partial<M>;
 
@@ -237,6 +324,30 @@ export abstract class EmbeddingFunction<
   async computeQueryEmbeddings(data: T): Promise<Awaited<IntoVector>> {
     return this.computeSourceEmbeddings([data]).then(
       (embeddings) => embeddings[0],
+    );
+  }
+
+  /**
+   * Compute the embeddings for a given query with retries
+   */
+  async computeQueryEmbeddingsWithRetry(data: T): Promise<Awaited<IntoVector>> {
+    return retryWithExponentialBackoff(
+      () => this.computeQueryEmbeddings(data),
+      {
+        maxRetries: this.maxRetries,
+      },
+    );
+  }
+
+  /**
+   * Compute the embeddings for the source column in the database with retries
+   */
+  async computeSourceEmbeddingsWithRetry(
+    data: T[],
+  ): Promise<number[][] | Float32Array[] | Float64Array[]> {
+    return retryWithExponentialBackoff(
+      () => this.computeSourceEmbeddings(data),
+      { maxRetries: this.maxRetries },
     );
   }
 }

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -786,7 +786,9 @@ export class LocalTable extends Table {
             new Error("No embedding functions are defined in the table"),
           );
         }
-        return await embeddingFunc.function.computeQueryEmbeddings(query);
+        return await embeddingFunc.function.computeQueryEmbeddingsWithRetry(
+          query,
+        );
       },
     );
 


### PR DESCRIPTION
[Already implemented](https://github.com/lancedb/lancedb/pull/614) in the Python SDK. Resolves https://github.com/lancedb/lancedb/issues/2343