### PR TITLE
fix(ci): upgrade LocalStack to 4.0 for S3 integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   localstack:
-    image: localstack/localstack:3.3
+    image: localstack/localstack:4.0
     ports:
       - 4566:4566
     environment:


### PR DESCRIPTION
## Summary
- Upgrade LocalStack from 3.3 to 4.0 in `docker-compose.yml` to fix S3 integration test failures in CI
- Version 3.3 has compatibility issues with newer Python 3.13 and updated boto3 dependencies
- Matches the LocalStack version used successfully in the lance repository

## Test plan
- [ ] Verify `docker compose up --detach --wait` completes successfully in CI
- [ ] All tests in `test_s3.py` pass (5 tests)
- [ ] All `@pytest.mark.s3_test` tests in `test_namespace_integration.py` pass (7 tests)
- [ ] No regressions in non-integration test jobs (Mac, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)