### PR TITLE
ci: add top-level permissions to GHA workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -19,6 +19,9 @@ on:
     paths:
       - .github/workflows/java-publish.yml
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build and Publish

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -24,6 +24,9 @@ on:
       - java/**
       - .github/workflows/java.yml
 
+permissions:
+  contents: read
+
 jobs:
   build-java:
     runs-on: ubuntu-24.04

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -10,6 +10,10 @@ on:
       - nodejs/**
       - java/**
       - .github/workflows/license-header-check.yml
+
+permissions:
+  contents: read
+
 jobs:
   check-licenses:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,9 @@ on:
       - .github/workflows/nodejs.yml
       - docker-compose.yml
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,6 +13,9 @@ on:
 env:
   PIP_EXTRA_INDEX_URL: "https://pypi.fury.io/lance-format/ https://pypi.fury.io/lancedb/"
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Python ${{ matrix.config.platform }} manylinux${{ matrix.config.manylinux }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,9 @@ on:
       - python/**
       - .github/workflows/python.yml
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ on:
       - rust/**
       - .github/workflows/rust.yml
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/update_package_lock_run.yml
+++ b/.github/workflows/update_package_lock_run.yml
@@ -3,6 +3,9 @@ name: Update package-lock.json
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_package_lock_run_nodejs.yml
+++ b/.github/workflows/update_package_lock_run_nodejs.yml
@@ -3,6 +3,9 @@ name: Update NodeJs package-lock.json
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the 10 workflows that had no top-level permissions block. Workflows that already declared permissions, or individual jobs that need elevated permissions (`issues: write`, `pull-requests: write`, `contents: write`), are left unchanged.

Affected workflows: `dev.yml`, `java-publish.yml`, `java.yml`, `license-header-check.yml`, `nodejs.yml`, `pypi-publish.yml`, `python.yml`, `rust.yml`, `update_package_lock_run.yml`, `update_package_lock_run_nodejs.yml`