### PR TITLE
feat: update lance dependency to 5.0.0-rc.1

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -126,7 +126,7 @@ jobs:
         # We run this as part of the job because the binary needs to be built
         # first to export the types of the native code.
         set -e
-        npm ci
+        npm ci --include=optional
         npm run docs
         if ! git diff --exit-code -- ../ ':(exclude)Cargo.lock'; then
           echo "Docs need to be updated"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,8 +3072,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -4134,14 +4134,13 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "arrow-arith",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-ipc",
  "arrow-ord",
  "arrow-row",
@@ -4202,8 +4201,8 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4224,8 +4223,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrayref",
  "paste",
@@ -4234,8 +4233,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4272,13 +4271,12 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
@@ -4304,8 +4302,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4323,8 +4321,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4361,8 +4359,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4394,8 +4392,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4459,8 +4457,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4504,8 +4502,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4521,8 +4519,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4535,8 +4533,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4581,8 +4579,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4621,8 +4619,8 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "5.1.0-beta.3"
-source = "git+https://github.com/lance-format/lance.git?tag=v5.1.0-beta.3#0a0d53b5ef4b0f65bb775ce63bdcabc79d1d14b8"
+version = "5.0.0-rc.1"
+source = "git+https://github.com/lance-format/lance.git?tag=v5.0.0-rc.1#d130b036a62a5d8a904dfbe711d3f7b91b132194"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,20 @@ categories = ["database-implementations"]
 rust-version = "1.91.0"
 
 [workspace.dependencies]
-lance = { "version" = "=5.1.0-beta.3", default-features = false, "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-core = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-datagen = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-file = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-io = { "version" = "=5.1.0-beta.3", default-features = false, "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-index = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-linalg = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace-impls = { "version" = "=5.1.0-beta.3", default-features = false, "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-table = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-testing = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-datafusion = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-encoding = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
-lance-arrow = { "version" = "=5.1.0-beta.3", "tag" = "v5.1.0-beta.3", "git" = "https://github.com/lance-format/lance.git" }
+lance = { "version" = "=5.0.0-rc.1", default-features = false, "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-core = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-datagen = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-file = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-io = { "version" = "=5.0.0-rc.1", default-features = false, "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-index = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-linalg = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace-impls = { "version" = "=5.0.0-rc.1", default-features = false, "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-table = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-testing = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-datafusion = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-encoding = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance-arrow = { "version" = "=5.0.0-rc.1", "tag" = "v5.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
 ahash = "0.8"
 # Note that this one does not include pyarrow
 arrow = { version = "57.2", optional = false }


### PR DESCRIPTION
DO NOT MERGE

## Summary
- Update all 14 lance workspace dependencies from `5.1.0-beta.3` to `5.0.0-rc.1`
- Updated both version pins and git tags in `Cargo.toml`
- Cargo.lock updated accordingly

## Test plan
- [x] `cargo check --features remote --tests --examples` passes
- [x] `cargo clippy --features remote --tests --examples` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)