### PR TITLE
fix(node): remove redundant `postbuild:release` script to fix build failure

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -75,7 +75,6 @@
     "build:debug": "napi build --platform --dts ../lancedb/native.d.ts --js ../lancedb/native.js --output-dir lancedb",
     "postbuild:debug": "shx mkdir -p dist && shx cp lancedb/*.node dist/",
     "build:release": "napi build --platform --release --dts ../lancedb/native.d.ts --js ../lancedb/native.js --output-dir dist",
-    "postbuild:release": "shx mkdir -p dist && shx cp lancedb/*.node dist/",
     "build": "npm run build:debug && npm run tsc",
     "build-release": "npm run build:release && npm run tsc",
     "tsc": "tsc -b",


### PR DESCRIPTION
The `build:release` command already outputs the `*.node` files directly to the `dist/` directory via the `--output-dir dist` flag.

Therefore, the `postbuild:release` script, which attempts to copy `*.node` files from the `lancedb/` source directory, fails with a "no such file or directory" error because the source files do not exist there.

This commit removes the redundant `postbuild:release` script to resolve the build failure.

fix #3284 