### PR TITLE
fix(python): allow _rowid in Permutation.select_columns

### DIFF
--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -648,6 +648,9 @@ class Permutation:
 
         new_selection = {}
         for name in columns:
+            if name == "_rowid":
+                new_selection[name] = name
+                continue
             value = self.selection.get(name, None)
             if value is None:
                 raise ValueError(

--- a/python/python/tests/test_permutation.py
+++ b/python/python/tests/test_permutation.py
@@ -699,6 +699,18 @@ def test_select_columns(some_permutation: Permutation):
         some_permutation.select_columns([])
 
 
+def test_select_columns_rowid(some_permutation: Permutation):
+    # _rowid is a virtual column produced by the Rust reader; it is not part of
+    # the Arrow schema, so it was previously rejected by select_columns().
+    result = some_permutation.select_columns(["_rowid", "id"])
+    assert "_rowid" in result.schema.names
+    assert "id" in result.schema.names
+
+    # Selecting _rowid alone should also work
+    result_rowid_only = some_permutation.select_columns(["_rowid"])
+    assert result_rowid_only.schema.names == ["_rowid"]
+
+
 def test_iter_basic(some_permutation: Permutation):
     """Test basic iteration with custom batch size."""
     batch_size = 100


### PR DESCRIPTION
## Summary

`Permutation.select_columns(["_rowid", ...])` raised a `ValueError` because the Python validation layer built its allowed set from Arrow schema names, and `_rowid` is a virtual column not present in the schema.

The Rust `PermutationReader` already handles `_rowid` selection via `has_row_id()`. The fix treats `_rowid` as a special case in `select_columns` and passes it through directly.

## Changes

- `python/python/lancedb/permutation.py`: skip the schema lookup for `_rowid` in `select_columns`
- `python/python/tests/test_permutation.py`: add `test_select_columns_rowid` covering `["_rowid", "id"]` and `["_rowid"]` alone

## Related

Fixes #3132