### PR TITLE
fix(python): fix LinearCombinationReranker score computation

### DIFF
--- a/python/python/lancedb/rerankers/linear_combination.py
+++ b/python/python/lancedb/rerankers/linear_combination.py
@@ -12,18 +12,19 @@ from .base import Reranker
 class LinearCombinationReranker(Reranker):
     """
     Reranks the results using a linear combination of the scores from the
-    vector and FTS search. For missing scores, fill with `fill` value.
+    vector and FTS search. Vector distances are inverted to relevance before
+    combining. For missing scores, apply the `fill` penalty.
     Parameters
     ----------
     weight : float, default 0.7
         The weight to give to the vector score. Must be between 0 and 1.
     fill : float, default 1.0
-        The score to give to results that are only in one of the two result sets.
-        This is treated as penalty, so a higher value means a lower score.
-        TODO: We should just hardcode this--
-        its pretty confusing as we invert scores to calculate final score
+        The penalty to apply to results that are only in one of the two result
+        sets. `fill` is interpreted in distance space, so a missing `_distance`
+        or `_score` contributes a relevance score of `1 - fill`. A higher value
+        means a lower final relevance score.
     return_score : str, default "relevance"
-        opntions are "relevance" or "all"
+        options are "relevance" or "all"
         The type of score to return. If "relevance", will return only the relevance
         score. If "all", will return all scores from the vector and FTS search along
         with the relevance score.
@@ -103,7 +104,7 @@ class LinearCombinationReranker(Reranker):
         combined_list = []
         for row_id, result in results.items():
             vector_score = self._invert_score(result.get("_distance", fill))
-            fts_score = result.get("_score", fill)
+            fts_score = result.get("_score", 1 - fill)
             result["_relevance_score"] = self._combine_score(vector_score, fts_score)
             combined_list.append(result)
 
@@ -123,8 +124,8 @@ class LinearCombinationReranker(Reranker):
         return tbl
 
     def _combine_score(self, vector_score, fts_score):
-        # these scores represent distance
-        return 1 - (self.weight * vector_score + (1 - self.weight) * fts_score)
+        # Both vector_score and fts_score are relevance scores
+        return self.weight * vector_score + (1 - self.weight) * fts_score
 
     def _invert_score(self, dist: float):
         # Invert the score between relevance and distance

--- a/python/python/tests/test_rerankers.py
+++ b/python/python/tests/test_rerankers.py
@@ -316,6 +316,41 @@ def test_linear_combination(tmp_path, use_tantivy):
     _run_test_hybrid_reranker(reranker, tmp_path, use_tantivy)
 
 
+def test_linear_combination_merge_results_regression():
+    reranker = LinearCombinationReranker(weight=0.6, fill=0.25, return_score="all")
+
+    vector_results = pa.Table.from_pydict(
+        {
+            "_rowid": [0, 1],
+            "_distance": [0.2, 0.4],
+            "_text": ["a", "b"],
+        }
+    )
+    fts_results = pa.Table.from_pydict(
+        {
+            "_rowid": [1, 2],
+            "_score": [0.1, 0.9],
+            "_text": ["b", "c"],
+        }
+    )
+
+    combined_results = reranker.merge_results(
+        vector_results, fts_results, reranker.fill
+    )
+    assert combined_results["_rowid"].to_pylist() == [2, 0, 1]
+
+    relevance_scores = {
+        row["_rowid"]: row["_relevance_score"] for row in combined_results.to_pylist()
+    }
+    assert relevance_scores == pytest.approx(
+        {
+            0: 0.6 * 0.8 + 0.4 * 0.75,
+            1: 0.6 * 0.6 + 0.4 * 0.1,
+            2: 0.6 * 0.75 + 0.4 * 0.9,
+        }
+    )
+
+
 @pytest.mark.parametrize("use_tantivy", [True, False])
 def test_rrf_reranker(tmp_path, use_tantivy):
     reranker = RRFReranker()


### PR DESCRIPTION
Close: https://github.com/lancedb/lancedb/issues/3154

Fix two bugs in `LinearCombinationReranker`:
1. Remove extra inversion in `_combine_score`: Both inputs are already in relevance semantics
2. Fix missing `_score` fill value: Changed the fallback for missing `_score` from `fill` to `1 - fill`, making the penalty symmetric with the `_distance` side.

Also updated the docstring to clarify the semantics and added unit tests.
