### PR TITLE
fix(python): preserve vector type in table.add with mode=overwrite

### DIFF
--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -3859,7 +3859,7 @@ class AsyncTable:
         # new code path is ready.
         if on_bad_vectors != "error" or (
             schema.metadata is not None and b"embedding_functions" in schema.metadata
-        ):
+        ) or mode == "overwrite":
             data = _sanitize_data(
                 data,
                 schema,


### PR DESCRIPTION
## Summary

When calling `table.add()` with `mode='overwrite'`, the input data was passed directly to the Rust layer without being cast to the table's schema. In overwrite mode, the Rust layer uses the input schema as the new table schema, which caused vector columns of type `fixed_size_list` to be replaced with regular `list`.

## Fix

This fix ensures that `_sanitize_data` is called in overwrite mode, which casts the input data to match the table's existing schema (including preserving `fixed_size_list` types).

## Root Cause

In `AsyncTable.add()`, the `_sanitize_data()` function (which handles schema casting) was only called when:
1. `on_bad_vectors != 'error'` (data cleaning needed), OR
2. The table schema contains embedding functions

For overwrite mode with default `on_bad_vectors='error'` and no embedding functions, `_sanitize_data` was skipped entirely. This allowed the input data's schema (with `list` vector type) to be used directly by the Rust layer, which then adopted it as the new table schema.

## Changes

**File:** `python/python/lancedb/table.py`

Added `mode == 'overwrite'` to the condition that triggers `_sanitize_data`:

```python
if on_bad_vectors != 'error' or (
    schema.metadata is not None and b'embedding_functions' in schema.metadata
) or mode == 'overwrite':  # <-- Added
```

This ensures the input data is always cast to the table's schema in overwrite mode, preserving `fixed_size_list` vector types.

## Testing

- The fix was verified by analyzing the `_align_field_types` and `_cast_to_target_schema` code paths, which correctly handle `fixed_size_list` type preservation during schema casting.
- The existing test `test_add_overwrite` in `rust/lancedb/src/table/add_data.rs` validates the basic overwrite behavior.

Fixes #3183
