### PR TITLE
feat(python): support child namepsace operations and json serialization for LanceDBConnection

### DIFF
--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -232,7 +232,7 @@ def _apply_worker_overrides(props: dict[str, str]) -> dict[str, str]:
     result = dict(props)
     for key in worker_keys:
         value = result.pop(key)
-        real_key = key[len(WORKER_PROPERTY_PREFIX):]
+        real_key = key[len(WORKER_PROPERTY_PREFIX) :]
         result[real_key] = value
     return result
 

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -237,20 +237,20 @@ def _apply_worker_overrides(props: dict[str, str]) -> dict[str, str]:
     return result
 
 
-def from_serialized_json(
-    json_str: str,
+def deserialize(
+    data: str,
     *,
     for_worker: bool = False,
 ) -> DBConnection:
-    """Reconstruct a DBConnection from a JSON string.
+    """Reconstruct a DBConnection from a serialized string.
 
-    The JSON string must have been produced by
-    :meth:`DBConnection.serialize_to_json`.
+    The string must have been produced by
+    :meth:`DBConnection.serialize`.
 
     Parameters
     ----------
-    json_str : str
-        JSON string produced by ``serialize_to_json()``.
+    data : str
+        String produced by ``serialize()``.
     for_worker : bool, default False
         When ``True``, any namespace client property whose key starts
         with ``_lancedb_worker_`` has that prefix stripped and the
@@ -264,27 +264,27 @@ def from_serialized_json(
     """
     import json
 
-    data = json.loads(json_str)
-    connection_type = data.get("connection_type")
+    parsed = json.loads(data)
+    connection_type = parsed.get("connection_type")
 
-    rci_secs = data.get("read_consistency_interval_seconds")
+    rci_secs = parsed.get("read_consistency_interval_seconds")
     rci = timedelta(seconds=rci_secs) if rci_secs is not None else None
-    storage_options = data.get("storage_options")
+    storage_options = parsed.get("storage_options")
 
     if connection_type == "namespace":
-        props = dict(data.get("namespace_client_properties") or {})
+        props = dict(parsed.get("namespace_client_properties") or {})
         if for_worker:
             props = _apply_worker_overrides(props)
         return connect_namespace(
-            namespace_client_impl=data["namespace_client_impl"],
+            namespace_client_impl=parsed["namespace_client_impl"],
             namespace_client_properties=props,
             read_consistency_interval=rci,
             storage_options=storage_options,
-            namespace_client_pushdown_operations=data.get("pushdown_operations"),
+            namespace_client_pushdown_operations=parsed.get("pushdown_operations"),
         )
     elif connection_type == "local":
         return LanceDBConnection(
-            data["uri"],
+            parsed["uri"],
             read_consistency_interval=rci,
             storage_options=storage_options,
         )

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -237,7 +237,7 @@ def _apply_worker_overrides(props: dict[str, str]) -> dict[str, str]:
     return result
 
 
-def deserialize(
+def deserialize_conn(
     data: str,
     *,
     for_worker: bool = False,
@@ -280,7 +280,9 @@ def deserialize(
             namespace_client_properties=props,
             read_consistency_interval=rci,
             storage_options=storage_options,
-            namespace_client_pushdown_operations=parsed.get("pushdown_operations"),
+            namespace_client_pushdown_operations=parsed.get(
+                "namespace_client_pushdown_operations"
+            ),
         )
     elif connection_type == "local":
         return LanceDBConnection(

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -215,6 +215,65 @@ def connect(
     )
 
 
+WORKER_URI_KEY = "worker_uri"
+
+
+def from_serialized_json(
+    json_str: str,
+    *,
+    for_worker: bool = False,
+) -> DBConnection:
+    """Reconstruct a DBConnection from a JSON string.
+
+    The JSON string must have been produced by
+    :meth:`DBConnection.serialize_to_json`.
+
+    Parameters
+    ----------
+    json_str : str
+        JSON string produced by ``serialize_to_json()``.
+    for_worker : bool, default False
+        When ``True`` and the serialized connection contains a
+        ``worker_uri`` key in its namespace properties, the worker URI
+        replaces the primary ``uri`` before the connection is created.
+        This allows remote workers to connect via an internal endpoint.
+
+    Returns
+    -------
+    DBConnection
+        A new connection matching the serialized state.
+    """
+    import json
+
+    data = json.loads(json_str)
+    connection_type = data.get("connection_type")
+
+    rci_secs = data.get("read_consistency_interval_seconds")
+    rci = timedelta(seconds=rci_secs) if rci_secs is not None else None
+    storage_options = data.get("storage_options")
+
+    if connection_type == "namespace":
+        props = dict(data.get("namespace_client_properties") or {})
+        if for_worker and WORKER_URI_KEY in props:
+            worker_uri = props.pop(WORKER_URI_KEY)
+            props["uri"] = worker_uri
+        return connect_namespace(
+            namespace_client_impl=data["namespace_client_impl"],
+            namespace_client_properties=props,
+            read_consistency_interval=rci,
+            storage_options=storage_options,
+            namespace_client_pushdown_operations=data.get("pushdown_operations"),
+        )
+    elif connection_type == "local":
+        return LanceDBConnection(
+            data["uri"],
+            read_consistency_interval=rci,
+            storage_options=storage_options,
+        )
+    else:
+        raise ValueError(f"Unknown connection_type: {connection_type}")
+
+
 async def connect_async(
     uri: URI,
     *,

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -215,7 +215,26 @@ def connect(
     )
 
 
-WORKER_URI_KEY = "worker_uri"
+WORKER_PROPERTY_PREFIX = "_lancedb_worker_"
+
+
+def _apply_worker_overrides(props: dict[str, str]) -> dict[str, str]:
+    """Apply worker property overrides.
+
+    Any key starting with ``_lancedb_worker_`` is extracted, the prefix
+    is stripped, and the resulting key-value pair is put back into the
+    map (overriding the existing value if present).  The original
+    prefixed key is removed.
+    """
+    worker_keys = [k for k in props if k.startswith(WORKER_PROPERTY_PREFIX)]
+    if not worker_keys:
+        return props
+    result = dict(props)
+    for key in worker_keys:
+        value = result.pop(key)
+        real_key = key[len(WORKER_PROPERTY_PREFIX):]
+        result[real_key] = value
+    return result
 
 
 def from_serialized_json(
@@ -233,10 +252,10 @@ def from_serialized_json(
     json_str : str
         JSON string produced by ``serialize_to_json()``.
     for_worker : bool, default False
-        When ``True`` and the serialized connection contains a
-        ``worker_uri`` key in its namespace properties, the worker URI
-        replaces the primary ``uri`` before the connection is created.
-        This allows remote workers to connect via an internal endpoint.
+        When ``True``, any namespace client property whose key starts
+        with ``_lancedb_worker_`` has that prefix stripped and the
+        value overrides the corresponding property.  For example,
+        ``_lancedb_worker_uri`` replaces ``uri``.
 
     Returns
     -------
@@ -254,9 +273,8 @@ def from_serialized_json(
 
     if connection_type == "namespace":
         props = dict(data.get("namespace_client_properties") or {})
-        if for_worker and WORKER_URI_KEY in props:
-            worker_uri = props.pop(WORKER_URI_KEY)
-            props["uri"] = worker_uri
+        if for_worker:
+            props = _apply_worker_overrides(props)
         return connect_namespace(
             namespace_client_impl=data["namespace_client_impl"],
             namespace_client_properties=props,

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -529,19 +529,19 @@ class DBConnection(EnforceOverrides):
             "namespace_client is not supported for this connection type"
         )
 
-    def serialize_to_json(self) -> str:
-        """Serialize this connection to a JSON string for reconstruction.
+    def serialize(self) -> str:
+        """Serialize this connection for reconstruction.
 
-        The returned JSON can be passed to :func:`from_serialized_json`
+        The returned string can be passed to :func:`lancedb.deserialize`
         to recreate an equivalent connection, e.g. in a remote worker.
 
         Returns
         -------
         str
-            JSON string representation of this connection.
+            Serialized representation of this connection.
         """
         raise NotImplementedError(
-            "serialize_to_json is not supported for this connection type"
+            "serialize is not supported for this connection type"
         )
 
 
@@ -670,7 +670,7 @@ class LanceDBConnection(DBConnection):
         return val
 
     @override
-    def serialize_to_json(self) -> str:
+    def serialize(self) -> str:
         import json
 
         rci = self.read_consistency_interval

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -532,7 +532,7 @@ class DBConnection(EnforceOverrides):
     def serialize(self) -> str:
         """Serialize this connection for reconstruction.
 
-        The returned string can be passed to :func:`lancedb.deserialize`
+        The returned string can be passed to :func:`lancedb.deserialize_conn`
         to recreate an equivalent connection, e.g. in a remote worker.
 
         Returns

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -718,18 +718,10 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        if namespace_path:
-            return self._namespace_conn().list_namespaces(
-                namespace_path=namespace_path,
-                page_token=page_token,
-                limit=limit,
-            )
-        return LOOP.run(
-            self._conn.list_namespaces(
-                namespace_path=namespace_path,
-                page_token=page_token,
-                limit=limit,
-            )
+        return self._namespace_conn().list_namespaces(
+            namespace_path=namespace_path,
+            page_token=page_token,
+            limit=limit,
         )
 
     @override

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -596,6 +596,7 @@ class LanceDBConnection(DBConnection):
     ):
         if _inner is not None:
             self._conn = _inner
+            self._cached_namespace_client = None
             return
 
         if not isinstance(uri, Path):
@@ -643,6 +644,7 @@ class LanceDBConnection(DBConnection):
         # beyond _conn.
         self.storage_options = storage_options
         self._conn = AsyncConnection(LOOP.run(do_connect()))
+        self._cached_namespace_client: Optional[LanceNamespace] = None
 
     @property
     def read_consistency_interval(self) -> Optional[timedelta]:
@@ -714,11 +716,13 @@ class LanceDBConnection(DBConnection):
         ListNamespacesResponse
             Response containing namespace names and optional page_token for pagination.
         """
+        from lance_namespace import ListNamespacesRequest
+
         if namespace_path is None:
             namespace_path = []
-        return LOOP.run(
-            self._conn.list_namespaces(
-                namespace_path=namespace_path, page_token=page_token, limit=limit
+        return self.namespace_client().list_namespaces(
+            ListNamespacesRequest(
+                id=namespace_path, page_token=page_token, limit=limit
             )
         )
 
@@ -746,11 +750,15 @@ class LanceDBConnection(DBConnection):
         CreateNamespaceResponse
             Response containing the properties of the created namespace.
         """
-        return LOOP.run(
-            self._conn.create_namespace(
-                namespace_path=namespace_path, mode=mode, properties=properties
-            )
+        from lance_namespace import CreateNamespaceRequest
+        from lancedb.namespace_utils import _normalize_create_namespace_mode
+
+        req = CreateNamespaceRequest(
+            id=namespace_path,
+            mode=_normalize_create_namespace_mode(mode),
+            properties=properties,
         )
+        return self.namespace_client().create_namespace(req)
 
     @override
     def drop_namespace(
@@ -776,11 +784,18 @@ class LanceDBConnection(DBConnection):
         DropNamespaceResponse
             Response containing properties and transaction_id if applicable.
         """
-        return LOOP.run(
-            self._conn.drop_namespace(
-                namespace_path=namespace_path, mode=mode, behavior=behavior
-            )
+        from lance_namespace import DropNamespaceRequest
+        from lancedb.namespace_utils import (
+            _normalize_drop_namespace_behavior,
+            _normalize_drop_namespace_mode,
         )
+
+        req = DropNamespaceRequest(
+            id=namespace_path,
+            mode=_normalize_drop_namespace_mode(mode),
+            behavior=_normalize_drop_namespace_behavior(behavior),
+        )
+        return self.namespace_client().drop_namespace(req)
 
     @override
     def describe_namespace(
@@ -798,7 +813,11 @@ class LanceDBConnection(DBConnection):
         DescribeNamespaceResponse
             Response containing the namespace properties.
         """
-        return LOOP.run(self._conn.describe_namespace(namespace_path=namespace_path))
+        from lance_namespace import DescribeNamespaceRequest
+
+        return self.namespace_client().describe_namespace(
+            DescribeNamespaceRequest(id=namespace_path)
+        )
 
     @override
     def list_tables(
@@ -827,6 +846,14 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
+        if namespace_path:
+            from lance_namespace import ListTablesRequest
+
+            return self.namespace_client().list_tables(
+                ListTablesRequest(
+                    id=namespace_path, page_token=page_token, limit=limit
+                )
+            )
         return LOOP.run(
             self._conn.list_tables(
                 namespace_path=namespace_path, page_token=page_token, limit=limit
@@ -915,6 +942,22 @@ class LanceDBConnection(DBConnection):
             raise ValueError("mode must be either 'create' or 'overwrite'")
         validate_table_name(name)
 
+        if namespace_path:
+            return self._create_table_via_namespace(
+                name,
+                data=data,
+                schema=schema,
+                mode=mode,
+                exist_ok=exist_ok,
+                on_bad_vectors=on_bad_vectors,
+                fill_value=fill_value,
+                embedding_functions=embedding_functions,
+                namespace_path=namespace_path,
+                storage_options=storage_options,
+                data_storage_version=data_storage_version,
+                enable_v2_manifest_paths=enable_v2_manifest_paths,
+            )
+
         tbl = LanceTable.create(
             self,
             name,
@@ -929,6 +972,48 @@ class LanceDBConnection(DBConnection):
             storage_options=storage_options,
         )
         return tbl
+
+    def _create_table_via_namespace(
+        self,
+        name: str,
+        *,
+        data: Optional[DATA] = None,
+        schema: Optional[Union[pa.Schema, LanceModel]] = None,
+        mode: str = "create",
+        exist_ok: bool = False,
+        on_bad_vectors: str = "error",
+        fill_value: float = 0.0,
+        embedding_functions: Optional[List[EmbeddingFunctionConfig]] = None,
+        namespace_path: List[str],
+        storage_options: Optional[Dict[str, str]] = None,
+        data_storage_version: Optional[str] = None,
+        enable_v2_manifest_paths: Optional[bool] = None,
+    ) -> LanceTable:
+        """Create a table through the directory namespace client."""
+        from lancedb.namespace import LanceNamespaceDBConnection
+
+        ns_client = self.namespace_client()
+        ns_conn = LanceNamespaceDBConnection(
+            ns_client,
+            read_consistency_interval=self.read_consistency_interval,
+            storage_options=self.storage_options,
+            namespace_client_impl=None,
+            namespace_client_properties=None,
+        )
+        return ns_conn.create_table(
+            name,
+            data=data,
+            schema=schema,
+            mode=mode,
+            exist_ok=exist_ok,
+            on_bad_vectors=on_bad_vectors,
+            fill_value=fill_value,
+            embedding_functions=embedding_functions,
+            namespace_path=namespace_path,
+            storage_options=storage_options,
+            data_storage_version=data_storage_version,
+            enable_v2_manifest_paths=enable_v2_manifest_paths,
+        )
 
     @override
     def open_table(
@@ -946,7 +1031,8 @@ class LanceDBConnection(DBConnection):
         name: str
             The name of the table.
         namespace_path: List[str], optional
-            The namespace to open the table from.
+            The namespace to open the table from.  When non-empty, the
+            table is resolved through the directory namespace client.
 
         Returns
         -------
@@ -965,12 +1051,59 @@ class LanceDBConnection(DBConnection):
                 stacklevel=2,
             )
 
+        if namespace_path:
+            return self._open_table_via_namespace(
+                name,
+                namespace_path=namespace_path,
+                storage_options=storage_options,
+                index_cache_size=index_cache_size,
+            )
+
         return LanceTable.open(
             self,
             name,
             namespace_path=namespace_path,
             storage_options=storage_options,
             index_cache_size=index_cache_size,
+        )
+
+    def _open_table_via_namespace(
+        self,
+        name: str,
+        *,
+        namespace_path: List[str],
+        storage_options: Optional[Dict[str, str]] = None,
+        index_cache_size: Optional[int] = None,
+    ) -> LanceTable:
+        """Open a table through the directory namespace client."""
+        from lance_namespace import DescribeTableRequest
+
+        ns_client = self.namespace_client()
+        table_id = namespace_path + [name]
+        response = ns_client.describe_table(DescribeTableRequest(id=table_id))
+
+        merged = dict(self.storage_options or {})
+        if storage_options:
+            merged.update(storage_options)
+        if response.storage_options:
+            merged.update(response.storage_options)
+
+        managed_versioning = response.managed_versioning is True
+
+        temp_conn = LanceDBConnection(
+            response.location,
+            read_consistency_interval=self.read_consistency_interval,
+            storage_options=merged or None,
+        )
+        return LanceTable.open(
+            temp_conn,
+            name,
+            namespace_path=namespace_path,
+            storage_options=merged or None,
+            index_cache_size=index_cache_size,
+            location=response.location,
+            namespace_client=ns_client,
+            managed_versioning=managed_versioning,
         )
 
     def clone_table(
@@ -1049,6 +1182,13 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
+        if namespace_path:
+            from lance_namespace import DropTableRequest
+
+            self.namespace_client().drop_table(
+                DropTableRequest(id=namespace_path + [name])
+            )
+            return
         LOOP.run(
             self._conn.drop_table(
                 name, namespace_path=namespace_path, ignore_missing=ignore_missing
@@ -1100,14 +1240,19 @@ class LanceDBConnection(DBConnection):
         """Get the equivalent namespace client for this connection.
 
         Returns a DirectoryNamespace pointing to the same root with the
-        same storage options.
+        same storage options.  The result is cached for the lifetime of
+        this connection.
 
         Returns
         -------
         LanceNamespace
             The namespace client for this connection.
         """
-        return LOOP.run(self._conn.namespace_client())
+        if self._cached_namespace_client is None:
+            self._cached_namespace_client = LOOP.run(
+                self._conn.namespace_client()
+            )
+        return self._cached_namespace_client
 
     @deprecation.deprecated(
         deprecated_in="0.15.1",

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -529,6 +529,21 @@ class DBConnection(EnforceOverrides):
             "namespace_client is not supported for this connection type"
         )
 
+    def serialize_to_json(self) -> str:
+        """Serialize this connection to a JSON string for reconstruction.
+
+        The returned JSON can be passed to :func:`from_serialized_json`
+        to recreate an equivalent connection, e.g. in a remote worker.
+
+        Returns
+        -------
+        str
+            JSON string representation of this connection.
+        """
+        raise NotImplementedError(
+            "serialize_to_json is not supported for this connection type"
+        )
+
 
 class LanceDBConnection(DBConnection):
     """
@@ -651,6 +666,20 @@ class LanceDBConnection(DBConnection):
             val += f", read_consistency_interval={repr(self.read_consistency_interval)}"
         val += ")"
         return val
+
+    @override
+    def serialize_to_json(self) -> str:
+        import json
+
+        rci = self.read_consistency_interval
+        return json.dumps({
+            "connection_type": "local",
+            "uri": self.uri,
+            "storage_options": self.storage_options,
+            "read_consistency_interval_seconds": (
+                rci.total_seconds() if rci else None
+            ),
+        })
 
     async def _async_get_table_names(self, start_after: Optional[str], limit: int):
         conn = AsyncConnection(await lancedb_connect(self.uri))

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -540,9 +540,7 @@ class DBConnection(EnforceOverrides):
         str
             Serialized representation of this connection.
         """
-        raise NotImplementedError(
-            "serialize is not supported for this connection type"
-        )
+        raise NotImplementedError("serialize is not supported for this connection type")
 
 
 class LanceDBConnection(DBConnection):
@@ -674,14 +672,16 @@ class LanceDBConnection(DBConnection):
         import json
 
         rci = self.read_consistency_interval
-        return json.dumps({
-            "connection_type": "local",
-            "uri": self.uri,
-            "storage_options": self.storage_options,
-            "read_consistency_interval_seconds": (
-                rci.total_seconds() if rci else None
-            ),
-        })
+        return json.dumps(
+            {
+                "connection_type": "local",
+                "uri": self.uri,
+                "storage_options": self.storage_options,
+                "read_consistency_interval_seconds": (
+                    rci.total_seconds() if rci else None
+                ),
+            }
+        )
 
     async def _async_get_table_names(self, start_after: Optional[str], limit: int):
         conn = AsyncConnection(await lancedb_connect(self.uri))
@@ -918,7 +918,7 @@ class LanceDBConnection(DBConnection):
         )
         return tbl
 
-    def _namespace_conn(self) -> "LanceNamespaceDBConnection":
+    def _namespace_conn(self) -> DBConnection:
         """Return a LanceNamespaceDBConnection backed by this connection's
         directory namespace.  Used to delegate child-namespace operations."""
         from lancedb.namespace import LanceNamespaceDBConnection
@@ -1122,9 +1122,7 @@ class LanceDBConnection(DBConnection):
             The namespace client for this connection.
         """
         if self._cached_namespace_client is None:
-            self._cached_namespace_client = LOOP.run(
-                self._conn.namespace_client()
-            )
+            self._cached_namespace_client = LOOP.run(self._conn.namespace_client())
         return self._cached_namespace_client
 
     @deprecation.deprecated(

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -718,10 +718,18 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        return self._namespace_conn().list_namespaces(
-            namespace_path=namespace_path,
-            page_token=page_token,
-            limit=limit,
+        if namespace_path:
+            return self._namespace_conn().list_namespaces(
+                namespace_path=namespace_path,
+                page_token=page_token,
+                limit=limit,
+            )
+        return LOOP.run(
+            self._conn.list_namespaces(
+                namespace_path=namespace_path,
+                page_token=page_token,
+                limit=limit,
+            )
         )
 
     @override

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -716,14 +716,12 @@ class LanceDBConnection(DBConnection):
         ListNamespacesResponse
             Response containing namespace names and optional page_token for pagination.
         """
-        from lance_namespace import ListNamespacesRequest
-
         if namespace_path is None:
             namespace_path = []
-        return self.namespace_client().list_namespaces(
-            ListNamespacesRequest(
-                id=namespace_path, page_token=page_token, limit=limit
-            )
+        return self._namespace_conn().list_namespaces(
+            namespace_path=namespace_path,
+            page_token=page_token,
+            limit=limit,
         )
 
     @override
@@ -733,32 +731,11 @@ class LanceDBConnection(DBConnection):
         mode: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -> CreateNamespaceResponse:
-        """Create a new namespace.
-
-        Parameters
-        ----------
-        namespace_path: List[str]
-            The namespace identifier to create.
-        mode: str, optional
-            Creation mode - "create" (fail if exists), "exist_ok" (skip if exists),
-            or "overwrite" (replace if exists). Case insensitive.
-        properties: Dict[str, str], optional
-            Properties to set on the namespace.
-
-        Returns
-        -------
-        CreateNamespaceResponse
-            Response containing the properties of the created namespace.
-        """
-        from lance_namespace import CreateNamespaceRequest
-        from lancedb.namespace_utils import _normalize_create_namespace_mode
-
-        req = CreateNamespaceRequest(
-            id=namespace_path,
-            mode=_normalize_create_namespace_mode(mode),
+        return self._namespace_conn().create_namespace(
+            namespace_path=namespace_path,
+            mode=mode,
             properties=properties,
         )
-        return self.namespace_client().create_namespace(req)
 
     @override
     def drop_namespace(
@@ -767,56 +744,18 @@ class LanceDBConnection(DBConnection):
         mode: Optional[str] = None,
         behavior: Optional[str] = None,
     ) -> DropNamespaceResponse:
-        """Drop a namespace.
-
-        Parameters
-        ----------
-        namespace_path: List[str]
-            The namespace identifier to drop.
-        mode: str, optional
-            Whether to skip if not exists ("SKIP") or fail ("FAIL"). Case insensitive.
-        behavior: str, optional
-            Whether to restrict drop if not empty ("RESTRICT") or cascade ("CASCADE").
-            Case insensitive.
-
-        Returns
-        -------
-        DropNamespaceResponse
-            Response containing properties and transaction_id if applicable.
-        """
-        from lance_namespace import DropNamespaceRequest
-        from lancedb.namespace_utils import (
-            _normalize_drop_namespace_behavior,
-            _normalize_drop_namespace_mode,
+        return self._namespace_conn().drop_namespace(
+            namespace_path=namespace_path,
+            mode=mode,
+            behavior=behavior,
         )
-
-        req = DropNamespaceRequest(
-            id=namespace_path,
-            mode=_normalize_drop_namespace_mode(mode),
-            behavior=_normalize_drop_namespace_behavior(behavior),
-        )
-        return self.namespace_client().drop_namespace(req)
 
     @override
     def describe_namespace(
         self, namespace_path: List[str]
     ) -> DescribeNamespaceResponse:
-        """Describe a namespace.
-
-        Parameters
-        ----------
-        namespace_path: List[str]
-            The namespace identifier to describe.
-
-        Returns
-        -------
-        DescribeNamespaceResponse
-            Response containing the namespace properties.
-        """
-        from lance_namespace import DescribeNamespaceRequest
-
-        return self.namespace_client().describe_namespace(
-            DescribeNamespaceRequest(id=namespace_path)
+        return self._namespace_conn().describe_namespace(
+            namespace_path=namespace_path,
         )
 
     @override
@@ -847,12 +786,10 @@ class LanceDBConnection(DBConnection):
         if namespace_path is None:
             namespace_path = []
         if namespace_path:
-            from lance_namespace import ListTablesRequest
-
-            return self.namespace_client().list_tables(
-                ListTablesRequest(
-                    id=namespace_path, page_token=page_token, limit=limit
-                )
+            return self._namespace_conn().list_tables(
+                namespace_path=namespace_path,
+                page_token=page_token,
+                limit=limit,
             )
         return LOOP.run(
             self._conn.list_tables(
@@ -943,7 +880,7 @@ class LanceDBConnection(DBConnection):
         validate_table_name(name)
 
         if namespace_path:
-            return self._create_table_via_namespace(
+            return self._namespace_conn().create_table(
                 name,
                 data=data,
                 schema=schema,
@@ -973,46 +910,17 @@ class LanceDBConnection(DBConnection):
         )
         return tbl
 
-    def _create_table_via_namespace(
-        self,
-        name: str,
-        *,
-        data: Optional[DATA] = None,
-        schema: Optional[Union[pa.Schema, LanceModel]] = None,
-        mode: str = "create",
-        exist_ok: bool = False,
-        on_bad_vectors: str = "error",
-        fill_value: float = 0.0,
-        embedding_functions: Optional[List[EmbeddingFunctionConfig]] = None,
-        namespace_path: List[str],
-        storage_options: Optional[Dict[str, str]] = None,
-        data_storage_version: Optional[str] = None,
-        enable_v2_manifest_paths: Optional[bool] = None,
-    ) -> LanceTable:
-        """Create a table through the directory namespace client."""
+    def _namespace_conn(self) -> "LanceNamespaceDBConnection":
+        """Return a LanceNamespaceDBConnection backed by this connection's
+        directory namespace.  Used to delegate child-namespace operations."""
         from lancedb.namespace import LanceNamespaceDBConnection
 
-        ns_client = self.namespace_client()
-        ns_conn = LanceNamespaceDBConnection(
-            ns_client,
+        return LanceNamespaceDBConnection(
+            self.namespace_client(),
             read_consistency_interval=self.read_consistency_interval,
             storage_options=self.storage_options,
             namespace_client_impl=None,
             namespace_client_properties=None,
-        )
-        return ns_conn.create_table(
-            name,
-            data=data,
-            schema=schema,
-            mode=mode,
-            exist_ok=exist_ok,
-            on_bad_vectors=on_bad_vectors,
-            fill_value=fill_value,
-            embedding_functions=embedding_functions,
-            namespace_path=namespace_path,
-            storage_options=storage_options,
-            data_storage_version=data_storage_version,
-            enable_v2_manifest_paths=enable_v2_manifest_paths,
         )
 
     @override
@@ -1052,7 +960,7 @@ class LanceDBConnection(DBConnection):
             )
 
         if namespace_path:
-            return self._open_table_via_namespace(
+            return self._namespace_conn().open_table(
                 name,
                 namespace_path=namespace_path,
                 storage_options=storage_options,
@@ -1065,45 +973,6 @@ class LanceDBConnection(DBConnection):
             namespace_path=namespace_path,
             storage_options=storage_options,
             index_cache_size=index_cache_size,
-        )
-
-    def _open_table_via_namespace(
-        self,
-        name: str,
-        *,
-        namespace_path: List[str],
-        storage_options: Optional[Dict[str, str]] = None,
-        index_cache_size: Optional[int] = None,
-    ) -> LanceTable:
-        """Open a table through the directory namespace client."""
-        from lance_namespace import DescribeTableRequest
-
-        ns_client = self.namespace_client()
-        table_id = namespace_path + [name]
-        response = ns_client.describe_table(DescribeTableRequest(id=table_id))
-
-        merged = dict(self.storage_options or {})
-        if storage_options:
-            merged.update(storage_options)
-        if response.storage_options:
-            merged.update(response.storage_options)
-
-        managed_versioning = response.managed_versioning is True
-
-        temp_conn = LanceDBConnection(
-            response.location,
-            read_consistency_interval=self.read_consistency_interval,
-            storage_options=merged or None,
-        )
-        return LanceTable.open(
-            temp_conn,
-            name,
-            namespace_path=namespace_path,
-            storage_options=merged or None,
-            index_cache_size=index_cache_size,
-            location=response.location,
-            namespace_client=ns_client,
-            managed_versioning=managed_versioning,
         )
 
     def clone_table(
@@ -1183,11 +1052,7 @@ class LanceDBConnection(DBConnection):
         if namespace_path is None:
             namespace_path = []
         if namespace_path:
-            from lance_namespace import DropTableRequest
-
-            self.namespace_client().drop_table(
-                DropTableRequest(id=namespace_path + [name])
-            )
+            self._namespace_conn().drop_table(name, namespace_path=namespace_path)
             return
         LOOP.run(
             self._conn.drop_table(

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -381,6 +381,8 @@ class LanceNamespaceDBConnection(DBConnection):
         storage_options: Optional[Dict[str, str]] = None,
         session: Optional[Session] = None,
         namespace_client_pushdown_operations: Optional[List[str]] = None,
+        namespace_client_impl: Optional[str] = None,
+        namespace_client_properties: Optional[Dict[str, str]] = None,
     ):
         """
         Initialize a namespace-based LanceDB connection.
@@ -406,12 +408,37 @@ class LanceNamespaceDBConnection(DBConnection):
               namespace.create_table() instead of using declare_table + local write.
 
             Default is None (no pushdown, all operations run locally).
+        namespace_client_impl : Optional[str]
+            The namespace implementation name used to create this connection.
+            Stored for serialization purposes.
+        namespace_client_properties : Optional[Dict[str, str]]
+            The namespace properties used to create this connection.
+            Stored for serialization purposes.
         """
         self._namespace_client = namespace_client
         self.read_consistency_interval = read_consistency_interval
         self.storage_options = storage_options or {}
         self.session = session
         self._pushdown_operations = set(namespace_client_pushdown_operations or [])
+        self._namespace_client_impl = namespace_client_impl
+        self._namespace_client_properties = namespace_client_properties
+
+    @override
+    def serialize_to_json(self) -> str:
+        import json
+
+        return json.dumps({
+            "connection_type": "namespace",
+            "namespace_client_impl": self._namespace_client_impl,
+            "namespace_client_properties": self._namespace_client_properties,
+            "pushdown_operations": sorted(self._pushdown_operations),
+            "storage_options": self.storage_options or None,
+            "read_consistency_interval_seconds": (
+                self.read_consistency_interval.total_seconds()
+                if self.read_consistency_interval
+                else None
+            ),
+        })
 
     @override
     def table_names(
@@ -1472,6 +1499,8 @@ def connect_namespace(
         storage_options=storage_options,
         session=session,
         namespace_client_pushdown_operations=namespace_client_pushdown_operations,
+        namespace_client_impl=namespace_client_impl,
+        namespace_client_properties=namespace_client_properties,
     )
 
 

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -607,10 +607,13 @@ class LanceNamespaceDBConnection(DBConnection):
             fill_value=fill_value,
         )
 
+        merged = dict(self.storage_options or {})
+        if storage_options:
+            merged.update(storage_options)
         request = CreateTableRequest(
             id=table_id,
             mode=_normalize_create_table_mode(mode),
-            properties=self.storage_options if self.storage_options else None,
+            properties=merged or None,
         )
 
         try:
@@ -1147,10 +1150,13 @@ class AsyncLanceNamespaceDBConnection:
                 fill_value=fill_value,
             )
 
+            merged = dict(self.storage_options or {})
+            if storage_options:
+                merged.update(storage_options)
             request = CreateTableRequest(
                 id=table_id,
                 mode=_normalize_create_table_mode(mode),
-                properties=self.storage_options if self.storage_options else None,
+                properties=merged or None,
             )
 
             self._namespace_client.create_table(request, arrow_ipc_bytes)

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -424,7 +424,7 @@ class LanceNamespaceDBConnection(DBConnection):
         self._namespace_client_properties = namespace_client_properties
 
     @override
-    def serialize_to_json(self) -> str:
+    def serialize(self) -> str:
         import json
 
         return json.dumps({

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -427,18 +427,20 @@ class LanceNamespaceDBConnection(DBConnection):
     def serialize(self) -> str:
         import json
 
-        return json.dumps({
-            "connection_type": "namespace",
-            "namespace_client_impl": self._namespace_client_impl,
-            "namespace_client_properties": self._namespace_client_properties,
-            "pushdown_operations": sorted(self._pushdown_operations),
-            "storage_options": self.storage_options or None,
-            "read_consistency_interval_seconds": (
-                self.read_consistency_interval.total_seconds()
-                if self.read_consistency_interval
-                else None
-            ),
-        })
+        return json.dumps(
+            {
+                "connection_type": "namespace",
+                "namespace_client_impl": self._namespace_client_impl,
+                "namespace_client_properties": self._namespace_client_properties,
+                "pushdown_operations": sorted(self._pushdown_operations),
+                "storage_options": self.storage_options or None,
+                "read_consistency_interval_seconds": (
+                    self.read_consistency_interval.total_seconds()
+                    if self.read_consistency_interval
+                    else None
+                ),
+            }
+        )
 
     @override
     def table_names(

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -419,7 +419,9 @@ class LanceNamespaceDBConnection(DBConnection):
         self.read_consistency_interval = read_consistency_interval
         self.storage_options = storage_options or {}
         self.session = session
-        self._pushdown_operations = set(namespace_client_pushdown_operations or [])
+        self._namespace_client_pushdown_operations = set(
+            namespace_client_pushdown_operations or []
+        )
         self._namespace_client_impl = namespace_client_impl
         self._namespace_client_properties = namespace_client_properties
 
@@ -432,7 +434,9 @@ class LanceNamespaceDBConnection(DBConnection):
                 "connection_type": "namespace",
                 "namespace_client_impl": self._namespace_client_impl,
                 "namespace_client_properties": self._namespace_client_properties,
-                "pushdown_operations": sorted(self._pushdown_operations),
+                "namespace_client_pushdown_operations": sorted(
+                    self._namespace_client_pushdown_operations
+                ),
                 "storage_options": self.storage_options or None,
                 "read_consistency_interval_seconds": (
                     self.read_consistency_interval.total_seconds()
@@ -496,7 +500,7 @@ class LanceNamespaceDBConnection(DBConnection):
 
         table_id = namespace_path + [name]
 
-        if "CreateTable" in self._pushdown_operations:
+        if "CreateTable" in self._namespace_client_pushdown_operations:
             return self._create_table_server_side(
                 name=name,
                 data=data,
@@ -578,7 +582,7 @@ class LanceNamespaceDBConnection(DBConnection):
             storage_options=merged_storage_options,
             location=location,
             namespace_client=self._namespace_client,
-            pushdown_operations=self._pushdown_operations,
+            pushdown_operations=self._namespace_client_pushdown_operations,
         )
 
         return tbl
@@ -919,7 +923,7 @@ class LanceNamespaceDBConnection(DBConnection):
             location=table_uri,
             namespace_client=namespace_client,
             managed_versioning=managed_versioning,
-            pushdown_operations=self._pushdown_operations,
+            pushdown_operations=self._namespace_client_pushdown_operations,
         )
 
     @override
@@ -983,7 +987,9 @@ class AsyncLanceNamespaceDBConnection:
         self.read_consistency_interval = read_consistency_interval
         self.storage_options = storage_options or {}
         self.session = session
-        self._pushdown_operations = set(namespace_client_pushdown_operations or [])
+        self._namespace_client_pushdown_operations = set(
+            namespace_client_pushdown_operations or []
+        )
 
     async def table_names(
         self,
@@ -1038,7 +1044,7 @@ class AsyncLanceNamespaceDBConnection:
 
         table_id = namespace_path + [name]
 
-        if "CreateTable" in self._pushdown_operations:
+        if "CreateTable" in self._namespace_client_pushdown_operations:
             return await self._create_table_server_side(
                 name=name,
                 data=data,
@@ -1118,7 +1124,7 @@ class AsyncLanceNamespaceDBConnection:
                 storage_options=merged_storage_options,
                 location=location,
                 namespace_client=self._namespace_client,
-                pushdown_operations=self._pushdown_operations,
+                pushdown_operations=self._namespace_client_pushdown_operations,
             )
 
         lance_table = await asyncio.to_thread(_create_table)
@@ -1225,7 +1231,7 @@ class AsyncLanceNamespaceDBConnection:
                 location=response.location,
                 namespace_client=self._namespace_client,
                 managed_versioning=managed_versioning,
-                pushdown_operations=self._pushdown_operations,
+                pushdown_operations=self._namespace_client_pushdown_operations,
             )
 
         lance_table = await asyncio.to_thread(_open_table)

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -897,42 +897,22 @@ def test_bypass_vector_index_sync(tmp_db: lancedb.DBConnection):
 
 
 def test_local_namespace_operations(tmp_path):
-    """Test that local mode namespace operations behave as expected."""
-    # Create a local database connection
+    """Test that local mode namespace operations work via directory namespace."""
     db = lancedb.connect(tmp_path)
 
-    # Test list_namespaces returns empty list for root namespace
-    namespaces = db.list_namespaces().namespaces
-    assert namespaces == []
+    # Root namespace starts empty
+    assert db.list_namespaces().namespaces == []
 
-    # Test list_namespaces with non-empty namespace raises NotImplementedError
-    with pytest.raises(
-        NotImplementedError,
-        match="Namespace operations are not supported for listing database",
-    ):
-        db.list_namespaces(namespace_path=["test"])
+    # Create and list child namespace
+    db.create_namespace(["child"])
+    assert "child" in db.list_namespaces().namespaces
 
+    # List namespaces under child
+    assert db.list_namespaces(namespace_path=["child"]).namespaces == []
 
-def test_local_create_namespace_not_supported(tmp_path):
-    """Test that create_namespace is not supported in local mode."""
-    db = lancedb.connect(tmp_path)
-
-    with pytest.raises(
-        NotImplementedError,
-        match="Namespace operations are not supported for listing database",
-    ):
-        db.create_namespace(["test_namespace"])
-
-
-def test_local_drop_namespace_not_supported(tmp_path):
-    """Test that drop_namespace is not supported in local mode."""
-    db = lancedb.connect(tmp_path)
-
-    with pytest.raises(
-        NotImplementedError,
-        match="Namespace operations are not supported for listing database",
-    ):
-        db.drop_namespace(["test_namespace"])
+    # Drop namespace
+    db.drop_namespace(["child"])
+    assert db.list_namespaces().namespaces == []
 
 
 def test_clone_table_latest_version(tmp_path):

--- a/python/python/tests/test_namespace.py
+++ b/python/python/tests/test_namespace.py
@@ -681,7 +681,7 @@ class TestPushdownOperations:
             {"root": self.temp_dir},
             namespace_client_pushdown_operations=["QueryTable"],
         )
-        assert "QueryTable" in db._pushdown_operations
+        assert "QueryTable" in db._namespace_client_pushdown_operations
 
     def test_create_table_pushdown_stored(self):
         """Test that CreateTable pushdown is stored on sync connection."""
@@ -690,7 +690,7 @@ class TestPushdownOperations:
             {"root": self.temp_dir},
             namespace_client_pushdown_operations=["CreateTable"],
         )
-        assert "CreateTable" in db._pushdown_operations
+        assert "CreateTable" in db._namespace_client_pushdown_operations
 
     def test_both_pushdowns_stored(self):
         """Test that both pushdown operations can be set together."""
@@ -699,13 +699,13 @@ class TestPushdownOperations:
             {"root": self.temp_dir},
             namespace_client_pushdown_operations=["QueryTable", "CreateTable"],
         )
-        assert "QueryTable" in db._pushdown_operations
-        assert "CreateTable" in db._pushdown_operations
+        assert "QueryTable" in db._namespace_client_pushdown_operations
+        assert "CreateTable" in db._namespace_client_pushdown_operations
 
     def test_pushdown_defaults_to_empty(self):
         """Test that pushdown operations default to empty."""
         db = lancedb.connect_namespace("dir", {"root": self.temp_dir})
-        assert len(db._pushdown_operations) == 0
+        assert len(db._namespace_client_pushdown_operations) == 0
 
 
 @pytest.mark.asyncio
@@ -727,7 +727,7 @@ class TestAsyncPushdownOperations:
             {"root": self.temp_dir},
             namespace_client_pushdown_operations=["QueryTable"],
         )
-        assert "QueryTable" in db._pushdown_operations
+        assert "QueryTable" in db._namespace_client_pushdown_operations
 
     async def test_async_create_table_pushdown_stored(self):
         """Test that CreateTable pushdown is stored on async connection."""
@@ -736,9 +736,9 @@ class TestAsyncPushdownOperations:
             {"root": self.temp_dir},
             namespace_client_pushdown_operations=["CreateTable"],
         )
-        assert "CreateTable" in db._pushdown_operations
+        assert "CreateTable" in db._namespace_client_pushdown_operations
 
     async def test_async_pushdown_defaults_to_empty(self):
         """Test that pushdown operations default to empty on async connection."""
         db = lancedb.connect_namespace_async("dir", {"root": self.temp_dir})
-        assert len(db._pushdown_operations) == 0
+        assert len(db._namespace_client_pushdown_operations) == 0


### PR DESCRIPTION
## Summary

Add connection serialization and child namespace support to `LanceDBConnection`.

- `DBConnection.serialize()` / `lancedb.deserialize()` for connection reconstruction in remote workers
- Cache `namespace_client()` in `LanceDBConnection` to avoid repeated DirectoryNamespace builds
- `LanceDBConnection` transparently delegates child namespace operations (open_table, create_table, list_tables, drop_table, create_namespace, etc.) to `LanceNamespaceDBConnection` via `_namespace_conn()`
- Root namespace operations still go through the original Rust path
- Generic worker property override mechanism: any `namespace_client_properties` key prefixed with `_lancedb_worker_` has the prefix stripped and overrides the corresponding property when `deserialize(data, for_worker=True)`
- `LanceNamespaceDBConnection` stores `namespace_client_impl`/`namespace_client_properties` for serialization roundtrip