### PR TITLE
fix(ci): bump AWS SDK MSRV pins to March 2025 release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,14 +207,14 @@ jobs:
       - name: Downgrade  dependencies
         # These packages have newer requirements for MSRV
         run: |
-          cargo update -p aws-sdk-bedrockruntime --precise 1.64.0
-          cargo update -p aws-sdk-dynamodb --precise 1.55.0
-          cargo update -p aws-config --precise 1.5.10
-          cargo update -p aws-sdk-kms --precise 1.51.0
-          cargo update -p aws-sdk-s3 --precise 1.65.0
-          cargo update -p aws-sdk-sso --precise 1.50.0
-          cargo update -p aws-sdk-ssooidc --precise 1.51.0
-          cargo update -p aws-sdk-sts --precise 1.51.0
+          cargo update -p aws-sdk-bedrockruntime --precise 1.77.0
+          cargo update -p aws-sdk-dynamodb --precise 1.68.0
+          cargo update -p aws-config --precise 1.6.0
+          cargo update -p aws-sdk-kms --precise 1.63.0
+          cargo update -p aws-sdk-s3 --precise 1.79.0
+          cargo update -p aws-sdk-sso --precise 1.62.0
+          cargo update -p aws-sdk-ssooidc --precise 1.63.0
+          cargo update -p aws-sdk-sts --precise 1.63.0
           cargo update -p home --precise 0.5.9
       - name: cargo +${{ matrix.msrv }} check
         env:


### PR DESCRIPTION
Lance v4.1.0-beta requires the default-https-client feature on
aws-sdk-dynamodb and aws-sdk-s3, which was introduced in the March
2025 AWS SDK release. Update all AWS SDK pins to versions from the
same AWS SDK release to maintain internal dependency compatibility.
