### PR TITLE
fix: preserve valid OpenAI embeddings in mixed batches

### DIFF
--- a/python/python/lancedb/embeddings/openai.py
+++ b/python/python/lancedb/embeddings/openai.py
@@ -97,29 +97,85 @@ class OpenAIEmbeddings(TextEmbeddingFunction):
                 valid_texts.append(text)
                 valid_indices.append(idx)
 
+        if not valid_texts:
+            return [None] * len(texts)
+
         # TODO retry, rate limit, token limit
         try:
-            kwargs = {
-                "input": valid_texts,
-                "model": self.name,
-            }
-            if self.name != "text-embedding-ada-002":
-                kwargs["dimensions"] = self.dim
-
-            rs = self._openai_client.embeddings.create(**kwargs)
-            valid_embeddings = {
-                idx: v.embedding for v, idx in zip(rs.data, valid_indices)
-            }
+            valid_embeddings = self._generate_valid_embeddings(
+                valid_texts,
+                valid_indices,
+                openai,
+            )
         except openai.AuthenticationError:
             logging.error("Authentication failed: Invalid API key provided")
             raise
-        except openai.BadRequestError:
-            logging.exception("Bad request: %s", texts)
-            return [None] * len(texts)
         except Exception:
             logging.exception("OpenAI embeddings error")
             raise
         return [valid_embeddings.get(idx, None) for idx in range(len(texts))]
+
+    def _generate_valid_embeddings(
+        self, valid_texts: List[str], valid_indices: List[int], openai
+    ) -> dict[int, List[float]]:
+        try:
+            return {
+                idx: embedding
+                for idx, embedding in zip(
+                    valid_indices,
+                    self._request_embeddings(valid_texts),
+                )
+            }
+        except openai.BadRequestError:
+            logging.warning(
+                "OpenAI rejected a batched embedding request; retrying row-by-row "
+                "to isolate invalid inputs."
+            )
+            return self._generate_embeddings_row_by_row(
+                valid_texts,
+                valid_indices,
+                openai,
+            )
+
+    def _generate_embeddings_row_by_row(
+        self, valid_texts: List[str], valid_indices: List[int], openai
+    ) -> dict[int, List[float]]:
+        valid_embeddings = {}
+
+        for idx, text in zip(valid_indices, valid_texts):
+            try:
+                embeddings = self._request_embeddings([text])
+            except openai.BadRequestError:
+                logging.warning(
+                    "OpenAI rejected embedding input at row %s; storing null so "
+                    "ingestion can continue.",
+                    idx,
+                )
+                continue
+
+            if embeddings:
+                valid_embeddings[idx] = embeddings[0]
+            else:
+                logging.warning(
+                    "OpenAI returned no embedding for row %s; storing null so "
+                    "ingestion can continue.",
+                    idx,
+                )
+
+        return valid_embeddings
+
+    def _request_embeddings(self, texts: List[str]) -> List[List[float]]:
+        rs = self._openai_client.embeddings.create(**self._request_kwargs(texts))
+        return [item.embedding for item in rs.data]
+
+    def _request_kwargs(self, texts: List[str]) -> dict:
+        kwargs = {
+            "input": texts,
+            "model": self.name,
+        }
+        if self.name != "text-embedding-ada-002":
+            kwargs["dimensions"] = self.dim
+        return kwargs
 
     @cached_property
     def _openai_client(self):

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 import os
+from types import SimpleNamespace
 from typing import List, Optional, Union
 from unittest.mock import MagicMock, patch
 
@@ -485,6 +486,118 @@ def test_retry(mock_sleep):
     result = test_function()
     assert mock_sleep.call_count == 9
     assert result == "result"
+
+
+def _mock_openai_embeddings(monkeypatch, responses):
+    import lancedb.embeddings.openai as openai_module
+
+    calls = []
+
+    class MockAuthenticationError(Exception):
+        pass
+
+    class MockBadRequestError(Exception):
+        pass
+
+    class MockEmbeddingsClient:
+        def create(self, **kwargs):
+            input_key = tuple(kwargs["input"])
+            calls.append(input_key)
+            response = responses[input_key]
+            if (
+                isinstance(response, tuple)
+                and len(response) == 2
+                and response[0] == "bad_request"
+            ):
+                raise MockBadRequestError(response[1])
+            if isinstance(response, Exception):
+                raise response
+            return SimpleNamespace(
+                data=[
+                    SimpleNamespace(embedding=embedding) for embedding in response
+                ]
+            )
+
+    mock_client = SimpleNamespace(embeddings=MockEmbeddingsClient())
+    mock_openai = SimpleNamespace(
+        AuthenticationError=MockAuthenticationError,
+        BadRequestError=MockBadRequestError,
+        OpenAI=lambda **kwargs: mock_client,
+        AzureOpenAI=lambda **kwargs: mock_client,
+    )
+    monkeypatch.setattr(
+        openai_module,
+        "attempt_import_or_raise",
+        lambda *_args, **_kwargs: mock_openai,
+    )
+    return calls, MockBadRequestError
+
+
+def test_openai_bad_request_falls_back_to_row_level_requests(monkeypatch, caplog):
+    calls, _ = _mock_openai_embeddings(
+        monkeypatch,
+        {
+            ("valid text", "bad text"): ("bad_request", "batch contains invalid row"),
+            ("valid text",): [[0.1, 0.2]],
+            ("bad text",): ("bad_request", "invalid row"),
+        },
+    )
+
+    model = get_registry().get("openai").create(
+        name="text-embedding-3-small",
+        dim=2,
+        max_retries=0,
+    )
+
+    caplog.set_level("WARNING")
+    embeddings = model.generate_embeddings(["valid text", "bad text", ""])
+
+    assert calls == [
+        ("valid text", "bad text"),
+        ("valid text",),
+        ("bad text",),
+    ]
+    assert embeddings == [[0.1, 0.2], None, None]
+    assert "row-by-row" in caplog.text
+    assert "row 1" in caplog.text
+
+
+def test_openai_bad_request_can_store_null_embeddings(monkeypatch, tmp_path):
+    vector = [0.1, 0.2]
+    _mock_openai_embeddings(
+        monkeypatch,
+        {
+            ("valid text", "bad text"): ("bad_request", "batch contains invalid row"),
+            ("valid text",): [vector],
+            ("bad text",): ("bad_request", "invalid row"),
+        },
+    )
+
+    model = get_registry().get("openai").create(
+        name="text-embedding-3-small",
+        dim=2,
+        max_retries=0,
+    )
+
+    class TextModel(LanceModel):
+        text: str = model.SourceField()
+        vector: Vector(model.ndims()) = model.VectorField()
+
+    db = lancedb.connect(tmp_path)
+    table = db.create_table("words", schema=TextModel, mode="overwrite")
+    table.alter_columns(dict(path="vector", nullable=True))
+
+    table.add(
+        [{"text": "valid text"}, {"text": "bad text"}],
+        on_bad_vectors="null",
+    )
+
+    actual = table.to_arrow()
+    vectors = actual["vector"].to_pylist()
+
+    assert actual["text"].to_pylist() == ["valid text", "bad text"]
+    assert vectors[0] == pytest.approx(vector)
+    assert vectors[1] is None
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- retry OpenAI embedding batches row-by-row when a batch-level bad request occurs
- keep successful rows, log the failing row index, and leave invalid rows as null embeddings
- add regression tests for row-level fallback and nullable ingestion behavior

## Testing
- remote x86_64 validation on `141.164.59.25`
- `PYTHONPATH=/home/lixdj/lancedb-codex/python/python python -m ruff check python/python/lancedb/embeddings/openai.py python/python/tests/test_embeddings.py`
- `PYTHONPATH=/home/lixdj/lancedb-codex/python/python python -m pytest -q python/python/tests/test_embeddings.py::test_openai_bad_request_can_store_null_embeddings python/python/tests/test_embeddings.py::test_openai_bad_request_falls_back_to_row_level_requests python/python/tests/test_embeddings.py::test_openai_no_retry_on_401`

Closes #1677
