### PR TITLE
feat(ci): add custom PyPI support for manual wheel uploads

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,6 +4,28 @@ on:
   push:
     tags:
       - 'python-v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to checkout (branch, tag, or SHA)"
+        required: false
+        default: ""
+        type: string
+      debug:
+        description: "Build debug wheels (with debug symbols)"
+        required: false
+        default: true
+        type: boolean
+      custom_pypi_url:
+        description: "Custom PyPI index URL (e.g., Azure Artifacts). If set, uploads to this instead of default PyPI/Fury"
+        required: false
+        default: ""
+        type: string
+      custom_pypi_token:
+        description: "Access token for the custom PyPI index"
+        required: false
+        default: ""
+        type: string
   pull_request:
     # This should trigger a dry run (we skip the final publish step)
     paths:
@@ -42,6 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
           lfs: true
       - name: Set up Python
@@ -51,14 +74,27 @@ jobs:
       - uses: ./.github/workflows/build_linux_wheel
         with:
           python-minor-version: 10
-          args: "--release --strip ${{ matrix.config.extra_args }}"
+          args: "--release ${{ (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && !inputs.debug)) && '--strip' || '' }} ${{ matrix.config.extra_args }}"
           arm-build: ${{ matrix.config.platform == 'aarch64' }}
           manylinux: ${{ matrix.config.manylinux }}
+      - name: Upload wheels as artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lancedb-debug-manylinux_${{ matrix.config.manylinux }}_${{ matrix.config.platform }}
+          path: target/wheels/*.whl
+          retention-days: 90
       - uses: ./.github/workflows/upload_wheel
         if: startsWith(github.ref, 'refs/tags/python-v')
         with:
           pypi_token: ${{ secrets.LANCEDB_PYPI_API_TOKEN }}
           fury_token: ${{ secrets.FURY_TOKEN }}
+      - uses: ./.github/workflows/upload_wheel
+        if: github.event_name == 'workflow_dispatch' && inputs.custom_pypi_url != ''
+        with:
+          repo: custom
+          custom_pypi_url: ${{ inputs.custom_pypi_url }}
+          custom_pypi_token: ${{ inputs.custom_pypi_token }}
   mac:
     timeout-minutes: 90
     runs-on: ${{ matrix.config.runner }}
@@ -72,6 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
           lfs: true
       - name: Set up Python
@@ -81,18 +118,32 @@ jobs:
       - uses: ./.github/workflows/build_mac_wheel
         with:
           python-minor-version: 10
-          args: "--release --strip --target ${{ matrix.config.target }} --features fp16kernels"
+          args: "--release ${{ (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && !inputs.debug)) && '--strip' || '' }} --target ${{ matrix.config.target }} --features fp16kernels"
+      - name: Upload wheels as artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lancedb-debug-macosx_arm64
+          path: target/wheels/*.whl
+          retention-days: 90
       - uses: ./.github/workflows/upload_wheel
         if: startsWith(github.ref, 'refs/tags/python-v')
         with:
           pypi_token: ${{ secrets.LANCEDB_PYPI_API_TOKEN }}
           fury_token: ${{ secrets.FURY_TOKEN }}
+      - uses: ./.github/workflows/upload_wheel
+        if: github.event_name == 'workflow_dispatch' && inputs.custom_pypi_url != ''
+        with:
+          repo: custom
+          custom_pypi_url: ${{ inputs.custom_pypi_url }}
+          custom_pypi_token: ${{ inputs.custom_pypi_token }}
   windows:
     timeout-minutes: 60
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
           lfs: true
       - name: Set up Python
@@ -102,13 +153,26 @@ jobs:
       - uses: ./.github/workflows/build_windows_wheel
         with:
           python-minor-version: 10
-          args: "--release --strip"
+          args: "--release ${{ (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && !inputs.debug)) && '--strip' || '' }}"
           vcpkg_token: ${{ secrets.VCPKG_GITHUB_PACKAGES }}
+      - name: Upload wheels as artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lancedb-debug-win_amd64
+          path: target/wheels/*.whl
+          retention-days: 90
       - uses: ./.github/workflows/upload_wheel
         if: startsWith(github.ref, 'refs/tags/python-v')
         with:
           pypi_token: ${{ secrets.LANCEDB_PYPI_API_TOKEN }}
           fury_token: ${{ secrets.FURY_TOKEN }}
+      - uses: ./.github/workflows/upload_wheel
+        if: github.event_name == 'workflow_dispatch' && inputs.custom_pypi_url != ''
+        with:
+          repo: custom
+          custom_pypi_url: ${{ inputs.custom_pypi_url }}
+          custom_pypi_token: ${{ inputs.custom_pypi_token }}
   gh-release:
     if: startsWith(github.ref, 'refs/tags/python-v')
     runs-on: ubuntu-latest
@@ -182,7 +246,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    if: always() && failure() && startsWith(github.ref, 'refs/tags/python-v')
+    if: always() && failure() && (startsWith(github.ref, 'refs/tags/python-v') || github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/create-failure-issue

--- a/.github/workflows/upload_wheel/action.yml
+++ b/.github/workflows/upload_wheel/action.yml
@@ -3,11 +3,21 @@ name: upload-wheel
 description: "Upload wheels to Pypi"
 inputs:
   pypi_token:
-    required: true
+    required: false
     description: "release token for the repo"
   fury_token:
-    required: true
+    required: false
     description: "release token for the fury repo"
+  repo:
+    required: false
+    description: "pypi, fury, or custom"
+    default: ""
+  custom_pypi_url:
+    required: false
+    description: "Custom PyPI index URL (e.g., Azure Artifacts)"
+  custom_pypi_token:
+    required: false
+    description: "Access token for the custom PyPI index"
 
 runs:
   using: "composite"
@@ -22,7 +32,9 @@ runs:
     shell: bash
     id: choose_repo
     run: |
-      if [[ ${{ github.ref }} == *beta* ]]; then
+      if [[ -n "${{ inputs.repo }}" ]]; then
+        echo "repo=${{ inputs.repo }}" >> $GITHUB_OUTPUT
+      elif [[ ${{ github.ref }} == *beta* ]]; then
         echo "repo=fury" >> $GITHUB_OUTPUT
       else
         echo "repo=pypi" >> $GITHUB_OUTPUT
@@ -32,11 +44,19 @@ runs:
     env:
       FURY_TOKEN: ${{ inputs.fury_token }}
       PYPI_TOKEN: ${{ inputs.pypi_token }}
+      CUSTOM_PYPI_URL: ${{ inputs.custom_pypi_url }}
+      CUSTOM_PYPI_TOKEN: ${{ inputs.custom_pypi_token }}
     run: |
       if [[ ${{ steps.choose_repo.outputs.repo }} == fury ]]; then
         WHEEL=$(ls target/wheels/lancedb-*.whl 2> /dev/null | head -n 1)
         echo "Uploading $WHEEL to Fury"
         curl -f -F package=@$WHEEL https://$FURY_TOKEN@push.fury.io/lancedb/
+      elif [[ ${{ steps.choose_repo.outputs.repo }} == custom ]]; then
+        echo "Uploading to custom PyPI index: $CUSTOM_PYPI_URL"
+        twine upload --repository-url "$CUSTOM_PYPI_URL" \
+          --username __token__ \
+          --password "$CUSTOM_PYPI_TOKEN" \
+          target/wheels/lancedb-*.whl
       else
         twine upload --repository ${{ steps.choose_repo.outputs.repo }} \
           --username __token__ \


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to `pypi-publish.yml` enabling manual workflow runs
- Add inputs for specifying git ref, debug mode, and custom PyPI repository credentials
- Update `upload_wheel` action to support custom PyPI uploads via twine
- Upload wheel artifacts when triggered via workflow_dispatch for easier debugging

This enables manually triggering wheel builds and uploading them to a custom PyPI repository (e.g., Azure Artifacts) instead of the default PyPI/Fury.

🤖 Generated with [Claude Code](https://claude.com/claude-code)