### PR TITLE
ci: modify check_lance_release.py to prefer stable releases over betas

### DIFF
--- a/ci/check_lance_release.py
+++ b/ci/check_lance_release.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import os
 import re
@@ -26,6 +27,7 @@ SEMVER_RE = re.compile(
 )
 
 
+@functools.total_ordering
 @dataclass(frozen=True)
 class SemVer:
     major: int
@@ -156,7 +158,9 @@ def read_current_version(repo_root: Path) -> str:
 
 
 def determine_latest_tag(tags: Iterable[TagInfo]) -> TagInfo:
-    return max(tags, key=lambda tag: tag.semver)
+    # Stable releases (no prerelease) are always preferred over pre-releases.
+    # Within each group, standard semver ordering applies.
+    return max(tags, key=lambda tag: (not tag.semver.prerelease, tag.semver))
 
 
 def write_outputs(args: argparse.Namespace, payload: dict) -> None:


### PR DESCRIPTION
When Lance 3.0.0 released the check_lance_release.py script did not make a PR for it because it was a pre-release.  This change may not be perfect but it always ranks stable releases above non-stable releases.