### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -18,6 +18,6 @@ body:
       label: Link
       description: >
         Provide a link to the existing documentation, if applicable.
-      placeholder: ex. https://lancedb.com/docs/tables/...
+      placeholder: ex. https://docs.lancedb.com/tables/...
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # **The Multimodal AI Lakehouse**
 
-[**How to Install** ](#how-to-install) ✦ [**Detailed Documentation**](https://lancedb.com/docs) ✦ [**Tutorials and Recipes**](https://github.com/lancedb/vectordb-recipes/tree/main) ✦  [**Contributors**](#contributors) 
+[**How to Install** ](#how-to-install) ✦ [**Detailed Documentation**](https://docs.lancedb.com) ✦ [**Tutorials and Recipes**](https://github.com/lancedb/vectordb-recipes/tree/main) ✦  [**Contributors**](#contributors) 
 
 **The ultimate multimodal data platform for AI/ML applications.** 
 
@@ -57,7 +57,7 @@ LanceDB is a central location where developers can build, train and analyze thei
 
 ## **How to Install**:
 
-Follow the [Quickstart](https://lancedb.com/docs/quickstart/) doc to set up LanceDB locally. 
+Follow the [Quickstart](https://docs.lancedb.com/quickstart) doc to set up LanceDB locally. 
 
 **API & SDK:** We also support Python, Typescript and Rust SDKs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # LanceDB Documentation
 
-LanceDB docs are available at [lancedb.com/docs](https://lancedb.com/docs).
+LanceDB docs are available at [docs.lancedb.com](https://docs.lancedb.com).
 
 The SDK docs are built and deployed automatically by [Github Actions](../.github/workflows/docs.yml)
 whenever a commit is pushed to the `main` branch. So it is possible for the docs to show

--- a/docs/src/js/README.md
+++ b/docs/src/js/README.md
@@ -34,7 +34,7 @@ const results = await table.vectorSearch([0.1, 0.3]).limit(20).toArray();
 console.log(results);
 ```
 
-The [quickstart](https://lancedb.com/docs/quickstart/basic-usage/) contains more complete examples.
+The [quickstart](https://docs.lancedb.com/quickstart/) contains more complete examples.
 
 ## Development
 

--- a/docs/src/js/interfaces/ConnectionOptions.md
+++ b/docs/src/js/interfaces/ConnectionOptions.md
@@ -89,4 +89,4 @@ optional storageOptions: Record<string, string>;
 
 (For LanceDB OSS only): configuration for object storage.
 
-The available options are described at https://lancedb.com/docs/storage/
+The available options are described at https://docs.lancedb.com/storage/

--- a/docs/src/js/interfaces/CreateTableOptions.md
+++ b/docs/src/js/interfaces/CreateTableOptions.md
@@ -97,4 +97,4 @@ Configuration for object storage.
 Options already set on the connection will be inherited by the table,
 but can be overridden here.
 
-The available options are described at https://lancedb.com/docs/storage/
+The available options are described at https://docs.lancedb.com/storage/

--- a/docs/src/js/interfaces/OpenTableOptions.md
+++ b/docs/src/js/interfaces/OpenTableOptions.md
@@ -42,4 +42,4 @@ Configuration for object storage.
 Options already set on the connection will be inherited by the table,
 but can be overridden here.
 
-The available options are described at https://lancedb.com/docs/storage/
+The available options are described at https://docs.lancedb.com/storage/

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -30,7 +30,7 @@ const results = await table.vectorSearch([0.1, 0.3]).limit(20).toArray();
 console.log(results);
 ```
 
-The [quickstart](https://lancedb.com/docs/quickstart/basic-usage/) contains more complete examples.
+The [quickstart](https://docs.lancedb.com/quickstart/) contains more complete examples.
 
 ## Development
 

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -42,7 +42,7 @@ export interface CreateTableOptions {
    * Options already set on the connection will be inherited by the table,
    * but can be overridden here.
    *
-   * The available options are described at https://lancedb.com/docs/storage/
+   * The available options are described at https://docs.lancedb.com/storage/
    */
   storageOptions?: Record<string, string>;
 
@@ -78,7 +78,7 @@ export interface OpenTableOptions {
    * Options already set on the connection will be inherited by the table,
    * but can be overridden here.
    *
-   * The available options are described at https://lancedb.com/docs/storage/
+   * The available options are described at https://docs.lancedb.com/storage/
    */
   storageOptions?: Record<string, string>;
   /**

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -35,7 +35,7 @@ pub struct ConnectionOptions {
     pub read_consistency_interval: Option<f64>,
     /// (For LanceDB OSS only): configuration for object storage.
     ///
-    /// The available options are described at https://lancedb.com/docs/storage/
+    /// The available options are described at https://docs.lancedb.com/storage/
     pub storage_options: Option<HashMap<String, String>>,
     /// (For LanceDB OSS only): the session to use for this connection. Holds
     /// shared caches and other session-specific state.

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -110,7 +110,7 @@ def connect(
         default configuration is used.
     storage_options: dict, optional
         Additional options for the storage backend. See available options at
-        <https://lancedb.com/docs/storage/>
+        <https://docs.lancedb.com/storage/>
     session: Session, optional
         (For LanceDB OSS only)
         A session to use for this connection. Sessions allow you to configure
@@ -336,7 +336,7 @@ async def connect_async(
         default configuration is used.
     storage_options: dict, optional
         Additional options for the storage backend. See available options at
-        <https://lancedb.com/docs/storage/>
+        <https://docs.lancedb.com/storage/>
     session: Session, optional
         (For LanceDB OSS only)
         A session to use for this connection. Sessions allow you to configure

--- a/python/python/lancedb/common.py
+++ b/python/python/lancedb/common.py
@@ -96,7 +96,7 @@ def data_to_reader(
             f"Unknown data type {type(data)}. "
             "Supported types: list of dicts, pandas DataFrame, polars DataFrame, "
             "pyarrow Table/RecordBatch, or Pydantic models. "
-            "See https://lancedb.com/docs/tables/ for examples."
+            "See https://docs.lancedb.com/tables/ for examples."
         )
 
 

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -282,7 +282,7 @@ class DBConnection(EnforceOverrides):
             Additional options for the storage backend. Options already set on the
             connection will be inherited by the table, but can be overridden here.
             See available options at
-            <https://lancedb.com/docs/storage/>
+            <https://docs.lancedb.com/storage/>
 
             To enable stable row IDs (row IDs remain stable after compaction,
             update, delete, and merges), set `new_table_enable_stable_row_ids`
@@ -433,7 +433,7 @@ class DBConnection(EnforceOverrides):
             Additional options for the storage backend. Options already set on the
             connection will be inherited by the table, but can be overridden here.
             See available options at
-            <https://lancedb.com/docs/storage/>
+            <https://docs.lancedb.com/storage/>
 
         Returns
         -------
@@ -1434,7 +1434,7 @@ class AsyncConnection(object):
             Additional options for the storage backend. Options already set on the
             connection will be inherited by the table, but can be overridden here.
             See available options at
-            <https://lancedb.com/docs/storage/>
+            <https://docs.lancedb.com/storage/>
 
             To enable stable row IDs (row IDs remain stable after compaction,
             update, delete, and merges), set `new_table_enable_stable_row_ids`
@@ -1625,7 +1625,7 @@ class AsyncConnection(object):
             Additional options for the storage backend. Options already set on the
             connection will be inherited by the table, but can be overridden here.
             See available options at
-            <https://lancedb.com/docs/storage/>
+            <https://docs.lancedb.com/storage/>
         index_cache_size: int, default 256
             **Deprecated**: Use session-level cache configuration instead.
             Create a Session with custom cache sizes and pass it to lancedb.connect().

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -191,7 +191,7 @@ def _into_pyarrow_reader(
             f"Unknown data type {type(data)}. "
             "Supported types: list of dicts, pandas DataFrame, polars DataFrame, "
             "pyarrow Table/RecordBatch, or Pydantic models. "
-            "See https://lancedb.com/docs/tables/ for examples."
+            "See https://docs.lancedb.com/tables/ for examples."
         )
 
 

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -171,7 +171,7 @@ impl OpenTableBuilder {
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let store_params = self
             .request
@@ -188,7 +188,7 @@ impl OpenTableBuilder {
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
@@ -738,7 +738,7 @@ impl ConnectBuilder {
 
     /// Set an option for the storage layer.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.request.options.insert(key.into(), value.into());
         self
@@ -746,7 +746,7 @@ impl ConnectBuilder {
 
     /// Set multiple options for the storage layer.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
@@ -914,7 +914,7 @@ impl ConnectNamespaceBuilder {
 
     /// Set an option for the storage layer.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.storage_options.insert(key.into(), value.into());
         self
@@ -922,7 +922,7 @@ impl ConnectNamespaceBuilder {
 
     /// Set multiple options for the storage layer.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,

--- a/rust/lancedb/src/connection/create_table.rs
+++ b/rust/lancedb/src/connection/create_table.rs
@@ -55,7 +55,7 @@ impl CreateTableBuilder {
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let store_params = self
             .request
@@ -73,7 +73,7 @@ impl CreateTableBuilder {
     /// Options already set on the connection will be inherited by the table,
     /// but can be overridden here.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -73,7 +73,7 @@ pub struct ListingDatabaseOptions {
     /// These are used to create/list tables and they are inherited by all tables
     /// opened by this database.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub storage_options: HashMap<String, String>,
 }
 
@@ -185,7 +185,7 @@ impl ListingDatabaseOptionsBuilder {
 
     /// Set an option for the storage layer.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.options
             .storage_options
@@ -195,7 +195,7 @@ impl ListingDatabaseOptionsBuilder {
 
     /// Set multiple options for the storage layer.
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     pub fn storage_options(
         mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -69,7 +69,7 @@
 //! It treats [`FixedSizeList<Float16/Float32>`](https://docs.rs/arrow/latest/arrow/array/struct.FixedSizeListArray.html)
 //! columns as vector columns.
 //!
-//! For more details, please refer to the [LanceDB documentation](https://lancedb.com/docs).
+//! For more details, please refer to the [LanceDB documentation](https://docs.lancedb.com).
 //!
 //! #### Create a table
 //!

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -97,7 +97,7 @@ pub struct RemoteDatabaseOptions {
     pub host_override: Option<String>,
     /// Storage options configure the storage layer (e.g. S3, GCS, Azure, etc.)
     ///
-    /// See available options at <https://lancedb.com/docs/storage/>
+    /// See available options at <https://docs.lancedb.com/storage/>
     ///
     /// These options are only used for LanceDB Enterprise and only a subset of options
     /// are supported.


### PR DESCRIPTION
## Summary

Replace old `lancedb.com/docs/*` URLs with `docs.lancedb.com/*` across the codebase.

## Problem

URLs with sub-paths like `lancedb.com/docs/storage/`, `lancedb.com/docs/tables/`, and `lancedb.com/docs/quickstart/` all return **Page Not Found
**. Only `lancedb.com/docs/` (without sub-path) correctly redirects to `docs.lancedb.com`.

<img width="1001" height="592" alt="image" src="https://github.com/user-attachments/assets/80e4f5d5-74ec-4949-a3cd-0bf3496149bc" />


## Changes

Updated 19 files (Rust, Python, TypeScript, docs, README, issue template) to use the correct `docs.lancedb.com` domain.