### PR TITLE
fix(python): skip test_url_retrieve_downloads_image when PIL not installed

### DIFF
--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -559,7 +559,8 @@ def test_url_retrieve_downloads_image():
     matching the real usage pattern in embedding functions.
     """
     import io
-    from PIL import Image
+
+    Image = pytest.importorskip("PIL.Image")
     from lancedb.embeddings.utils import url_retrieve
 
     image_url = "http://farm1.staticflickr.com/53/167798175_7c7845bbbd_z.jpg"


### PR DESCRIPTION
The test added in #3190 unconditionally imports `PIL`, which is an optional dependency. This causes CI failures in environments where Pillow isn't installed (`ModuleNotFoundError: No module named 'PIL'`).

Use `pytest.importorskip` to skip gracefully when Pillow is unavailable.

Fixes CI failure on main.