### PR TITLE
feat(rust): infer FixedSizeList schema from variable-length list input

### DIFF
--- a/rust/lancedb/src/data/inspect.rs
+++ b/rust/lancedb/src/data/inspect.rs
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use arrow::compute::kernels::{aggregate::bool_and, length::length};
 use arrow_array::{
-    Array, GenericListArray, OffsetSizeTrait, PrimitiveArray, RecordBatchReader,
+    Array, ArrayRef, GenericListArray, OffsetSizeTrait, PrimitiveArray, RecordBatch,
+    RecordBatchReader,
     cast::AsArray,
     types::{ArrowPrimitiveType, Int32Type, Int64Type},
 };
+use arrow_cast::cast;
 use arrow_ord::cmp::eq;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Field, Schema};
 use num_traits::{ToPrimitive, Zero};
 
 use crate::error::{Error, Result};
@@ -32,6 +34,114 @@ where
         Ok(None)
     } else {
         Ok(Some(dim))
+    }
+}
+
+/// Given a batch, return a schema where variable-length list columns whose names contain
+/// "vector" or "embedding" (case-insensitive) are converted to FixedSizeList, if a
+/// uniform dimension can be determined from the batch.
+///
+/// - Float list columns → `FixedSizeList(Float32, dim)`
+/// - Integer list columns → `FixedSizeList(UInt8, dim)` if all values fit in [0, 255],
+///   otherwise `FixedSizeList(Float32, dim)`
+///
+/// Columns that don't match the name heuristic, have non-uniform lengths, or have
+/// non-numeric value types are left unchanged.
+pub fn infer_fsl_schema(batch: &RecordBatch) -> Arc<Schema> {
+    let schema = batch.schema();
+    let mut new_fields: Vec<Arc<Field>> = schema.fields().iter().cloned().collect();
+    let mut changed = false;
+
+    for (i, field) in schema.fields().iter().enumerate() {
+        let name_lower = field.name().to_lowercase();
+        if !name_lower.contains("vector") && !name_lower.contains("embedding") {
+            continue;
+        }
+
+        let col = batch.column(i);
+
+        let (value_dtype, dim) = match field.data_type() {
+            DataType::List(value_field)
+                if value_field.data_type().is_floating()
+                    || value_field.data_type().is_integer() =>
+            {
+                let dim = infer_dimension::<Int32Type>(col.as_list::<i32>())
+                    .ok()
+                    .flatten()
+                    .map(|d| d as i64);
+                (value_field.data_type().clone(), dim)
+            }
+            DataType::LargeList(value_field)
+                if value_field.data_type().is_floating()
+                    || value_field.data_type().is_integer() =>
+            {
+                let dim = infer_dimension::<Int64Type>(col.as_list::<i64>())
+                    .ok()
+                    .flatten();
+                (value_field.data_type().clone(), dim)
+            }
+            _ => continue,
+        };
+
+        let Some(dim) = dim else { continue };
+        if dim == 0 {
+            continue;
+        }
+
+        let target_element_type = if value_dtype.is_floating() {
+            DataType::Float32
+        } else {
+            let values_arr = match field.data_type() {
+                DataType::List(_) => col.as_list::<i32>().values().clone(),
+                DataType::LargeList(_) => col.as_list::<i64>().values().clone(),
+                _ => unreachable!(),
+            };
+            infer_integer_element_type(&values_arr)
+        };
+
+        let new_value_field = Arc::new(Field::new("item", target_element_type, true));
+        let new_type = DataType::FixedSizeList(new_value_field, dim as i32);
+        new_fields[i] = Arc::new(field.as_ref().clone().with_data_type(new_type));
+        changed = true;
+    }
+
+    if changed {
+        Arc::new(Schema::new_with_metadata(
+            new_fields,
+            schema.metadata().clone(),
+        ))
+    } else {
+        schema
+    }
+}
+
+/// Determine whether integer list values should be stored as UInt8 or Float32.
+///
+/// Returns UInt8 if all non-null values are in [0, 255]; otherwise Float32.
+fn infer_integer_element_type(values: &ArrayRef) -> DataType {
+    let Ok(int64_arr) = cast(values.as_ref(), &DataType::Int64) else {
+        return DataType::Float32;
+    };
+    let int64_arr = int64_arr.as_primitive::<Int64Type>();
+
+    let mut any_valid = false;
+    let mut min_val = i64::MAX;
+    let mut max_val = i64::MIN;
+
+    for v in int64_arr.iter().flatten() {
+        any_valid = true;
+        if v < min_val {
+            min_val = v;
+        }
+        if v > max_val {
+            max_val = v;
+        }
+    }
+
+    if !any_valid || (min_val >= 0 && max_val <= 255) {
+        DataType::UInt8
+    } else {
+        DataType::Float32
     }
 }
 
@@ -102,11 +212,151 @@ mod tests {
     use super::*;
 
     use arrow_array::{
-        FixedSizeListArray, Float32Array, ListArray, RecordBatch, RecordBatchIterator, StringArray,
-        types::{Float32Type, Float64Type},
+        FixedSizeListArray, Float32Array, Int32Array, ListArray, RecordBatch, RecordBatchIterator,
+        StringArray,
+        types::{Float32Type, Float64Type, Int32Type as Int32ArrayType},
     };
     use arrow_schema::{DataType, Field, Schema};
     use std::{sync::Arc, vec};
+
+    #[test]
+    fn test_infer_fsl_schema_float_list() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "embedding",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..3).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0), Some(4.0)])),
+                )),
+            ],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+
+        let expected = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "embedding",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+                true,
+            ),
+        ]));
+        assert_eq!(inferred, expected);
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_int_list_uint8() {
+        // List<Int32> named "vector" with values in [0, 255] → FSL<UInt8, dim>
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ListArray::from_iter_primitive::<
+                Int32ArrayType,
+                _,
+                _,
+            >(
+                (0..3).map(|_| Some(vec![Some(0i32), Some(100), Some(255)])),
+            ))],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+
+        let expected = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::UInt8, true)), 3),
+            true,
+        )]));
+        assert_eq!(inferred, expected);
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_int_list_float32() {
+        // List<Int32> named "vector" with values outside [0, 255] → FSL<Float32, dim>
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ListArray::from_iter_primitive::<
+                Int32ArrayType,
+                _,
+                _,
+            >(
+                (0..3).map(|_| Some(vec![Some(-1i32), Some(100), Some(200)])),
+            ))],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+
+        let expected = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
+            true,
+        )]));
+        assert_eq!(inferred, expected);
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_non_uniform() {
+        // List with varying lengths named "embedding" → stays as List
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+                    Some(vec![Some(1.0f32), Some(2.0)]),
+                    Some(vec![Some(3.0f32), Some(4.0), Some(5.0)]),
+                ]),
+            )],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        assert_eq!(inferred, schema);
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_non_vector_name() {
+        // List<Float32> named "data" (no vector/embedding) → stays as List
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "data",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..3).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0)])),
+                ),
+            )],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        assert_eq!(inferred, schema);
+    }
 
     #[test]
     fn test_infer_vector_columns() {

--- a/rust/lancedb/src/data/inspect.rs
+++ b/rust/lancedb/src/data/inspect.rs
@@ -336,7 +336,10 @@ mod tests {
                 Int32ArrayType,
                 _,
                 _,
-            >(vec![Some(vec![Some(0i32), Some(300)])]))],
+            >(vec![Some(vec![
+                Some(0i32),
+                Some(300),
+            ])]))],
         )
         .unwrap();
 

--- a/rust/lancedb/src/data/inspect.rs
+++ b/rust/lancedb/src/data/inspect.rs
@@ -37,13 +37,21 @@ where
     }
 }
 
-/// Given a batch, return a schema where variable-length list columns whose names contain
-/// "vector" or "embedding" (case-insensitive) are converted to FixedSizeList, if a
-/// uniform dimension can be determined from the batch.
+/// Given a batch, return a schema where variable-length list columns whose names
+/// contain "vector" or "embedding" (case-insensitive substring) are converted to
+/// FixedSizeList, if a uniform dimension can be determined from the batch.
 ///
-/// - Float list columns → `FixedSizeList(Float32, dim)`
-/// - Integer list columns → `FixedSizeList(UInt8, dim)` if all values fit in [0, 255],
-///   otherwise `FixedSizeList(Float32, dim)`
+/// - Float list columns → `FixedSizeList(Float32, dim)`. Float32 is the canonical
+///   element type for vector indices in Lance.
+/// - Integer list columns → `FixedSizeList(UInt8, dim)` if all values fit in [0, 255]
+///   (i.e. plausible binary vectors), otherwise `FixedSizeList(Float32, dim)`.
+///   The Float32 fallback exists because users commonly write `[1, 2, 3]` in Python
+///   meaning floats; preserving Int32/Int64 here would surprise them later when a
+///   vector index requires a float element type.
+///
+/// Note: this is the substring match used by Python's `_name_suggests_vector_column`
+/// on the no-target-schema (inference) path. The on-bad-vectors sanitization path
+/// in Python uses a stricter exact-match rule; that path is not represented here.
 ///
 /// Columns that don't match the name heuristic, have non-uniform lengths, or have
 /// non-numeric value types are left unchanged.
@@ -314,6 +322,37 @@ mod tests {
     }
 
     #[test]
+    fn test_infer_fsl_schema_int_list_value_over_255_is_float32() {
+        // Mirrors Python's `test_create_table_infers_large_int_vectors`: an
+        // integer value exceeding 255 forces the inferred element type to Float32.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ListArray::from_iter_primitive::<
+                Int32ArrayType,
+                _,
+                _,
+            >(vec![Some(vec![Some(0i32), Some(300)])]))],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        let f = inferred.field_with_name("vector").unwrap();
+        assert!(
+            matches!(
+                f.data_type(),
+                DataType::FixedSizeList(inner, 2) if inner.data_type() == &DataType::Float32
+            ),
+            "expected FixedSizeList(Float32, 2), got {:?}",
+            f.data_type()
+        );
+    }
+
+    #[test]
     fn test_infer_fsl_schema_non_uniform() {
         // List with varying lengths named "embedding" → stays as List
         let schema = Arc::new(Schema::new(vec![Field::new(
@@ -356,6 +395,254 @@ mod tests {
 
         let inferred = infer_fsl_schema(&batch);
         assert_eq!(inferred, schema);
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_large_list() {
+        // LargeList<Float32> named "embedding" should also infer FSL.
+        use arrow_array::LargeListArray;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::LargeList(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(LargeListArray::from_iter_primitive::<
+                Float32Type,
+                _,
+                _,
+            >(
+                (0..3).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0)])),
+            ))],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        let embedding_field = inferred.field_with_name("embedding").unwrap();
+        assert!(
+            matches!(embedding_field.data_type(), DataType::FixedSizeList(_, 3)),
+            "expected FixedSizeList(_, 3), got {:?}",
+            embedding_field.data_type()
+        );
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_dim_zero_stays_list() {
+        // List<Float32> named "embedding" where all rows are empty lists → stays List.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..3).map(|_| Some(Vec::<Option<f32>>::new())),
+                ),
+            )],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        assert_eq!(inferred, schema);
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_with_null_rows() {
+        // Some null rows mixed with uniform-length valid rows: the inferred
+        // dimension comes from the non-null rows (Kleene `bool_and` over the
+        // length-equality mask treats null lengths as "unknown"), so the column
+        // is converted to FixedSizeList(Float32, 3).
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+                    Some(vec![Some(1.0f32), Some(2.0), Some(3.0)]),
+                    None,
+                    Some(vec![Some(4.0f32), Some(5.0), Some(6.0)]),
+                ]),
+            )],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        let f = inferred.field_with_name("embedding").unwrap();
+        let DataType::FixedSizeList(inner, dim) = f.data_type() else {
+            panic!("expected FixedSizeList, got {:?}", f.data_type());
+        };
+        assert_eq!(*dim, 3);
+        assert_eq!(inner.data_type(), &DataType::Float32);
+
+        // The null row must remain null after coercion to the inferred schema —
+        // pin this so a future change that silently drops the null row fails here.
+        let coerced = crate::data::sanitize::coerce_schema_batch(batch.clone(), inferred).unwrap();
+        let fsl = coerced.column(0).as_fixed_size_list();
+        assert!(fsl.is_valid(0));
+        assert!(fsl.is_null(1));
+        assert!(fsl.is_valid(2));
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_all_null_list() {
+        // All-null list column → stays List.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+                    None::<Vec<Option<f32>>>,
+                    None,
+                    None,
+                ]),
+            )],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        let f = inferred.field_with_name("embedding").unwrap();
+        // Null rows have length 0 so this should NOT be promoted to FSL.
+        assert!(
+            matches!(f.data_type(), DataType::List(_)),
+            "expected List, got {:?}",
+            f.data_type()
+        );
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_int_list_all_null_values_uint8() {
+        // Integer list column where every value is null exercises the
+        // !any_valid path of infer_integer_element_type, which returns UInt8.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ListArray::from_iter_primitive::<
+                Int32ArrayType,
+                _,
+                _,
+            >(
+                (0..3).map(|_| Some(vec![None::<i32>, None, None])),
+            ))],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        let f = inferred.field_with_name("vector").unwrap();
+        match f.data_type() {
+            DataType::FixedSizeList(inner, 3) => {
+                assert_eq!(inner.data_type(), &DataType::UInt8);
+            }
+            other => panic!("expected FSL<UInt8, 3>, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_case_insensitive_substring_name() {
+        // Case-insensitive substring matches: "Embedding", "VECTOR", and names
+        // that contain "vector"/"embedding" as a substring (e.g. "VectorId",
+        // "my_embedding_v2") all trigger inference. Matches Python's
+        // `_name_suggests_vector_column`.
+        for name in [
+            "Embedding",
+            "VECTOR",
+            "VectorId",
+            "my_embedding_v2",
+            "user_vectors",
+        ] {
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                name,
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            )]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(
+                    ListArray::from_iter_primitive::<Float32Type, _, _>(
+                        (0..2).map(|_| Some(vec![Some(1.0f32), Some(2.0)])),
+                    ),
+                )],
+            )
+            .unwrap();
+            let inferred = infer_fsl_schema(&batch);
+            let f = inferred.field_with_name(name).unwrap();
+            assert!(
+                matches!(f.data_type(), DataType::FixedSizeList(_, 2)),
+                "column {name}: expected FSL, got {:?}",
+                f.data_type()
+            );
+        }
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_non_numeric_value_type() {
+        // List<Utf8> named "embedding" → stays List (non-numeric values skipped).
+        use arrow_array::builder::{ListBuilder, StringBuilder};
+        let mut builder = ListBuilder::new(StringBuilder::new());
+        for _ in 0..2 {
+            builder.values().append_value("a");
+            builder.values().append_value("b");
+            builder.append(true);
+        }
+        let list = builder.finish();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            list.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(list)]).unwrap();
+        let inferred = infer_fsl_schema(&batch);
+        assert_eq!(inferred, schema);
+    }
+
+    #[test]
+    fn test_infer_fsl_schema_preserves_metadata() {
+        // Schema-level and field-level metadata should survive inference.
+        let mut schema_md = std::collections::HashMap::new();
+        schema_md.insert("schema_key".to_string(), "schema_val".to_string());
+
+        let mut field_md = std::collections::HashMap::new();
+        field_md.insert("field_key".to_string(), "field_val".to_string());
+
+        let embedding_field = Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )
+        .with_metadata(field_md.clone());
+
+        let schema = Arc::new(Schema::new_with_metadata(
+            vec![embedding_field],
+            schema_md.clone(),
+        ));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(1.0f32), Some(2.0)])),
+                ),
+            )],
+        )
+        .unwrap();
+
+        let inferred = infer_fsl_schema(&batch);
+        assert_eq!(inferred.metadata(), &schema_md);
+        let f = inferred.field_with_name("embedding").unwrap();
+        assert_eq!(f.metadata(), &field_md);
+        assert!(matches!(f.data_type(), DataType::FixedSizeList(_, 2)));
     }
 
     #[test]

--- a/rust/lancedb/src/data/sanitize.rs
+++ b/rust/lancedb/src/data/sanitize.rs
@@ -11,13 +11,75 @@ use arrow_array::{
 };
 use arrow_cast::{can_cast_types, cast};
 use arrow_schema::{ArrowError, DataType, Field, Schema};
+use futures::StreamExt;
 use half::f16;
 use lance_arrow::{DataTypeExt, FixedSizeListArrayExt};
 use log::warn;
 use num_traits::cast::AsPrimitive;
 
-use super::inspect::infer_dimension;
+use super::inspect::{infer_dimension, infer_fsl_schema};
+use crate::arrow::{SendableRecordBatchStream, SimpleRecordBatchStream};
+use crate::data::scannable::{PeekedScannable, Scannable};
 use crate::error::Result;
+
+/// A [`Scannable`] wrapper that applies [`coerce_schema_batch`] to every batch,
+/// converting columns to the target schema (e.g. List → FixedSizeList).
+pub(crate) struct CoerceScannable {
+    pub(crate) inner: Box<dyn Scannable>,
+    pub(crate) schema: Arc<Schema>,
+}
+
+impl Scannable for CoerceScannable {
+    fn schema(&self) -> arrow_schema::SchemaRef {
+        self.schema.clone()
+    }
+
+    fn num_rows(&self) -> Option<usize> {
+        self.inner.num_rows()
+    }
+
+    fn rescannable(&self) -> bool {
+        self.inner.rescannable()
+    }
+
+    fn scan_as_stream(&mut self) -> SendableRecordBatchStream {
+        let inner_stream = self.inner.scan_as_stream();
+        let target_schema = self.schema.clone();
+        let stream = inner_stream.map(move |batch_result| {
+            batch_result.and_then(|batch| {
+                coerce_schema_batch(batch, target_schema.clone()).map_err(crate::Error::from)
+            })
+        });
+        Box::pin(SimpleRecordBatchStream {
+            schema: self.schema.clone(),
+            stream,
+        })
+    }
+}
+
+/// Peek at the first batch of `data` to infer FSL schema, then return a
+/// [`Scannable`] that applies the conversion if the schema changed.
+///
+/// Variable-length list columns whose names contain "vector" or "embedding" are
+/// converted to FixedSizeList when a uniform dimension can be inferred.
+pub async fn maybe_infer_fsl_scannable(data: Box<dyn Scannable>) -> Result<Box<dyn Scannable>> {
+    let mut peeked = PeekedScannable::new(data);
+    let Some(first_batch) = peeked.peek().await else {
+        return Ok(Box::new(peeked));
+    };
+
+    let original_schema = peeked.schema();
+    let inferred_schema = infer_fsl_schema(&first_batch);
+
+    if inferred_schema != original_schema {
+        Ok(Box::new(CoerceScannable {
+            inner: Box::new(peeked),
+            schema: inferred_schema,
+        }))
+    } else {
+        Ok(Box::new(peeked))
+    }
+}
 
 fn cast_array<I: ArrowNumericType, O: ArrowNumericType>(
     arr: &PrimitiveArray<I>,

--- a/rust/lancedb/src/data/sanitize.rs
+++ b/rust/lancedb/src/data/sanitize.rs
@@ -57,11 +57,29 @@ impl Scannable for CoerceScannable {
     }
 }
 
+/// Run [`maybe_infer_fsl_scannable`] on `add.data` if the add is an Overwrite *and*
+/// schema inference is enabled.
+///
+/// Inference is intentionally Overwrite-only: for Append we already have an existing
+/// table schema and rely on the schema-cast path to align incoming data; running
+/// inference again would risk producing a schema that disagrees with the table.
+/// See the doc on [`crate::table::AddDataBuilder`] for the user-facing contract.
+pub(crate) async fn maybe_infer_for_overwrite(
+    add: &mut crate::table::AddDataBuilder,
+) -> Result<()> {
+    use crate::table::AddDataMode;
+    if matches!(add.mode, AddDataMode::Overwrite) && add.write_options.infer_vector_columns {
+        let data = std::mem::replace(&mut add.data, Box::new(Vec::<RecordBatch>::new()));
+        add.data = maybe_infer_fsl_scannable(data).await?;
+    }
+    Ok(())
+}
+
 /// Peek at the first batch of `data` to infer FSL schema, then return a
 /// [`Scannable`] that applies the conversion if the schema changed.
 ///
-/// Variable-length list columns whose names contain "vector" or "embedding" are
-/// converted to FixedSizeList when a uniform dimension can be inferred.
+/// Variable-length list columns named "vector" or "embedding" are converted to
+/// FixedSizeList when a uniform dimension can be inferred.
 pub async fn maybe_infer_fsl_scannable(data: Box<dyn Scannable>) -> Result<Box<dyn Scannable>> {
     let mut peeked = PeekedScannable::new(data);
     let Some(first_batch) = peeked.peek().await else {
@@ -111,6 +129,56 @@ where
     }
 }
 
+/// Coerce a `List`/`LargeList` array to a `FixedSizeList` of the target dimension.
+///
+/// Returns a `SchemaError` if any row's length does not match the expected dimension.
+/// This is the intended default: silently nulling out mismatched rows (which is what
+/// `arrow_cast::cast` does for this conversion) loses data without telling the user.
+fn coerce_list_to_fixed_size_list(
+    array: &Arc<dyn Array>,
+    field: &Field,
+) -> std::result::Result<Arc<dyn Array>, ArrowError> {
+    let DataType::FixedSizeList(_, exp_dim) = field.data_type() else {
+        unreachable!("caller guarantees target is FixedSizeList");
+    };
+
+    let dim = match array.data_type() {
+        DataType::List(_) => infer_dimension::<Int32Type>(array.as_list::<i32>())
+            .map_err(|e| {
+                ArrowError::SchemaError(format!("failed to infer dimension from list: {}", e))
+            })?
+            .map(|d| d as i64),
+        DataType::LargeList(_) => {
+            infer_dimension::<Int64Type>(array.as_list::<i64>()).map_err(|e| {
+                ArrowError::SchemaError(format!("failed to infer dimension from large list: {}", e))
+            })?
+        }
+        _ => unreachable!("caller guarantees source is List or LargeList"),
+    };
+
+    let Some(dim) = dim else {
+        return Err(ArrowError::SchemaError(format!(
+            "Cannot coerce column {} to {:?}: input rows have non-uniform lengths",
+            field.name(),
+            field.data_type(),
+        )));
+    };
+
+    if dim != *exp_dim as i64 {
+        return Err(ArrowError::SchemaError(format!(
+            "Cannot coerce column {} to {:?}: expected dimension {} but got {}",
+            field.name(),
+            field.data_type(),
+            exp_dim,
+            dim,
+        )));
+    }
+
+    // Dimension is uniform and matches the target; arrow_cast::cast will produce a
+    // FixedSizeList with no row dropped, also handling the inner element type cast.
+    cast(array, field.data_type())
+}
+
 fn coerce_array(
     array: &Arc<dyn Array>,
     field: &Field,
@@ -119,6 +187,12 @@ fn coerce_array(
         return Ok(array.clone());
     }
     match (array.data_type(), field.data_type()) {
+        // List/LargeList -> FixedSizeList must use the explicit branch below so that
+        // rows whose length disagrees with the target dimension produce a SchemaError
+        // rather than being silently nulled out by arrow_cast::cast.
+        (DataType::List(_) | DataType::LargeList(_), DataType::FixedSizeList(_, _)) => {
+            coerce_list_to_fixed_size_list(array, field)
+        }
         // Normal cast-able types.
         (adt, dt) if can_cast_types(adt, dt) => cast(&array, dt),
         // Casting between f16/f32/f64 can be lossy.
@@ -138,61 +212,17 @@ fn coerce_array(
                 _ => unreachable!(),
             }
         }
-        (adt, DataType::FixedSizeList(exp_field, exp_dim)) => match adt {
-            // Cast a float fixed size array with same dimension to the expected type.
-            DataType::FixedSizeList(_, dim) if dim == exp_dim => {
-                let actual_sub = array.as_fixed_size_list();
-                let values = coerce_array(actual_sub.values(), exp_field)?;
-                Ok(Arc::new(FixedSizeListArray::try_new_from_values(
-                    values.clone(),
-                    *dim,
-                )?) as Arc<dyn Array>)
-            }
-            DataType::List(_) | DataType::LargeList(_) => {
-                let Some(dim) = (match adt {
-                    DataType::List(_) => infer_dimension::<Int32Type>(array.as_list::<i32>())
-                        .map_err(|e| {
-                            ArrowError::SchemaError(format!(
-                                "failed to infer dimension from list: {}",
-                                e
-                            ))
-                        })?
-                        .map(|d| d as i64),
-                    DataType::LargeList(_) => infer_dimension::<Int64Type>(array.as_list::<i64>())
-                        .map_err(|e| {
-                            ArrowError::SchemaError(format!(
-                                "failed to infer dimension from large list: {}",
-                                e
-                            ))
-                        })?,
-                    _ => unreachable!(),
-                }) else {
-                    return Err(ArrowError::SchemaError(format!(
-                        "Incompatible coerce fixed size list: unable to coerce {:?} from {:?}",
-                        field,
-                        array.data_type()
-                    )));
-                };
-
-                if dim != *exp_dim as i64 {
-                    return Err(ArrowError::SchemaError(format!(
-                        "Incompatible coerce fixed size list: expected dimension {} but got {}",
-                        exp_dim, dim
-                    )));
-                }
-
-                let values = coerce_array(array, exp_field)?;
-                Ok(Arc::new(FixedSizeListArray::try_new_from_values(
-                    values.clone(),
-                    *exp_dim,
-                )?) as Arc<dyn Array>)
-            }
-            _ => Err(ArrowError::SchemaError(format!(
-                "Incompatible coerce fixed size list: unable to coerce {:?} from {:?}",
-                field,
-                array.data_type()
-            )))?,
-        },
+        // Cast a fixed size array with the same dimension to the expected element type.
+        (DataType::FixedSizeList(_, dim), DataType::FixedSizeList(exp_field, exp_dim))
+            if dim == exp_dim =>
+        {
+            let actual_sub = array.as_fixed_size_list();
+            let values = coerce_array(actual_sub.values(), exp_field)?;
+            Ok(Arc::new(FixedSizeListArray::try_new_from_values(
+                values.clone(),
+                *dim,
+            )?) as Arc<dyn Array>)
+        }
         _ => Err(ArrowError::SchemaError(format!(
             "Incompatible change field {}: unable to coerce {:?} to {:?}",
             field.name(),
@@ -202,7 +232,7 @@ fn coerce_array(
     }
 }
 
-fn coerce_schema_batch(
+pub(crate) fn coerce_schema_batch(
     batch: RecordBatch,
     schema: Arc<Schema>,
 ) -> std::result::Result<RecordBatch, ArrowError> {
@@ -247,11 +277,14 @@ mod tests {
 
     use arrow_array::{
         FixedSizeListArray, Float16Array, Float32Array, Float64Array, Int8Array, Int32Array,
-        RecordBatch, RecordBatchIterator, StringArray,
+        ListArray, RecordBatch, RecordBatchIterator, StringArray, types::Float32Type,
     };
     use arrow_schema::Field;
+    use futures::TryStreamExt;
     use half::f16;
     use lance_arrow::FixedSizeListArrayExt;
+
+    use crate::data::scannable::Scannable;
 
     #[test]
     fn test_coerce_list_to_fixed_size_list() {
@@ -330,5 +363,152 @@ mod tests {
         )
         .unwrap();
         assert_eq!(batch, &expected);
+    }
+
+    #[tokio::test]
+    async fn test_coerce_scannable_multi_batch_list_to_fsl() {
+        // Two batches of List<Float32> coerced to FixedSizeList<Float32, 3>.
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let make_batch = |start: f32| {
+            RecordBatch::try_new(
+                source_schema.clone(),
+                vec![Arc::new(
+                    ListArray::from_iter_primitive::<Float32Type, _, _>((0..2).map(|i| {
+                        Some(vec![
+                            Some(start + i as f32),
+                            Some(start + i as f32 + 0.1),
+                            Some(start + i as f32 + 0.2),
+                        ])
+                    })),
+                )],
+            )
+            .unwrap()
+        };
+        let batches = vec![make_batch(0.0), make_batch(10.0)];
+
+        let target_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
+            true,
+        )]));
+
+        let mut scannable = CoerceScannable {
+            inner: Box::new(batches.clone()),
+            schema: target_schema.clone(),
+        };
+        let stream = scannable.scan_as_stream();
+        let results: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        assert_eq!(results.len(), 2);
+        for batch in &results {
+            assert_eq!(batch.schema(), target_schema);
+            assert_eq!(batch.num_rows(), 2);
+            assert!(matches!(
+                batch.column(0).data_type(),
+                DataType::FixedSizeList(_, 3)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_coerce_scannable_heterogeneous_batches_error_on_mismatched_dim() {
+        // First batch has uniform length 3 (matches the inferred target). Second
+        // batch has a row of length 4. The coercion must return a SchemaError
+        // rather than silently nulling out the mismatched row — silent data loss
+        // is user-hostile and there is no way for the caller to detect it.
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let good = RecordBatch::try_new(
+            source_schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0)])),
+                ),
+            )],
+        )
+        .unwrap();
+        let bad = RecordBatch::try_new(
+            source_schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(4.0f32), Some(5.0), Some(6.0), Some(7.0)])),
+                ),
+            )],
+        )
+        .unwrap();
+        let batches = vec![good, bad];
+
+        let target_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
+            true,
+        )]));
+
+        let mut scannable = CoerceScannable {
+            inner: Box::new(batches),
+            schema: target_schema.clone(),
+        };
+        let mut stream = scannable.scan_as_stream();
+
+        let first = stream.next().await.expect("first batch present").unwrap();
+        assert_eq!(first.schema(), target_schema);
+        assert_eq!(first.column(0).as_fixed_size_list().null_count(), 0);
+
+        let err = stream
+            .next()
+            .await
+            .expect("second batch present")
+            .expect_err("expected SchemaError on dimension mismatch");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected dimension 3") && msg.contains("got 4"),
+            "error message should report expected vs actual dim, got: {msg}",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_coerce_scannable_error_on_non_uniform_lengths_within_batch() {
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            source_schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+                    Some(vec![Some(1.0f32), Some(2.0), Some(3.0)]),
+                    Some(vec![Some(4.0f32), Some(5.0), Some(6.0), Some(7.0)]),
+                ]),
+            )],
+        )
+        .unwrap();
+
+        let target_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
+            true,
+        )]));
+
+        let mut scannable = CoerceScannable {
+            inner: Box::new(vec![batch]),
+            schema: target_schema,
+        };
+        let mut stream = scannable.scan_as_stream();
+        let err = stream
+            .next()
+            .await
+            .expect("batch present")
+            .expect_err("expected SchemaError on non-uniform lengths");
+        assert!(
+            err.to_string().contains("non-uniform lengths"),
+            "error should mention non-uniform lengths, got: {err}",
+        );
     }
 }

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -1042,7 +1042,7 @@ impl Database for ListingDatabase {
 
         let data_schema = request.data.schema();
         let mut data = request.data;
-        if request.write_options.infer_schema {
+        if request.write_options.infer_vector_columns {
             data = maybe_infer_fsl_scannable(data).await?;
         }
 
@@ -1282,7 +1282,7 @@ mod tests {
     use crate::data::scannable::Scannable;
     use crate::database::{CreateTableMode, CreateTableRequest};
     use crate::table::WriteOptions;
-    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use arrow_array::{Array, Int32Array, RecordBatch, StringArray, cast::AsArray};
     use arrow_schema::{DataType, Field, Schema};
     use std::path::PathBuf;
     use tempfile::tempdir;
@@ -2664,6 +2664,53 @@ mod tests {
             "expected FixedSizeList(_, 4), got {:?}",
             embedding_field.data_type()
         );
+
+        // Row count and value preservation.
+        assert_eq!(table.count_rows(None).await.unwrap(), 3);
+        let db = Arc::new(db);
+        let table_obj = Table::new(table.clone(), db);
+        use crate::query::ExecutableQuery;
+        use futures::TryStreamExt;
+        let batches: Vec<RecordBatch> = table_obj
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3);
+        // Concatenate id column and check values.
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let col = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            ids.extend(col.values().iter().copied());
+        }
+        ids.sort();
+        assert_eq!(ids, vec![1, 2, 3]);
+        // Check embedding values: every row should be [1.0, 2.0, 3.0, 4.0].
+        for b in &batches {
+            let fsl = b.column_by_name("embedding").unwrap().as_fixed_size_list();
+            assert_eq!(fsl.value_length(), 4);
+            for row in 0..fsl.len() {
+                let values = fsl.value(row);
+                let floats = values
+                    .as_any()
+                    .downcast_ref::<arrow_array::Float32Array>()
+                    .unwrap();
+                assert_eq!(
+                    floats.values().to_vec(),
+                    vec![1.0f32, 2.0, 3.0, 4.0],
+                    "embedding row {row}"
+                );
+            }
+        }
     }
 
     #[tokio::test]
@@ -2698,7 +2745,7 @@ mod tests {
                 data: Box::new(vec![batch]),
                 mode: CreateTableMode::Create,
                 write_options: WriteOptions {
-                    infer_schema: false,
+                    infer_vector_columns: false,
                     ..Default::default()
                 },
                 location: None,
@@ -2714,5 +2761,33 @@ mod tests {
             "expected List (inference disabled), got {:?}",
             embedding_field.data_type()
         );
+
+        // Row count and value preservation: data should still be intact.
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+        let db = Arc::new(db);
+        let table_obj = Table::new(table.clone(), db);
+        use crate::query::ExecutableQuery;
+        use futures::TryStreamExt;
+        let batches: Vec<RecordBatch> = table_obj
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 2);
+        for b in &batches {
+            let list = b.column_by_name("embedding").unwrap().as_list::<i32>();
+            for row in 0..list.len() {
+                let values = list.value(row);
+                let floats = values
+                    .as_any()
+                    .downcast_ref::<arrow_array::Float32Array>()
+                    .unwrap();
+                assert_eq!(floats.values().to_vec(), vec![1.0f32, 2.0]);
+            }
+        }
     }
 }

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -11,7 +11,6 @@ use std::{collections::HashMap, sync::Arc};
 use lance::dataset::refs::Ref;
 use lance::dataset::{ReadParams, WriteMode, builder::DatasetBuilder};
 use lance::io::{ObjectStore, ObjectStoreParams, WrappingObjectStore};
-use lance_datafusion::utils::StreamingWriteSource;
 use lance_encoding::version::LanceFileVersion;
 use lance_io::object_store::{StorageOptionsAccessor, StorageOptionsProvider};
 use lance_table::io::commit::commit_handler_from_url;
@@ -19,6 +18,7 @@ use object_store::local::LocalFileSystem;
 use snafu::ResultExt;
 
 use crate::connection::ConnectRequest;
+use crate::data::sanitize::maybe_infer_fsl_scannable;
 use crate::database::ReadConsistency;
 use crate::database::namespace::LanceNamespaceDatabase;
 use crate::error::{CreateDirSnafu, Error, Result};
@@ -1040,13 +1040,17 @@ impl Database for ListingDatabase {
             stable_row_ids_override,
         );
 
-        let data_schema = request.data.arrow_schema();
+        let data_schema = request.data.schema();
+        let mut data = request.data;
+        if request.write_options.infer_schema {
+            data = maybe_infer_fsl_scannable(data).await?;
+        }
 
         match NativeTable::create(
             &table_uri,
             &request.name,
             request.namespace_path.clone(),
-            request.data,
+            data,
             self.store_wrapper.clone(),
             Some(write_params),
             self.read_consistency_interval,
@@ -2034,6 +2038,7 @@ mod tests {
                 }),
                 ..Default::default()
             }),
+            ..Default::default()
         };
 
         let table = db
@@ -2107,6 +2112,7 @@ mod tests {
                 }),
                 ..Default::default()
             }),
+            ..Default::default()
         };
 
         let table = db
@@ -2610,5 +2616,103 @@ mod tests {
             .await
             .unwrap();
         assert!(post_drop.tables.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_create_table_infers_fsl() {
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+        use arrow_schema::DataType;
+
+        let (_tempdir, db) = setup_database().await;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "embedding",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..3).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0), Some(4.0)])),
+                )),
+            ],
+        )
+        .unwrap();
+        let table = db
+            .create_table(CreateTableRequest {
+                name: "vectors".to_string(),
+                namespace_path: vec![],
+                data: Box::new(vec![batch]),
+                mode: CreateTableMode::Create,
+                write_options: Default::default(),
+                location: None,
+                namespace_client: None,
+            })
+            .await
+            .unwrap();
+
+        let stored_schema = table.schema().await.unwrap();
+        let embedding_field = stored_schema.field_with_name("embedding").unwrap();
+        assert!(
+            matches!(embedding_field.data_type(), DataType::FixedSizeList(_, 4)),
+            "expected FixedSizeList(_, 4), got {:?}",
+            embedding_field.data_type()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_infers_fsl_disabled() {
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+
+        let (_tempdir, db) = setup_database().await;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "embedding",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(1.0f32), Some(2.0)])),
+                )),
+            ],
+        )
+        .unwrap();
+        let table = db
+            .create_table(CreateTableRequest {
+                name: "vectors_no_infer".to_string(),
+                namespace_path: vec![],
+                data: Box::new(vec![batch]),
+                mode: CreateTableMode::Create,
+                write_options: WriteOptions {
+                    infer_schema: false,
+                    ..Default::default()
+                },
+                location: None,
+                namespace_client: None,
+            })
+            .await
+            .unwrap();
+
+        let stored_schema = table.schema().await.unwrap();
+        let embedding_field = stored_schema.field_with_name("embedding").unwrap();
+        assert!(
+            matches!(embedding_field.data_type(), DataType::List(_)),
+            "expected List (inference disabled), got {:?}",
+            embedding_field.data_type()
+        );
     }
 }

--- a/rust/lancedb/src/io/object_store.rs
+++ b/rust/lancedb/src/io/object_store.rs
@@ -234,6 +234,7 @@ mod test {
             .create_table("test", data)
             .write_options(WriteOptions {
                 lance_write_params: Some(param),
+                ..Default::default()
             })
             .execute()
             .await;

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -441,7 +441,7 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     }
 
     async fn create_table(&self, mut request: CreateTableRequest) -> Result<Arc<dyn BaseTable>> {
-        if request.write_options.infer_schema {
+        if request.write_options.infer_vector_columns {
             request.data = maybe_infer_fsl_scannable(request.data).await?;
         }
         let body = stream_as_body(request.data.scan_as_stream())?;
@@ -1020,6 +1020,136 @@ mod tests {
         .unwrap();
         let table = conn.create_table("table1", data).execute().await.unwrap();
         assert_eq!(table.name(), "table1");
+    }
+
+    async fn collect_request_body(body: reqwest::Body) -> Vec<u8> {
+        use futures::StreamExt;
+        use http_body::Body as _;
+        use std::pin::Pin;
+        let mut body = body;
+        let mut data = Vec::new();
+        let mut body_pin = Pin::new(&mut body);
+        futures::stream::poll_fn(|cx| body_pin.as_mut().poll_frame(cx))
+            .for_each(|frame| {
+                let frame = frame.unwrap();
+                if let Some(d) = frame.data_ref() {
+                    data.extend_from_slice(d);
+                }
+                futures::future::ready(())
+            })
+            .await;
+        data
+    }
+
+    #[tokio::test]
+    async fn test_create_table_infers_fsl_from_list() {
+        // When create_table receives a List<Float32> column named "embedding"
+        // with uniform row lengths, the request body sent to the server must
+        // already carry the inferred FixedSizeList schema.
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+        use reqwest::Body;
+
+        let data_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "embedding",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+        ]));
+        let data = RecordBatch::try_new(
+            data_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..3).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0), Some(4.0)])),
+                )),
+            ],
+        )
+        .unwrap();
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let conn = Connection::new_with_handler(move |mut request| {
+            assert_eq!(request.method(), &reqwest::Method::POST);
+            assert_eq!(request.url().path(), "/v1/table/embedding_table/create/");
+            let mut body_out = Body::from(Vec::new());
+            std::mem::swap(request.body_mut().as_mut().unwrap(), &mut body_out);
+            sender.send(body_out).unwrap();
+            http::Response::builder().status(200).body("").unwrap()
+        });
+
+        conn.create_table("embedding_table", data)
+            .execute()
+            .await
+            .unwrap();
+
+        // Read the body sent to the server and inspect its IPC stream schema.
+        let body = receiver.recv().unwrap();
+        let bytes = collect_request_body(body).await;
+        let cursor = std::io::Cursor::new(bytes);
+        let reader = arrow_ipc::reader::StreamReader::try_new(cursor, None).unwrap();
+        let sent_schema = reader.schema();
+        let embedding_field = sent_schema.field_with_name("embedding").unwrap();
+        assert!(
+            matches!(embedding_field.data_type(), DataType::FixedSizeList(_, 4)),
+            "expected FixedSizeList(_, 4) in sent body, got {:?}",
+            embedding_field.data_type()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_infers_fsl_disabled() {
+        // When infer_vector_columns is disabled via WriteOptions, the body sent to the
+        // server should keep the List<Float32> schema as-is.
+        use crate::table::WriteOptions;
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+        use reqwest::Body;
+
+        let data_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let data = RecordBatch::try_new(
+            data_schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(1.0f32), Some(2.0)])),
+                ),
+            )],
+        )
+        .unwrap();
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let conn = Connection::new_with_handler(move |mut request| {
+            let mut body_out = Body::from(Vec::new());
+            std::mem::swap(request.body_mut().as_mut().unwrap(), &mut body_out);
+            sender.send(body_out).unwrap();
+            http::Response::builder().status(200).body("").unwrap()
+        });
+
+        conn.create_table("embedding_table", data)
+            .write_options(WriteOptions {
+                infer_vector_columns: false,
+                ..Default::default()
+            })
+            .execute()
+            .await
+            .unwrap();
+
+        let body = receiver.recv().unwrap();
+        let bytes = collect_request_body(body).await;
+        let cursor = std::io::Cursor::new(bytes);
+        let reader = arrow_ipc::reader::StreamReader::try_new(cursor, None).unwrap();
+        let sent_schema = reader.schema();
+        let embedding_field = sent_schema.field_with_name("embedding").unwrap();
+        assert!(
+            matches!(embedding_field.data_type(), DataType::List(_)),
+            "expected List in sent body, got {:?}",
+            embedding_field.data_type()
+        );
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -17,6 +17,7 @@ use lance_namespace::models::{
 };
 
 use crate::Error;
+use crate::data::sanitize::maybe_infer_fsl_scannable;
 use crate::database::{
     CloneTableRequest, CreateTableMode, CreateTableRequest, Database, DatabaseOptions,
     OpenTableRequest, ReadConsistency, TableNamesRequest,
@@ -440,6 +441,9 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     }
 
     async fn create_table(&self, mut request: CreateTableRequest) -> Result<Arc<dyn BaseTable>> {
+        if request.write_options.infer_schema {
+            request.data = maybe_infer_fsl_scannable(request.data).await?;
+        }
         let body = stream_as_body(request.data.scan_as_stream())?;
 
         let identifier = build_table_identifier(

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -63,6 +63,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::RwLock;
 
+use crate::data::sanitize::maybe_infer_fsl_scannable;
+use crate::table::AddDataMode;
+
 const REQUEST_TIMEOUT_HEADER: HeaderName = HeaderName::from_static("x-request-timeout-ms");
 const METRIC_TYPE_KEY: &str = "metric_type";
 const INDEX_TYPE_KEY: &str = "index_type";
@@ -1254,6 +1257,11 @@ impl<S: HttpSend> BaseTable for RemoteTable<S> {
     }
     async fn add(&self, mut add: AddDataBuilder) -> Result<AddResult> {
         self.check_mutable().await?;
+
+        // For overwrite, infer FSL schema from incoming data (no existing table schema to cast to).
+        if matches!(add.mode, AddDataMode::Overwrite) && add.write_options.infer_schema {
+            add.data = maybe_infer_fsl_scannable(add.data).await?;
+        }
 
         let table_schema = self.schema().await?;
         let table_def = TableDefinition::try_from_rich_schema(table_schema.clone())?;

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -63,9 +63,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-use crate::data::sanitize::maybe_infer_fsl_scannable;
-use crate::table::AddDataMode;
-
 const REQUEST_TIMEOUT_HEADER: HeaderName = HeaderName::from_static("x-request-timeout-ms");
 const METRIC_TYPE_KEY: &str = "metric_type";
 const INDEX_TYPE_KEY: &str = "index_type";
@@ -1258,10 +1255,7 @@ impl<S: HttpSend> BaseTable for RemoteTable<S> {
     async fn add(&self, mut add: AddDataBuilder) -> Result<AddResult> {
         self.check_mutable().await?;
 
-        // For overwrite, infer FSL schema from incoming data (no existing table schema to cast to).
-        if matches!(add.mode, AddDataMode::Overwrite) && add.write_options.infer_schema {
-            add.data = maybe_infer_fsl_scannable(add.data).await?;
-        }
+        crate::data::sanitize::maybe_infer_for_overwrite(&mut add).await?;
 
         let table_schema = self.schema().await?;
         let table_def = TableDefinition::try_from_rich_schema(table_schema.clone())?;
@@ -2417,6 +2411,82 @@ mod tests {
         let body = collect_body(body).await;
         let expected_body = write_ipc_stream(&data);
         assert_eq!(&body, &expected_body);
+    }
+
+    #[tokio::test]
+    async fn test_add_overwrite_infers_fsl_from_list() {
+        // RemoteTable::add in Overwrite mode should send the inferred FSL
+        // schema (List<Float32> → FixedSizeList<Float32, dim>) to the server.
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+
+        let data_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let data = RecordBatch::try_new(
+            data_schema.clone(),
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..3).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0), Some(4.0)])),
+                ),
+            )],
+        )
+        .unwrap();
+
+        // Describe returns the initial (pre-overwrite) schema with a scalar id
+        // column. After overwrite the server-side schema is replaced; we only
+        // care that the bytes sent reflect the inferred FSL schema.
+        let initial_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let describe_body = describe_response(&initial_schema);
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let table =
+            Table::new_with_handler("my_table", move |mut request| match request.url().path() {
+                "/v1/table/my_table/describe/" => http::Response::builder()
+                    .status(200)
+                    .body(describe_body.clone())
+                    .unwrap(),
+                "/v1/table/my_table/insert/" => {
+                    assert_eq!(
+                        request
+                            .url()
+                            .query_pairs()
+                            .find(|(k, _)| k == "mode")
+                            .map(|kv| kv.1)
+                            .as_deref(),
+                        Some("overwrite"),
+                    );
+                    let mut body_out = reqwest::Body::from(Vec::new());
+                    std::mem::swap(request.body_mut().as_mut().unwrap(), &mut body_out);
+                    sender.send(body_out).unwrap();
+                    http::Response::builder()
+                        .status(200)
+                        .body(r#"{"version": 2}"#.to_string())
+                        .unwrap()
+                }
+                path => panic!("Unexpected request path: {}", path),
+            });
+
+        table
+            .add(data)
+            .mode(AddDataMode::Overwrite)
+            .execute()
+            .await
+            .unwrap();
+
+        let body = receiver.recv().unwrap();
+        let bytes = collect_body(body).await;
+        let cursor = std::io::Cursor::new(bytes);
+        let reader = arrow_ipc::reader::StreamReader::try_new(cursor, None).unwrap();
+        let sent_schema = reader.schema();
+        let embedding_field = sent_schema.field_with_name("embedding").unwrap();
+        assert!(
+            matches!(embedding_field.data_type(), DataType::FixedSizeList(_, 4)),
+            "expected FixedSizeList(_, 4) in sent body, got {:?}",
+            embedding_field.data_type()
+        );
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -48,7 +48,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::connection::NamespaceClientPushdownOperation;
-use crate::data::sanitize::maybe_infer_fsl_scannable;
 use crate::data::scannable::{PeekedScannable, Scannable, estimate_write_partitions};
 use crate::database::Database;
 use crate::embeddings::{EmbeddingDefinition, EmbeddingRegistry, MemoryRegistry};
@@ -195,17 +194,24 @@ pub struct WriteOptions {
     /// Overlapping `OpenTableBuilder` options (e.g. [AddDataBuilder::mode]) will take
     /// precedence over their counterparts in `WriteOptions` (e.g. [WriteParams::mode]).
     pub lance_write_params: Option<WriteParams>,
-    /// If true (the default), variable-length list columns whose names contain "vector"
-    /// or "embedding" will be automatically converted to FixedSizeList when their
-    /// dimension can be inferred from the data. Set to false to disable this behavior.
-    pub infer_schema: bool,
+    /// If true (the default), variable-length list columns whose names contain
+    /// "vector" or "embedding" (case-insensitive substring) will be converted to
+    /// `FixedSizeList` when a uniform dimension can be inferred from the first
+    /// batch.
+    ///
+    /// This applies when writing a new table schema (`create_table` and
+    /// `Table::add` with [`AddDataMode::Overwrite`]). It does not run on
+    /// [`AddDataMode::Append`], where the existing schema is used instead.
+    ///
+    /// Set to `false` to disable.
+    pub infer_vector_columns: bool,
 }
 
 impl Default for WriteOptions {
     fn default() -> Self {
         Self {
             lance_write_params: None,
-            infer_schema: true,
+            infer_vector_columns: true,
         }
     }
 }
@@ -2268,12 +2274,7 @@ impl BaseTable for NativeTable {
     async fn add(&self, mut add: AddDataBuilder) -> Result<AddResult> {
         let table_def = self.table_definition().await?;
 
-        // For overwrite, infer FSL schema from the incoming data. The table schema is
-        // not yet established, so we can't cast to it. For append, the table schema
-        // already exists and schema casting handles type alignment.
-        if matches!(add.mode, AddDataMode::Overwrite) && add.write_options.infer_schema {
-            add.data = maybe_infer_fsl_scannable(add.data).await?;
-        }
+        crate::data::sanitize::maybe_infer_for_overwrite(&mut add).await?;
 
         self.dataset.ensure_mutable()?;
         let ds_wrapper = self.dataset.clone();
@@ -2748,6 +2749,7 @@ mod tests {
     use futures::TryStreamExt;
     use lance::Dataset;
     use lance::io::{ObjectStoreParams, WrappingObjectStore};
+    use lance_arrow::FixedSizeListArrayExt;
     use tempfile::tempdir;
 
     use super::*;
@@ -4045,5 +4047,206 @@ mod tests {
             "expected FixedSizeList(_, 3), got {:?}",
             vector_field.data_type()
         );
+
+        // Row count and value readback.
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+        use arrow_array::Array;
+        use arrow_array::cast::AsArray;
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 2);
+        for b in &batches {
+            let fsl = b.column_by_name("vector").unwrap().as_fixed_size_list();
+            assert_eq!(fsl.value_length(), 3);
+            for row in 0..fsl.len() {
+                let values = fsl.value(row);
+                let floats = values
+                    .as_any()
+                    .downcast_ref::<arrow_array::Float32Array>()
+                    .unwrap();
+                assert_eq!(floats.values().to_vec(), vec![0.1f32, 0.2, 0.3]);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_overwrite_infers_fsl_disabled() {
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+        use arrow_schema::DataType;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+
+        let init_schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let init_batch = RecordBatch::try_new(
+            init_schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from(vec![0]))],
+        )
+        .unwrap();
+        let db = crate::connect(uri).execute().await.unwrap();
+        db.create_table("test", init_batch).execute().await.unwrap();
+
+        let new_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", DataType::Int32, false),
+            arrow_schema::Field::new(
+                "vector",
+                DataType::List(Arc::new(arrow_schema::Field::new(
+                    "item",
+                    DataType::Float32,
+                    true,
+                ))),
+                true,
+            ),
+        ]));
+        let new_batch = RecordBatch::try_new(
+            new_schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![1, 2])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(0.1f32), Some(0.2), Some(0.3)])),
+                )),
+            ],
+        )
+        .unwrap();
+        let table = db.open_table("test").execute().await.unwrap();
+        table
+            .add(new_batch)
+            .mode(crate::table::AddDataMode::Overwrite)
+            .write_options(WriteOptions {
+                infer_vector_columns: false,
+                ..Default::default()
+            })
+            .execute()
+            .await
+            .unwrap();
+
+        let stored_schema = table.schema().await.unwrap();
+        let vector_field = stored_schema.field_with_name("vector").unwrap();
+        assert!(
+            matches!(vector_field.data_type(), DataType::List(_)),
+            "expected List (inference disabled), got {:?}",
+            vector_field.data_type()
+        );
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_add_append_does_not_infer_fsl() {
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+        use arrow_schema::DataType;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+
+        // Create a table with an FSL-typed vector column upfront.
+        let init_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", DataType::Int32, false),
+            arrow_schema::Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(arrow_schema::Field::new("item", DataType::Float32, true)),
+                    4,
+                ),
+                true,
+            ),
+        ]));
+        let init_batch = RecordBatch::try_new(
+            init_schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![0])),
+                Arc::new(
+                    FixedSizeListArray::try_new_from_values(
+                        arrow_array::Float32Array::from(vec![0.0f32, 0.1, 0.2, 0.3]),
+                        4,
+                    )
+                    .unwrap(),
+                ),
+            ],
+        )
+        .unwrap();
+        let db = crate::connect(uri).execute().await.unwrap();
+        let table = db.create_table("test", init_batch).execute().await.unwrap();
+
+        // Append data whose vector column is List<Float32> with uniform length 4.
+        // This should succeed via the existing schema-cast path, NOT by re-inferring.
+        let append_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", DataType::Int32, false),
+            arrow_schema::Field::new(
+                "vector",
+                DataType::List(Arc::new(arrow_schema::Field::new(
+                    "item",
+                    DataType::Float32,
+                    true,
+                ))),
+                true,
+            ),
+        ]));
+        let append_batch = RecordBatch::try_new(
+            append_schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![1, 2])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(1.0f32), Some(2.0), Some(3.0), Some(4.0)])),
+                )),
+            ],
+        )
+        .unwrap();
+        table.add(append_batch).execute().await.unwrap();
+
+        // The schema must remain FixedSizeList — no re-inference happened.
+        let stored_schema = table.schema().await.unwrap();
+        let vector_field = stored_schema.field_with_name("vector").unwrap();
+        assert!(
+            matches!(vector_field.data_type(), DataType::FixedSizeList(_, 4)),
+            "expected FixedSizeList(_, 4), got {:?}",
+            vector_field.data_type()
+        );
+        assert_eq!(table.count_rows(None).await.unwrap(), 3);
+
+        // Now prove inference truly did not run on Append: send a uniform length-5
+        // batch. If inference were running, it would produce FSL(_, 5) and a new
+        // table would happily accept it. Because the existing table schema is
+        // FSL(_, 4), the coercion path must reject this with a dimension mismatch.
+        let mismatched = RecordBatch::try_new(
+            append_schema,
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![3])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+                    Some(vec![
+                        Some(9.0f32),
+                        Some(8.0),
+                        Some(7.0),
+                        Some(6.0),
+                        Some(5.0),
+                    ]),
+                ])),
+            ],
+        )
+        .unwrap();
+        let err = table
+            .add(mismatched)
+            .execute()
+            .await
+            .expect_err("appending length-5 lists into FSL(4) table must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("FixedSizeList(4)") && msg.contains("length 5"),
+            "error should report dimension mismatch, got: {msg}",
+        );
+        // Row count unchanged — the failed append did not commit any rows.
+        assert_eq!(table.count_rows(None).await.unwrap(), 3);
     }
 }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -48,7 +48,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::connection::NamespaceClientPushdownOperation;
-
+use crate::data::sanitize::maybe_infer_fsl_scannable;
 use crate::data::scannable::{PeekedScannable, Scannable, estimate_write_partitions};
 use crate::database::Database;
 use crate::embeddings::{EmbeddingDefinition, EmbeddingRegistry, MemoryRegistry};
@@ -184,7 +184,8 @@ enum BadVectorHandling {
 }
 
 /// Options to use when writing data
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct WriteOptions {
     // Coming soon: https://github.com/lancedb/lancedb/issues/992
     // /// What behavior to take if the data contains invalid vectors
@@ -194,6 +195,19 @@ pub struct WriteOptions {
     /// Overlapping `OpenTableBuilder` options (e.g. [AddDataBuilder::mode]) will take
     /// precedence over their counterparts in `WriteOptions` (e.g. [WriteParams::mode]).
     pub lance_write_params: Option<WriteParams>,
+    /// If true (the default), variable-length list columns whose names contain "vector"
+    /// or "embedding" will be automatically converted to FixedSizeList when their
+    /// dimension can be inferred from the data. Set to false to disable this behavior.
+    pub infer_schema: bool,
+}
+
+impl Default for WriteOptions {
+    fn default() -> Self {
+        Self {
+            lance_write_params: None,
+            infer_schema: true,
+        }
+    }
 }
 
 /// Filters that can be used to limit the rows returned by a query
@@ -2254,6 +2268,13 @@ impl BaseTable for NativeTable {
     async fn add(&self, mut add: AddDataBuilder) -> Result<AddResult> {
         let table_def = self.table_definition().await?;
 
+        // For overwrite, infer FSL schema from the incoming data. The table schema is
+        // not yet established, so we can't cast to it. For append, the table schema
+        // already exists and schema casting handles type alignment.
+        if matches!(add.mode, AddDataMode::Overwrite) && add.write_options.infer_schema {
+            add.data = maybe_infer_fsl_scannable(add.data).await?;
+        }
+
         self.dataset.ensure_mutable()?;
         let ds_wrapper = self.dataset.clone();
         let ds = self.dataset.get().await?;
@@ -3961,5 +3982,68 @@ mod tests {
         let result = table.list_indices().await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].index_type, crate::index::IndexType::Bitmap);
+    }
+
+    #[tokio::test]
+    async fn test_add_overwrite_infers_fsl() {
+        use arrow_array::ListArray;
+        use arrow_array::types::Float32Type;
+        use arrow_schema::DataType;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+
+        // Create initial table with scalar data
+        let init_schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let init_batch = RecordBatch::try_new(
+            init_schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from(vec![0]))],
+        )
+        .unwrap();
+        let db = crate::connect(uri).execute().await.unwrap();
+        db.create_table("test", init_batch).execute().await.unwrap();
+
+        // Overwrite with a list-typed "vector" column — should become FSL
+        let new_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", DataType::Int32, false),
+            arrow_schema::Field::new(
+                "vector",
+                DataType::List(Arc::new(arrow_schema::Field::new(
+                    "item",
+                    DataType::Float32,
+                    true,
+                ))),
+                true,
+            ),
+        ]));
+        let new_batch = RecordBatch::try_new(
+            new_schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![1, 2])),
+                Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(
+                    (0..2).map(|_| Some(vec![Some(0.1f32), Some(0.2), Some(0.3)])),
+                )),
+            ],
+        )
+        .unwrap();
+        let table = db.open_table("test").execute().await.unwrap();
+        table
+            .add(new_batch)
+            .mode(crate::table::AddDataMode::Overwrite)
+            .execute()
+            .await
+            .unwrap();
+
+        let stored_schema = table.schema().await.unwrap();
+        let vector_field = stored_schema.field_with_name("vector").unwrap();
+        assert!(
+            matches!(vector_field.data_type(), DataType::FixedSizeList(_, 3)),
+            "expected FixedSizeList(_, 3), got {:?}",
+            vector_field.data_type()
+        );
     }
 }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -441,6 +441,7 @@ mod tests {
             .add(new_batch.clone())
             .write_options(WriteOptions {
                 lance_write_params: Some(param),
+                ..Default::default()
             })
             .mode(AddDataMode::Append)
             .execute()

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -22,10 +22,19 @@ use super::{BaseTable, TableDefinition, WriteOptions};
 
 #[derive(Debug, Clone, Default)]
 pub enum AddDataMode {
-    /// Rows will be appended to the table (the default)
+    /// Rows will be appended to the table (the default).
+    ///
+    /// The incoming data is cast to the existing table schema. Vector-column
+    /// schema inference (see [`WriteOptions::infer_vector_columns`]) does **not**
+    /// run in this mode — the table schema is already established.
     #[default]
     Append,
-    /// The existing table will be overwritten with the new data
+    /// The existing table will be overwritten with the new data.
+    ///
+    /// Vector-column schema inference runs in this mode (when enabled), the same
+    /// way it does for `create_table`. Users have reported being surprised when
+    /// this was not the case (see issue #3183); the rule is: any path that
+    /// produces a new table schema also re-runs inference.
     Overwrite,
 }
 

--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -528,6 +528,7 @@ mod tests {
                     }),
                     ..Default::default()
                 }),
+                ..Default::default()
             })
             .execute()
             .await
@@ -589,6 +590,7 @@ mod tests {
                     }),
                     ..Default::default()
                 }),
+                ..Default::default()
             })
             .execute()
             .await


### PR DESCRIPTION
## Summary

- Adds `infer_fsl_schema()` in `data/inspect.rs` that promotes List/LargeList columns with "vector"/"embedding" names to FixedSizeList when a uniform dimension can be inferred from the first batch
- Adds `maybe_infer_fsl()` helper in `data/sanitize.rs` that peeks the first batch, infers the schema, and wraps the reader with `coerce_schema` if needed
- Wires inference into `ListingDatabase::create_table`, `NativeTable::add` (overwrite only), `RemoteDatabase::create_table`, and `RemoteTable::add` (overwrite only)
- Adds `WriteOptions.infer_schema: bool` (default `true`) to allow opting out; marks `WriteOptions` `#[non_exhaustive]`

Float lists → `FixedSizeList<Float32, dim>`. Integer lists → `FixedSizeList<UInt8, dim>` if all values in [0, 255], otherwise `FixedSizeList<Float32, dim>`.

Closes #3216

## Test plan

- 5 unit tests for `infer_fsl_schema` covering float lists, int→UInt8, int→Float32, non-uniform lengths, and non-vector names
- Integration test `test_create_table_infers_fsl` and `test_create_table_infers_fsl_disabled`
- Integration test `test_add_overwrite_infers_fsl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)