### PR TITLE
fix(python): use namespace-backed rust connection for namespace tables

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -591,10 +591,12 @@ class LanceDBConnection(DBConnection):
         storage_options: Optional[Dict[str, str]] = None,
         session: Optional[Session] = None,
         _inner: Optional[LanceDbConnection] = None,
+        _is_temporary_location_connection: bool = False,
     ):
         if _inner is not None:
             self._conn = _inner
             self._cached_namespace_client = None
+            self._is_temporary_location_connection = False
             return
 
         if not isinstance(uri, Path):
@@ -643,6 +645,7 @@ class LanceDBConnection(DBConnection):
         self.storage_options = storage_options
         self._conn = AsyncConnection(LOOP.run(do_connect()))
         self._cached_namespace_client: Optional[LanceNamespace] = None
+        self._is_temporary_location_connection = _is_temporary_location_connection
 
     @property
     def read_consistency_interval(self) -> Optional[timedelta]:
@@ -913,6 +916,12 @@ class LanceDBConnection(DBConnection):
     def _namespace_conn(self) -> DBConnection:
         """Return a LanceNamespaceDBConnection backed by this connection's
         directory namespace.  Used to delegate child-namespace operations."""
+        if self._is_temporary_location_connection:
+            raise RuntimeError(
+                "Temporary location connections cannot derive nested namespace "
+                "connections. Use the original namespace connection instead."
+            )
+
         from lancedb.namespace import LanceNamespaceDBConnection
 
         return LanceNamespaceDBConnection(

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -591,12 +591,10 @@ class LanceDBConnection(DBConnection):
         storage_options: Optional[Dict[str, str]] = None,
         session: Optional[Session] = None,
         _inner: Optional[LanceDbConnection] = None,
-        _is_temporary_location_connection: bool = False,
     ):
         if _inner is not None:
             self._conn = _inner
             self._cached_namespace_client = None
-            self._is_temporary_location_connection = False
             return
 
         if not isinstance(uri, Path):
@@ -645,7 +643,6 @@ class LanceDBConnection(DBConnection):
         self.storage_options = storage_options
         self._conn = AsyncConnection(LOOP.run(do_connect()))
         self._cached_namespace_client: Optional[LanceNamespace] = None
-        self._is_temporary_location_connection = _is_temporary_location_connection
 
     @property
     def read_consistency_interval(self) -> Optional[timedelta]:
@@ -916,12 +913,6 @@ class LanceDBConnection(DBConnection):
     def _namespace_conn(self) -> DBConnection:
         """Return a LanceNamespaceDBConnection backed by this connection's
         directory namespace.  Used to delegate child-namespace operations."""
-        if self._is_temporary_location_connection:
-            raise RuntimeError(
-                "Temporary location connections cannot derive nested namespace "
-                "connections. Use the original namespace connection instead."
-            )
-
         from lancedb.namespace import LanceNamespaceDBConnection
 
         return LanceNamespaceDBConnection(

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -578,12 +578,17 @@ class LanceNamespaceDBConnection(DBConnection):
             on_bad_vectors=on_bad_vectors,
             fill_value=fill_value,
             embedding_functions=embedding_functions,
-            namespace_path=namespace_path,
+            namespace_path=[],
             storage_options=merged_storage_options,
             location=location,
             namespace_client=self._namespace_client,
             pushdown_operations=self._namespace_client_pushdown_operations,
         )
+
+        tbl._namespace_path = namespace_path
+        tbl._location = location
+        tbl._namespace_client = self._namespace_client
+        tbl._pushdown_operations = self._namespace_client_pushdown_operations
 
         return tbl
 
@@ -914,17 +919,23 @@ class LanceNamespaceDBConnection(DBConnection):
         # storage options provider
         # Pass managed_versioning to avoid redundant describe_table call
         # Pass pushdown_operations if configured on this connection
-        return LanceTable.open(
+        table = LanceTable.open(
             temp_conn,
             name,
-            namespace_path=namespace_path,
+            namespace_path=[],
             storage_options=storage_options,
             index_cache_size=index_cache_size,
             location=table_uri,
-            namespace_client=namespace_client,
-            managed_versioning=managed_versioning,
+            namespace_client=None,
+            managed_versioning=False,
             pushdown_operations=self._namespace_client_pushdown_operations,
         )
+
+        table._namespace_path = namespace_path
+        table._location = table_uri
+        table._namespace_client = namespace_client
+        table._pushdown_operations = self._namespace_client_pushdown_operations
+        return table
 
     @override
     def namespace_client(self) -> LanceNamespace:
@@ -1120,7 +1131,7 @@ class AsyncLanceNamespaceDBConnection:
                 on_bad_vectors=on_bad_vectors,
                 fill_value=fill_value,
                 embedding_functions=embedding_functions,
-                namespace_path=namespace_path,
+                namespace_path=[],
                 storage_options=merged_storage_options,
                 location=location,
                 namespace_client=self._namespace_client,
@@ -1222,17 +1233,23 @@ class AsyncLanceNamespaceDBConnection:
                 session=self.session,
             )
 
-            return LanceTable.open(
+            table = LanceTable.open(
                 temp_conn,
                 name,
-                namespace_path=namespace_path,
+                namespace_path=[],
                 storage_options=merged_storage_options,
                 index_cache_size=index_cache_size,
                 location=response.location,
-                namespace_client=self._namespace_client,
-                managed_versioning=managed_versioning,
+                namespace_client=None,
+                managed_versioning=False,
                 pushdown_operations=self._namespace_client_pushdown_operations,
             )
+
+            table._namespace_path = namespace_path
+            table._location = response.location
+            table._namespace_client = self._namespace_client
+            table._pushdown_operations = self._namespace_client_pushdown_operations
+            return table
 
         lance_table = await asyncio.to_thread(_open_table)
         return lance_table._table

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -26,7 +26,7 @@ from datetime import timedelta
 import pyarrow as pa
 
 from lancedb.background_loop import LOOP
-from lancedb.db import DBConnection, LanceDBConnection
+from lancedb.db import AsyncConnection, DBConnection
 from lancedb.namespace_utils import (
     _normalize_create_namespace_mode,
     _normalize_drop_namespace_mode,
@@ -52,10 +52,38 @@ from lance_namespace import (
 )
 from lancedb.table import AsyncTable, LanceTable, Table
 from lancedb.util import validate_table_name
-from lancedb.common import DATA
+from lancedb.common import DATA, sanitize_uri
 from lancedb.pydantic import LanceModel
 from lancedb.embeddings import EmbeddingFunctionConfig
-from ._lancedb import Session
+from ._lancedb import Session, connect as lancedb_connect
+
+
+def _make_temp_async_connection(
+    uri: str,
+    read_consistency_interval: Optional[timedelta],
+    storage_options: Optional[Dict[str, str]],
+    session: Optional[Session],
+) -> AsyncConnection:
+    read_consistency_interval_secs = (
+        read_consistency_interval.total_seconds()
+        if read_consistency_interval is not None
+        else None
+    )
+
+    async def do_connect():
+        return await lancedb_connect(
+            sanitize_uri(uri),
+            None,
+            None,
+            None,
+            read_consistency_interval_secs,
+            None,
+            storage_options,
+            session,
+        )
+
+    return AsyncConnection(LOOP.run(do_connect()))
+
 
 from lance_namespace_urllib3_client.models.json_arrow_schema import JsonArrowSchema
 from lance_namespace_urllib3_client.models.json_arrow_field import JsonArrowField
@@ -562,29 +590,23 @@ class LanceNamespaceDBConnection(DBConnection):
         # Step 2: Create the dataset at the namespace-declared physical location.
         #
         # The namespace has already resolved the logical table identifier
-        # (namespace_path + name) to an exact storage location. We create a
-        # temporary LanceDBConnection rooted at that location so we can reuse the
-        # standard local LanceTable.create logic for the actual write.
-        # TODO: Refactor the local/namespace create path so we do not need this
-        # temporary connection trick just to reuse the existing LanceTable.create
-        # implementation.
+        # (namespace_path + name) to an exact storage location.  Create a
+        # short-lived AsyncConnection rooted at that physical location and use it
+        # only to perform the low-level dataset write.
         #
-        # This temporary connection is *not* a logical database root. If we were
-        # to pass the original namespace_path through to LanceTable.create, the
-        # lower layers would try to resolve the namespace again underneath an
-        # already-resolved table location. We therefore pass namespace_path=[] to
-        # the low-level create call and restore the logical namespace metadata on
-        # the returned Python wrapper after the write succeeds.
-        temp_conn = LanceDBConnection(
-            location,  # Use the actual location as the connection URI
-            read_consistency_interval=self.read_consistency_interval,
-            storage_options=merged_storage_options,
-            session=self.session,
-            _is_temporary_location_connection=True,
+        # The sync LanceTable wrapper that we return should still be bound to the
+        # original namespace connection so that namespace-aware operations keep
+        # using the logical table id, namespace client, and connection storage
+        # options.
+        temp_async_conn = _make_temp_async_connection(
+            location,
+            self.read_consistency_interval,
+            merged_storage_options,
+            self.session,
         )
 
         async_table = LOOP.run(
-            temp_conn._conn.create_table(
+            temp_async_conn.create_table(
                 name,
                 data,
                 schema=schema,
@@ -601,7 +623,7 @@ class LanceNamespaceDBConnection(DBConnection):
         )
 
         return LanceTable(
-            temp_conn,
+            self,
             name,
             namespace_path=namespace_path,
             location=location,
@@ -922,28 +944,24 @@ class LanceNamespaceDBConnection(DBConnection):
     ) -> LanceTable:
         # Open a table directly from the namespace-resolved physical location.
         #
-        # As in the create path above, the temporary connection is rooted at the
-        # concrete table location returned by the namespace. The logical
-        # namespace_path has already been resolved, so we must not reapply it when
-        # opening the table. We open with namespace_path=[] and then restore the
-        # logical namespace metadata on the returned Python wrapper.
-        # TODO: Refactor the local/namespace open path so we do not need this
-        # temporary connection trick just to reuse the existing LanceTable.open
-        # implementation.
+        # The namespace has already resolved the logical table identifier to a
+        # concrete storage location. Create a short-lived AsyncConnection rooted
+        # at that physical location and use it only for the low-level open.
         #
-        # Note: storage_options should already be merged by the caller.
+        # The returned sync LanceTable remains bound to the original namespace
+        # connection so that logical namespace metadata and namespace-aware helper
+        # behavior remain intact.
         if namespace_path is None:
             namespace_path = []
-        temp_conn = LanceDBConnection(
-            table_uri,  # Use the table location as the connection URI
-            read_consistency_interval=self.read_consistency_interval,
-            storage_options=storage_options if storage_options is not None else {},
-            session=self.session,
-            _is_temporary_location_connection=True,
+        temp_async_conn = _make_temp_async_connection(
+            table_uri,
+            self.read_consistency_interval,
+            storage_options if storage_options is not None else {},
+            self.session,
         )
 
         async_table = LOOP.run(
-            temp_conn._conn.open_table(
+            temp_async_conn.open_table(
                 name,
                 namespace_path=[],
                 storage_options=storage_options,
@@ -955,7 +973,7 @@ class LanceNamespaceDBConnection(DBConnection):
         )
 
         return LanceTable(
-            temp_conn,
+            self,
             name,
             namespace_path=namespace_path,
             location=table_uri,
@@ -1138,19 +1156,18 @@ class AsyncLanceNamespaceDBConnection:
         if namespace_storage_options:
             merged_storage_options.update(namespace_storage_options)
 
-        # Step 2: Create the dataset through the temporary connection from a
-        # thread, without re-entering LanceTable.create's shared path.
+        # Step 2: Create the dataset through a short-lived AsyncConnection
+        # rooted at the namespace-declared physical location.
         def _create_table():
-            temp_conn = LanceDBConnection(
+            temp_async_conn = _make_temp_async_connection(
                 location,
-                read_consistency_interval=self.read_consistency_interval,
-                storage_options=merged_storage_options,
-                session=self.session,
-                _is_temporary_location_connection=True,
+                self.read_consistency_interval,
+                merged_storage_options,
+                self.session,
             )
 
             return LOOP.run(
-                temp_conn._conn.create_table(
+                temp_async_conn.create_table(
                     name,
                     data,
                     schema=schema,
@@ -1249,19 +1266,18 @@ class AsyncLanceNamespaceDBConnection:
         # Convert None to False since we already have the answer from describe_table.
         managed_versioning = response.managed_versioning is True
 
-        # Open the table from the namespace-resolved physical location in a
-        # thread, without re-entering LanceTable.open's shared path.
+        # Open the table from the namespace-resolved physical location through a
+        # short-lived AsyncConnection.
         def _open_table():
-            temp_conn = LanceDBConnection(
+            temp_async_conn = _make_temp_async_connection(
                 response.location,
-                read_consistency_interval=self.read_consistency_interval,
-                storage_options=merged_storage_options,
-                session=self.session,
-                _is_temporary_location_connection=True,
+                self.read_consistency_interval,
+                merged_storage_options,
+                self.session,
             )
 
             return LOOP.run(
-                temp_conn._conn.open_table(
+                temp_async_conn.open_table(
                     name,
                     namespace_path=[],
                     storage_options=merged_storage_options,

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -558,13 +558,28 @@ class LanceNamespaceDBConnection(DBConnection):
         if namespace_storage_options:
             merged_storage_options.update(namespace_storage_options)
 
-        # Step 2: Create table using LanceTable.create with the location
-        # We need a temporary connection for the LanceTable.create method
+        # Step 2: Create the dataset at the namespace-declared physical location.
+        #
+        # The namespace has already resolved the logical table identifier
+        # (namespace_path + name) to an exact storage location. We create a
+        # temporary LanceDBConnection rooted at that location so we can reuse the
+        # standard local LanceTable.create logic for the actual write.
+        # TODO: Refactor the local/namespace create path so we do not need this
+        # temporary connection trick just to reuse the existing LanceTable.create
+        # implementation.
+        #
+        # This temporary connection is *not* a logical database root. If we were
+        # to pass the original namespace_path through to LanceTable.create, the
+        # lower layers would try to resolve the namespace again underneath an
+        # already-resolved table location. We therefore pass namespace_path=[] to
+        # the low-level create call and restore the logical namespace metadata on
+        # the returned Python wrapper after the write succeeds.
         temp_conn = LanceDBConnection(
             location,  # Use the actual location as the connection URI
             read_consistency_interval=self.read_consistency_interval,
             storage_options=merged_storage_options,
             session=self.session,
+            _is_temporary_location_connection=True,
         )
 
         # Note: storage_options_provider is auto-created in Rust from namespace_client
@@ -902,9 +917,18 @@ class LanceNamespaceDBConnection(DBConnection):
         namespace_client: Optional[Any] = None,
         managed_versioning: Optional[bool] = None,
     ) -> LanceTable:
-        # Open a table directly from a URI using the location parameter
-        # Note: storage_options should already be merged by the caller
-        # Note: storage_options_provider is auto-created in Rust from namespace_client
+        # Open a table directly from the namespace-resolved physical location.
+        #
+        # As in the create path above, the temporary connection is rooted at the
+        # concrete table location returned by the namespace. The logical
+        # namespace_path has already been resolved, so we must not reapply it when
+        # opening the table. We open with namespace_path=[] and then restore the
+        # logical namespace metadata on the returned Python wrapper.
+        # TODO: Refactor the local/namespace open path so we do not need this
+        # temporary connection trick just to reuse the existing LanceTable.open
+        # implementation.
+        #
+        # Note: storage_options should already be merged by the caller.
         if namespace_path is None:
             namespace_path = []
         temp_conn = LanceDBConnection(
@@ -912,6 +936,7 @@ class LanceNamespaceDBConnection(DBConnection):
             read_consistency_interval=self.read_consistency_interval,
             storage_options=storage_options if storage_options is not None else {},
             session=self.session,
+            _is_temporary_location_connection=True,
         )
 
         # Open the table using the temporary connection with the location parameter
@@ -1223,14 +1248,17 @@ class AsyncLanceNamespaceDBConnection:
         # Convert None to False since we already have the answer from describe_table.
         managed_versioning = response.managed_versioning is True
 
-        # Open table in a thread
-        # Note: storage_options_provider is auto-created in Rust from namespace_client
+        # Open the table from the namespace-resolved physical location in a
+        # thread. As in the sync helper above, use a temporary location-rooted
+        # connection, avoid reapplying namespace_path during the low-level open,
+        # and restore the logical namespace metadata on the Python wrapper.
         def _open_table():
             temp_conn = LanceDBConnection(
                 response.location,
                 read_consistency_interval=self.read_consistency_interval,
                 storage_options=merged_storage_options,
                 session=self.session,
+                _is_temporary_location_connection=True,
             )
 
             table = LanceTable.open(

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -10,7 +10,6 @@ through a namespace abstraction.
 
 from __future__ import annotations
 
-import asyncio
 import sys
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
@@ -25,6 +24,21 @@ if TYPE_CHECKING:
 from datetime import timedelta
 import pyarrow as pa
 
+from lance_namespace_urllib3_client.models.json_arrow_data_type import JsonArrowDataType
+from lance_namespace_urllib3_client.models.json_arrow_field import JsonArrowField
+from lance_namespace_urllib3_client.models.json_arrow_schema import JsonArrowSchema
+from lance_namespace_urllib3_client.models.query_table_request import QueryTableRequest
+from lance_namespace_urllib3_client.models.query_table_request_columns import (
+    QueryTableRequestColumns,
+)
+from lance_namespace_urllib3_client.models.query_table_request_full_text_query import (
+    QueryTableRequestFullTextQuery,
+)
+from lance_namespace_urllib3_client.models.query_table_request_vector import (
+    QueryTableRequestVector,
+)
+from lance_namespace_urllib3_client.models.string_fts_query import StringFtsQuery
+from lancedb._lancedb import connect_namespace_client as _connect_namespace_client
 from lancedb.background_loop import LOOP
 from lancedb.db import AsyncConnection, DBConnection
 from lancedb.namespace_utils import (
@@ -41,64 +55,18 @@ from lance_namespace import (
     ListNamespacesResponse,
     ListTablesResponse,
     ListTablesRequest,
-    DescribeTableRequest,
     DescribeNamespaceRequest,
     DropTableRequest,
     ListNamespacesRequest,
     CreateNamespaceRequest,
     DropNamespaceRequest,
-    DeclareTableRequest,
-    CreateTableRequest,
 )
 from lancedb.table import AsyncTable, LanceTable, Table
 from lancedb.util import validate_table_name
-from lancedb.common import DATA, sanitize_uri
+from lancedb.common import DATA
 from lancedb.pydantic import LanceModel
 from lancedb.embeddings import EmbeddingFunctionConfig
-from ._lancedb import Session, connect as lancedb_connect
-
-
-def _make_temp_async_connection(
-    uri: str,
-    read_consistency_interval: Optional[timedelta],
-    storage_options: Optional[Dict[str, str]],
-    session: Optional[Session],
-) -> AsyncConnection:
-    read_consistency_interval_secs = (
-        read_consistency_interval.total_seconds()
-        if read_consistency_interval is not None
-        else None
-    )
-
-    async def do_connect():
-        return await lancedb_connect(
-            sanitize_uri(uri),
-            None,
-            None,
-            None,
-            read_consistency_interval_secs,
-            None,
-            storage_options,
-            session,
-        )
-
-    return AsyncConnection(LOOP.run(do_connect()))
-
-
-from lance_namespace_urllib3_client.models.json_arrow_schema import JsonArrowSchema
-from lance_namespace_urllib3_client.models.json_arrow_field import JsonArrowField
-from lance_namespace_urllib3_client.models.json_arrow_data_type import JsonArrowDataType
-from lance_namespace_urllib3_client.models.query_table_request import QueryTableRequest
-from lance_namespace_urllib3_client.models.query_table_request_vector import (
-    QueryTableRequestVector,
-)
-from lance_namespace_urllib3_client.models.query_table_request_columns import (
-    QueryTableRequestColumns,
-)
-from lance_namespace_urllib3_client.models.query_table_request_full_text_query import (
-    QueryTableRequestFullTextQuery,
-)
-from lance_namespace_urllib3_client.models.string_fts_query import StringFtsQuery
+from ._lancedb import Session
 
 
 def _query_to_namespace_request(
@@ -453,6 +421,23 @@ class LanceNamespaceDBConnection(DBConnection):
         )
         self._namespace_client_impl = namespace_client_impl
         self._namespace_client_properties = namespace_client_properties
+        self._inner = AsyncConnection(
+            _connect_namespace_client(
+                namespace_client,
+                read_consistency_interval=(
+                    read_consistency_interval.total_seconds()
+                    if read_consistency_interval is not None
+                    else None
+                ),
+                storage_options=self.storage_options or None,
+                session=session,
+                namespace_client_pushdown_operations=(
+                    list(self._namespace_client_pushdown_operations)
+                ),
+                namespace_client_impl=namespace_client_impl,
+                namespace_client_properties=namespace_client_properties,
+            )
+        )
 
     @override
     def serialize(self) -> str:
@@ -526,13 +511,10 @@ class LanceNamespaceDBConnection(DBConnection):
         if mode.lower() not in ["create", "overwrite"]:
             raise ValueError("mode must be either 'create' or 'overwrite'")
         validate_table_name(name)
-
-        table_id = namespace_path + [name]
-
-        if "CreateTable" in self._namespace_client_pushdown_operations:
-            return self._create_table_server_side(
-                name=name,
-                data=data,
+        async_table = LOOP.run(
+            self._inner.create_table(
+                name,
+                data,
                 schema=schema,
                 mode=mode,
                 exist_ok=exist_ok,
@@ -542,146 +524,15 @@ class LanceNamespaceDBConnection(DBConnection):
                 namespace_path=namespace_path,
                 storage_options=storage_options,
             )
-
-        # Local create path: declare_table + local write
-        # Step 1: Get the table location and storage options from namespace
-        # In overwrite mode, if table exists, use describe_table to get
-        # existing location. Otherwise, call create_empty_table to reserve
-        # a new location
-        location = None
-        namespace_storage_options = None
-        if mode.lower() == "overwrite":
-            # Try to describe the table first to see if it exists
-            try:
-                describe_request = DescribeTableRequest(id=table_id)
-                describe_response = self._namespace_client.describe_table(
-                    describe_request
-                )
-                location = describe_response.location
-                namespace_storage_options = describe_response.storage_options
-            except Exception:
-                # Table doesn't exist, will create a new one below
-                pass
-
-        if location is None:
-            # Table doesn't exist or mode is "create", reserve a new location
-            declare_request = DeclareTableRequest(
-                id=table_id,
-                location=None,
-                properties=self.storage_options if self.storage_options else None,
-            )
-            declare_response = self._namespace_client.declare_table(declare_request)
-
-            if not declare_response.location:
-                raise ValueError(
-                    "Table location is missing from declare_table response"
-                )
-
-            location = declare_response.location
-            namespace_storage_options = declare_response.storage_options
-
-        # Merge storage options: self.storage_options < user options < namespace options
-        merged_storage_options = dict(self.storage_options)
-        if storage_options:
-            merged_storage_options.update(storage_options)
-        if namespace_storage_options:
-            merged_storage_options.update(namespace_storage_options)
-
-        # Step 2: Create the dataset at the namespace-declared physical location.
-        #
-        # The namespace has already resolved the logical table identifier
-        # (namespace_path + name) to an exact storage location.  Create a
-        # short-lived AsyncConnection rooted at that physical location and use it
-        # only to perform the low-level dataset write.
-        #
-        # The sync LanceTable wrapper that we return should still be bound to the
-        # original namespace connection so that namespace-aware operations keep
-        # using the logical table id, namespace client, and connection storage
-        # options.
-        temp_async_conn = _make_temp_async_connection(
-            location,
-            self.read_consistency_interval,
-            merged_storage_options,
-            self.session,
-        )
-
-        async_table = LOOP.run(
-            temp_async_conn.create_table(
-                name,
-                data,
-                schema=schema,
-                mode=mode,
-                exist_ok=exist_ok,
-                on_bad_vectors=on_bad_vectors,
-                fill_value=fill_value,
-                embedding_functions=embedding_functions,
-                namespace_path=[],
-                storage_options=merged_storage_options,
-                location=location,
-                namespace_client=self._namespace_client,
-            )
         )
 
         return LanceTable(
             self,
             name,
             namespace_path=namespace_path,
-            location=location,
             namespace_client=self._namespace_client,
             pushdown_operations=self._namespace_client_pushdown_operations,
             _async=async_table,
-        )
-
-    def _create_table_server_side(
-        self,
-        name: str,
-        data: Optional[DATA],
-        schema: Optional[Union[pa.Schema, LanceModel]],
-        mode: str,
-        exist_ok: bool,
-        on_bad_vectors: str,
-        fill_value: float,
-        embedding_functions: Optional[List[EmbeddingFunctionConfig]],
-        namespace_path: Optional[List[str]],
-        storage_options: Optional[Dict[str, str]],
-    ) -> Table:
-        """Create a table using server-side namespace.create_table()."""
-        if namespace_path is None:
-            namespace_path = []
-        table_id = namespace_path + [name]
-
-        arrow_ipc_bytes = _data_to_arrow_ipc(
-            data=data,
-            schema=schema,
-            embedding_functions=embedding_functions,
-            on_bad_vectors=on_bad_vectors,
-            fill_value=fill_value,
-        )
-
-        merged = dict(self.storage_options or {})
-        if storage_options:
-            merged.update(storage_options)
-        request = CreateTableRequest(
-            id=table_id,
-            mode=_normalize_create_table_mode(mode),
-            properties=merged or None,
-        )
-
-        try:
-            self._namespace_client.create_table(request, arrow_ipc_bytes)
-        except Exception as e:
-            if exist_ok and "already exists" in str(e).lower():
-                return self.open_table(
-                    name,
-                    namespace_path=namespace_path,
-                    storage_options=storage_options,
-                )
-            raise
-
-        return self.open_table(
-            name,
-            namespace_path=namespace_path,
-            storage_options=storage_options,
         )
 
     @override
@@ -695,30 +546,22 @@ class LanceNamespaceDBConnection(DBConnection):
     ) -> Table:
         if namespace_path is None:
             namespace_path = []
-        table_id = namespace_path + [name]
-        request = DescribeTableRequest(id=table_id)
-        response = self._namespace_client.describe_table(request)
+        async_table = LOOP.run(
+            self._inner.open_table(
+                name,
+                namespace_path=namespace_path,
+                storage_options=storage_options,
+                index_cache_size=index_cache_size,
+            )
+        )
 
-        # Merge storage options: self.storage_options < user options < namespace options
-        merged_storage_options = dict(self.storage_options)
-        if storage_options:
-            merged_storage_options.update(storage_options)
-        if response.storage_options:
-            merged_storage_options.update(response.storage_options)
-
-        # Pass managed_versioning to avoid redundant describe_table call in Rust.
-        # Convert None to False since we already have the answer from describe_table.
-        managed_versioning = response.managed_versioning is True
-
-        # Note: storage_options_provider is auto-created in Rust from namespace_client
-        return self._lance_table_from_uri(
+        return LanceTable(
+            self,
             name,
-            response.location,
             namespace_path=namespace_path,
-            storage_options=merged_storage_options,
-            index_cache_size=index_cache_size,
             namespace_client=self._namespace_client,
-            managed_versioning=managed_versioning,
+            pushdown_operations=self._namespace_client_pushdown_operations,
+            _async=async_table,
         )
 
     @override
@@ -944,31 +787,20 @@ class LanceNamespaceDBConnection(DBConnection):
     ) -> LanceTable:
         # Open a table directly from the namespace-resolved physical location.
         #
-        # The namespace has already resolved the logical table identifier to a
-        # concrete storage location. Create a short-lived AsyncConnection rooted
-        # at that physical location and use it only for the low-level open.
-        #
-        # The returned sync LanceTable remains bound to the original namespace
-        # connection so that logical namespace metadata and namespace-aware helper
-        # behavior remain intact.
+        # Open the table through the Rust namespace-backed connection.  The Rust
+        # layer keeps the logical namespace path and namespace client intact.
         if namespace_path is None:
             namespace_path = []
-        temp_async_conn = _make_temp_async_connection(
-            table_uri,
-            self.read_consistency_interval,
-            storage_options if storage_options is not None else {},
-            self.session,
-        )
 
         async_table = LOOP.run(
-            temp_async_conn.open_table(
+            self._inner.open_table(
                 name,
-                namespace_path=[],
+                namespace_path=namespace_path,
                 storage_options=storage_options,
                 index_cache_size=index_cache_size,
-                location=table_uri,
-                namespace_client=None,
-                managed_versioning=False,
+                location=None,
+                namespace_client=namespace_client,
+                managed_versioning=managed_versioning,
             )
         )
 
@@ -1047,6 +879,23 @@ class AsyncLanceNamespaceDBConnection:
         self._namespace_client_pushdown_operations = set(
             namespace_client_pushdown_operations or []
         )
+        self._inner = AsyncConnection(
+            _connect_namespace_client(
+                namespace_client,
+                read_consistency_interval=(
+                    read_consistency_interval.total_seconds()
+                    if read_consistency_interval is not None
+                    else None
+                ),
+                storage_options=self.storage_options or None,
+                session=session,
+                namespace_client_pushdown_operations=(
+                    list(self._namespace_client_pushdown_operations)
+                ),
+                namespace_client_impl=None,
+                namespace_client_properties=None,
+            )
+        )
 
     async def table_names(
         self,
@@ -1098,145 +947,16 @@ class AsyncLanceNamespaceDBConnection:
         if mode.lower() not in ["create", "overwrite"]:
             raise ValueError("mode must be either 'create' or 'overwrite'")
         validate_table_name(name)
-
-        table_id = namespace_path + [name]
-
-        if "CreateTable" in self._namespace_client_pushdown_operations:
-            return await self._create_table_server_side(
-                name=name,
-                data=data,
-                schema=schema,
-                mode=mode,
-                exist_ok=exist_ok,
-                on_bad_vectors=on_bad_vectors,
-                fill_value=fill_value,
-                embedding_functions=embedding_functions,
-                namespace_path=namespace_path,
-                storage_options=storage_options,
-            )
-
-        # Local create path: declare_table + local write
-        # Step 1: Get the table location and storage options from namespace
-        location = None
-        namespace_storage_options = None
-        if mode.lower() == "overwrite":
-            # Try to describe the table first to see if it exists
-            try:
-                describe_request = DescribeTableRequest(id=table_id)
-                describe_response = self._namespace_client.describe_table(
-                    describe_request
-                )
-                location = describe_response.location
-                namespace_storage_options = describe_response.storage_options
-            except Exception:
-                # Table doesn't exist, will create a new one below
-                pass
-
-        if location is None:
-            # Table doesn't exist or mode is "create", reserve a new location
-            declare_request = DeclareTableRequest(
-                id=table_id,
-                location=None,
-                properties=self.storage_options if self.storage_options else None,
-            )
-            declare_response = self._namespace_client.declare_table(declare_request)
-
-            if not declare_response.location:
-                raise ValueError(
-                    "Table location is missing from declare_table response"
-                )
-
-            location = declare_response.location
-            namespace_storage_options = declare_response.storage_options
-
-        # Merge storage options: self.storage_options < user options < namespace options
-        merged_storage_options = dict(self.storage_options)
-        if storage_options:
-            merged_storage_options.update(storage_options)
-        if namespace_storage_options:
-            merged_storage_options.update(namespace_storage_options)
-
-        # Step 2: Create the dataset through a short-lived AsyncConnection
-        # rooted at the namespace-declared physical location.
-        def _create_table():
-            temp_async_conn = _make_temp_async_connection(
-                location,
-                self.read_consistency_interval,
-                merged_storage_options,
-                self.session,
-            )
-
-            return LOOP.run(
-                temp_async_conn.create_table(
-                    name,
-                    data,
-                    schema=schema,
-                    mode=mode,
-                    exist_ok=exist_ok,
-                    on_bad_vectors=on_bad_vectors,
-                    fill_value=fill_value,
-                    embedding_functions=embedding_functions,
-                    namespace_path=[],
-                    storage_options=merged_storage_options,
-                    location=location,
-                    namespace_client=self._namespace_client,
-                )
-            )
-
-        return await asyncio.to_thread(_create_table)
-
-    async def _create_table_server_side(
-        self,
-        name: str,
-        data: Optional[DATA],
-        schema: Optional[Union[pa.Schema, LanceModel]],
-        mode: str,
-        exist_ok: bool,
-        on_bad_vectors: str,
-        fill_value: float,
-        embedding_functions: Optional[List[EmbeddingFunctionConfig]],
-        namespace_path: Optional[List[str]],
-        storage_options: Optional[Dict[str, str]],
-    ) -> AsyncTable:
-        """Create a table using server-side namespace.create_table()."""
-        if namespace_path is None:
-            namespace_path = []
-        table_id = namespace_path + [name]
-
-        def _prepare_and_create():
-            arrow_ipc_bytes = _data_to_arrow_ipc(
-                data=data,
-                schema=schema,
-                embedding_functions=embedding_functions,
-                on_bad_vectors=on_bad_vectors,
-                fill_value=fill_value,
-            )
-
-            merged = dict(self.storage_options or {})
-            if storage_options:
-                merged.update(storage_options)
-            request = CreateTableRequest(
-                id=table_id,
-                mode=_normalize_create_table_mode(mode),
-                properties=merged or None,
-            )
-
-            self._namespace_client.create_table(request, arrow_ipc_bytes)
-
-        try:
-            await asyncio.to_thread(_prepare_and_create)
-        except Exception as e:
-            if exist_ok and "already exists" in str(e).lower():
-                return await self.open_table(
-                    name,
-                    namespace_path=namespace_path,
-                    storage_options=storage_options,
-                )
-            raise
-
-        return await self.open_table(
+        return await self._inner.create_table(
             name,
+            data,
+            schema=schema,
+            mode=mode,
+            exist_ok=exist_ok,
+            on_bad_vectors=on_bad_vectors,
+            fill_value=fill_value,
             namespace_path=namespace_path,
+            embedding_functions=embedding_functions,
             storage_options=storage_options,
         )
 
@@ -1251,44 +971,12 @@ class AsyncLanceNamespaceDBConnection:
         """Open an existing table from the namespace."""
         if namespace_path is None:
             namespace_path = []
-        table_id = namespace_path + [name]
-        request = DescribeTableRequest(id=table_id)
-        response = self._namespace_client.describe_table(request)
-
-        # Merge storage options: self.storage_options < user options < namespace options
-        merged_storage_options = dict(self.storage_options)
-        if storage_options:
-            merged_storage_options.update(storage_options)
-        if response.storage_options:
-            merged_storage_options.update(response.storage_options)
-
-        # Capture managed_versioning from describe response.
-        # Convert None to False since we already have the answer from describe_table.
-        managed_versioning = response.managed_versioning is True
-
-        # Open the table from the namespace-resolved physical location through a
-        # short-lived AsyncConnection.
-        def _open_table():
-            temp_async_conn = _make_temp_async_connection(
-                response.location,
-                self.read_consistency_interval,
-                merged_storage_options,
-                self.session,
-            )
-
-            return LOOP.run(
-                temp_async_conn.open_table(
-                    name,
-                    namespace_path=[],
-                    storage_options=merged_storage_options,
-                    index_cache_size=index_cache_size,
-                    location=response.location,
-                    namespace_client=None,
-                    managed_versioning=False,
-                )
-            )
-
-        return await asyncio.to_thread(_open_table)
+        return await self._inner.open_table(
+            name,
+            namespace_path=namespace_path,
+            storage_options=storage_options,
+            index_cache_size=index_cache_size,
+        )
 
     async def drop_table(self, name: str, namespace_path: Optional[List[str]] = None):
         """Drop a table from the namespace."""

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 from datetime import timedelta
 import pyarrow as pa
 
+from lancedb.background_loop import LOOP
 from lancedb.db import DBConnection, LanceDBConnection
 from lancedb.namespace_utils import (
     _normalize_create_namespace_mode,
@@ -582,30 +583,32 @@ class LanceNamespaceDBConnection(DBConnection):
             _is_temporary_location_connection=True,
         )
 
-        # Note: storage_options_provider is auto-created in Rust from namespace_client
-        tbl = LanceTable.create(
+        async_table = LOOP.run(
+            temp_conn._conn.create_table(
+                name,
+                data,
+                schema=schema,
+                mode=mode,
+                exist_ok=exist_ok,
+                on_bad_vectors=on_bad_vectors,
+                fill_value=fill_value,
+                embedding_functions=embedding_functions,
+                namespace_path=[],
+                storage_options=merged_storage_options,
+                location=location,
+                namespace_client=self._namespace_client,
+            )
+        )
+
+        return LanceTable(
             temp_conn,
             name,
-            data,
-            schema,
-            mode=mode,
-            exist_ok=exist_ok,
-            on_bad_vectors=on_bad_vectors,
-            fill_value=fill_value,
-            embedding_functions=embedding_functions,
-            namespace_path=[],
-            storage_options=merged_storage_options,
+            namespace_path=namespace_path,
             location=location,
             namespace_client=self._namespace_client,
             pushdown_operations=self._namespace_client_pushdown_operations,
+            _async=async_table,
         )
-
-        tbl._namespace_path = namespace_path
-        tbl._location = location
-        tbl._namespace_client = self._namespace_client
-        tbl._pushdown_operations = self._namespace_client_pushdown_operations
-
-        return tbl
 
     def _create_table_server_side(
         self,
@@ -939,28 +942,28 @@ class LanceNamespaceDBConnection(DBConnection):
             _is_temporary_location_connection=True,
         )
 
-        # Open the table using the temporary connection with the location parameter
-        # Pass namespace_client to enable managed versioning support and auto-create
-        # storage options provider
-        # Pass managed_versioning to avoid redundant describe_table call
-        # Pass pushdown_operations if configured on this connection
-        table = LanceTable.open(
-            temp_conn,
-            name,
-            namespace_path=[],
-            storage_options=storage_options,
-            index_cache_size=index_cache_size,
-            location=table_uri,
-            namespace_client=None,
-            managed_versioning=False,
-            pushdown_operations=self._namespace_client_pushdown_operations,
+        async_table = LOOP.run(
+            temp_conn._conn.open_table(
+                name,
+                namespace_path=[],
+                storage_options=storage_options,
+                index_cache_size=index_cache_size,
+                location=table_uri,
+                namespace_client=None,
+                managed_versioning=False,
+            )
         )
 
-        table._namespace_path = namespace_path
-        table._location = table_uri
-        table._namespace_client = namespace_client
-        table._pushdown_operations = self._namespace_client_pushdown_operations
-        return table
+        return LanceTable(
+            temp_conn,
+            name,
+            namespace_path=namespace_path,
+            location=table_uri,
+            namespace_client=namespace_client,
+            managed_versioning=managed_versioning,
+            pushdown_operations=self._namespace_client_pushdown_operations,
+            _async=async_table,
+        )
 
     @override
     def namespace_client(self) -> LanceNamespace:
@@ -1135,37 +1138,35 @@ class AsyncLanceNamespaceDBConnection:
         if namespace_storage_options:
             merged_storage_options.update(namespace_storage_options)
 
-        # Step 2: Create table using LanceTable.create with the location
-        # Run the sync operation in a thread
+        # Step 2: Create the dataset through the temporary connection from a
+        # thread, without re-entering LanceTable.create's shared path.
         def _create_table():
             temp_conn = LanceDBConnection(
                 location,
                 read_consistency_interval=self.read_consistency_interval,
                 storage_options=merged_storage_options,
                 session=self.session,
+                _is_temporary_location_connection=True,
             )
 
-            # storage_options_provider is auto-created in Rust from namespace_client
-            return LanceTable.create(
-                temp_conn,
-                name,
-                data,
-                schema,
-                mode=mode,
-                exist_ok=exist_ok,
-                on_bad_vectors=on_bad_vectors,
-                fill_value=fill_value,
-                embedding_functions=embedding_functions,
-                namespace_path=[],
-                storage_options=merged_storage_options,
-                location=location,
-                namespace_client=self._namespace_client,
-                pushdown_operations=self._namespace_client_pushdown_operations,
+            return LOOP.run(
+                temp_conn._conn.create_table(
+                    name,
+                    data,
+                    schema=schema,
+                    mode=mode,
+                    exist_ok=exist_ok,
+                    on_bad_vectors=on_bad_vectors,
+                    fill_value=fill_value,
+                    embedding_functions=embedding_functions,
+                    namespace_path=[],
+                    storage_options=merged_storage_options,
+                    location=location,
+                    namespace_client=self._namespace_client,
+                )
             )
 
-        lance_table = await asyncio.to_thread(_create_table)
-        # Get the underlying async table from LanceTable
-        return lance_table._table
+        return await asyncio.to_thread(_create_table)
 
     async def _create_table_server_side(
         self,
@@ -1249,9 +1250,7 @@ class AsyncLanceNamespaceDBConnection:
         managed_versioning = response.managed_versioning is True
 
         # Open the table from the namespace-resolved physical location in a
-        # thread. As in the sync helper above, use a temporary location-rooted
-        # connection, avoid reapplying namespace_path during the low-level open,
-        # and restore the logical namespace metadata on the Python wrapper.
+        # thread, without re-entering LanceTable.open's shared path.
         def _open_table():
             temp_conn = LanceDBConnection(
                 response.location,
@@ -1261,26 +1260,19 @@ class AsyncLanceNamespaceDBConnection:
                 _is_temporary_location_connection=True,
             )
 
-            table = LanceTable.open(
-                temp_conn,
-                name,
-                namespace_path=[],
-                storage_options=merged_storage_options,
-                index_cache_size=index_cache_size,
-                location=response.location,
-                namespace_client=None,
-                managed_versioning=False,
-                pushdown_operations=self._namespace_client_pushdown_operations,
+            return LOOP.run(
+                temp_conn._conn.open_table(
+                    name,
+                    namespace_path=[],
+                    storage_options=merged_storage_options,
+                    index_cache_size=index_cache_size,
+                    location=response.location,
+                    namespace_client=None,
+                    managed_versioning=False,
+                )
             )
 
-            table._namespace_path = namespace_path
-            table._location = response.location
-            table._namespace_client = self._namespace_client
-            table._pushdown_operations = self._namespace_client_pushdown_operations
-            return table
-
-        lance_table = await asyncio.to_thread(_open_table)
-        return lance_table._table
+        return await asyncio.to_thread(_open_table)
 
     async def drop_table(self, name: str, namespace_path: Optional[List[str]] = None):
         """Drop a table from the namespace."""

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -38,6 +38,7 @@ from lance_namespace_urllib3_client.models.query_table_request_vector import (
     QueryTableRequestVector,
 )
 from lance_namespace_urllib3_client.models.string_fts_query import StringFtsQuery
+from lance_namespace.errors import TableNotFoundError
 from lancedb._lancedb import connect_namespace_client as _connect_namespace_client
 from lancedb.background_loop import LOOP
 from lancedb.db import AsyncConnection, DBConnection
@@ -546,14 +547,20 @@ class LanceNamespaceDBConnection(DBConnection):
     ) -> Table:
         if namespace_path is None:
             namespace_path = []
-        async_table = LOOP.run(
-            self._inner.open_table(
-                name,
-                namespace_path=namespace_path,
-                storage_options=storage_options,
-                index_cache_size=index_cache_size,
+        try:
+            async_table = LOOP.run(
+                self._inner.open_table(
+                    name,
+                    namespace_path=namespace_path,
+                    storage_options=storage_options,
+                    index_cache_size=index_cache_size,
+                )
             )
-        )
+        except RuntimeError as e:
+            if "Table not found" in str(e):
+                table_id = namespace_path + [name]
+                raise TableNotFoundError(f"Table not found: {'$'.join(table_id)}")
+            raise
 
         return LanceTable(
             self,
@@ -971,12 +978,18 @@ class AsyncLanceNamespaceDBConnection:
         """Open an existing table from the namespace."""
         if namespace_path is None:
             namespace_path = []
-        return await self._inner.open_table(
-            name,
-            namespace_path=namespace_path,
-            storage_options=storage_options,
-            index_cache_size=index_cache_size,
-        )
+        try:
+            return await self._inner.open_table(
+                name,
+                namespace_path=namespace_path,
+                storage_options=storage_options,
+                index_cache_size=index_cache_size,
+            )
+        except RuntimeError as e:
+            if "Table not found" in str(e):
+                table_id = namespace_path + [name]
+                raise TableNotFoundError(f"Table not found: {'$'.join(table_id)}")
+            raise
 
     async def drop_table(self, name: str, namespace_path: Optional[List[str]] = None):
         """Drop a table from the namespace."""

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -10,7 +10,7 @@ use std::{
 use arrow::{datatypes::Schema, ffi_stream::ArrowArrayStreamReader, pyarrow::FromPyArrow};
 use lancedb::{
     connection::Connection as LanceConnection,
-    connection::PushdownOperation,
+    connection::NamespaceClientPushdownOperation,
     database::namespace::LanceNamespaceDatabase,
     database::{CreateTableMode, Database, ReadConsistency},
 };
@@ -45,17 +45,17 @@ impl Connection {
     }
 }
 
-fn parse_pushdown_operations(
+fn parse_namespace_client_pushdown_operations(
     operations: Option<Vec<String>>,
-) -> PyResult<HashSet<PushdownOperation>> {
+) -> PyResult<HashSet<NamespaceClientPushdownOperation>> {
     let mut parsed = HashSet::new();
     for operation in operations.unwrap_or_default() {
         match operation.as_str() {
             "QueryTable" => {
-                parsed.insert(PushdownOperation::QueryTable);
+                parsed.insert(NamespaceClientPushdownOperation::QueryTable);
             }
             "CreateTable" => {
-                parsed.insert(PushdownOperation::CreateTable);
+                parsed.insert(NamespaceClientPushdownOperation::CreateTable);
             }
             _ => {
                 return Err(PyValueError::new_err(format!(
@@ -590,7 +590,8 @@ pub fn connect_namespace_client(
 ) -> PyResult<Connection> {
     let namespace_client = extract_namespace_arc(py, namespace_client)?;
     let read_consistency_interval = read_consistency_interval.map(Duration::from_secs_f64);
-    let pushdown_operations = parse_pushdown_operations(namespace_client_pushdown_operations)?;
+    let namespace_client_pushdown_operations =
+        parse_namespace_client_pushdown_operations(namespace_client_pushdown_operations)?;
     let ns_impl = namespace_client_impl.unwrap_or_else(|| "python".to_string());
     let ns_properties = namespace_client_properties.unwrap_or_default();
     let storage_options = storage_options.unwrap_or_default();
@@ -603,7 +604,7 @@ pub fn connect_namespace_client(
         storage_options,
         read_consistency_interval,
         session,
-        pushdown_operations,
+        namespace_client_pushdown_operations,
     );
 
     Ok(Connection::new(LanceConnection::new(

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use arrow::{datatypes::Schema, ffi_stream::ArrowArrayStreamReader, pyarrow::FromPyArrow};
 use lancedb::{
     connection::Connection as LanceConnection,
+    connection::PushdownOperation,
+    database::namespace::LanceNamespaceDatabase,
     database::{CreateTableMode, Database, ReadConsistency},
 };
 use pyo3::{
@@ -37,6 +43,29 @@ impl Connection {
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("Connection is closed"))
     }
+}
+
+fn parse_pushdown_operations(
+    operations: Option<Vec<String>>,
+) -> PyResult<HashSet<PushdownOperation>> {
+    let mut parsed = HashSet::new();
+    for operation in operations.unwrap_or_default() {
+        match operation.as_str() {
+            "QueryTable" => {
+                parsed.insert(PushdownOperation::QueryTable);
+            }
+            "CreateTable" => {
+                parsed.insert(PushdownOperation::CreateTable);
+            }
+            _ => {
+                return Err(PyValueError::new_err(format!(
+                    "Invalid pushdown operation: {}",
+                    operation
+                )));
+            }
+        }
+    }
+    Ok(parsed)
 }
 
 impl Connection {
@@ -536,6 +565,51 @@ pub fn connect(
         }
         Ok(Connection::new(builder.execute().await.infer_error()?))
     })
+}
+
+#[pyfunction]
+#[pyo3(signature = (
+    namespace_client,
+    read_consistency_interval=None,
+    storage_options=None,
+    session=None,
+    namespace_client_pushdown_operations=None,
+    namespace_client_impl=None,
+    namespace_client_properties=None,
+))]
+#[allow(clippy::too_many_arguments)]
+pub fn connect_namespace_client(
+    py: Python<'_>,
+    namespace_client: Py<PyAny>,
+    read_consistency_interval: Option<f64>,
+    storage_options: Option<HashMap<String, String>>,
+    session: Option<crate::session::Session>,
+    namespace_client_pushdown_operations: Option<Vec<String>>,
+    namespace_client_impl: Option<String>,
+    namespace_client_properties: Option<HashMap<String, String>>,
+) -> PyResult<Connection> {
+    let namespace_client = extract_namespace_arc(py, namespace_client)?;
+    let read_consistency_interval = read_consistency_interval.map(Duration::from_secs_f64);
+    let pushdown_operations = parse_pushdown_operations(namespace_client_pushdown_operations)?;
+    let ns_impl = namespace_client_impl.unwrap_or_else(|| "python".to_string());
+    let ns_properties = namespace_client_properties.unwrap_or_default();
+    let storage_options = storage_options.unwrap_or_default();
+    let session = session.map(|s| s.inner.clone());
+
+    let database = LanceNamespaceDatabase::from_namespace_client(
+        namespace_client,
+        ns_impl,
+        ns_properties,
+        storage_options,
+        read_consistency_interval,
+        session,
+        pushdown_operations,
+    );
+
+    Ok(Connection::new(LanceConnection::new(
+        Arc::new(database),
+        Arc::new(lancedb::embeddings::MemoryRegistry::new()),
+    )))
 }
 
 #[derive(FromPyObject)]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use arrow::RecordBatchStream;
-use connection::{Connection, connect};
+use connection::{Connection, connect, connect_namespace_client};
 use env_logger::Env;
 use expr::{PyExpr, expr_col, expr_func, expr_lit};
 use index::IndexConfig;
@@ -58,6 +58,7 @@ pub fn _lancedb(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPermutationReader>()?;
     m.add_class::<PyExpr>()?;
     m.add_function(wrap_pyfunction!(connect, m)?)?;
+    m.add_function(wrap_pyfunction!(connect_namespace_client, m)?)?;
     m.add_function(wrap_pyfunction!(permutation::async_permutation_builder, m)?)?;
     m.add_function(wrap_pyfunction!(util::validate_table_name, m)?)?;
     m.add_function(wrap_pyfunction!(query::fts_query_to_json, m)?)?;

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -915,7 +915,7 @@ use std::collections::HashSet;
 /// These operations will be executed on the namespace server instead of locally
 /// when enabled via [`ConnectNamespaceBuilder::pushdown_operations`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PushdownOperation {
+pub enum NamespaceClientPushdownOperation {
     /// Execute queries on the namespace server via `query_table()` instead of locally.
     QueryTable,
     /// Execute table creation on the namespace server via `create_table()`
@@ -931,7 +931,7 @@ pub struct ConnectNamespaceBuilder {
     read_consistency_interval: Option<std::time::Duration>,
     embedding_registry: Option<Arc<dyn EmbeddingRegistry>>,
     session: Option<Arc<lance::session::Session>>,
-    pushdown_operations: HashSet<PushdownOperation>,
+    pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
 }
 
 impl ConnectNamespaceBuilder {
@@ -1029,11 +1029,11 @@ impl ConnectNamespaceBuilder {
     /// and leveraging server-side compute resources.
     ///
     /// Available operations:
-    /// - [`PushdownOperation::QueryTable`]: Execute queries via `namespace.query_table()`
-    /// - [`PushdownOperation::CreateTable`]: Execute table creation via `namespace.create_table()`
+    /// - [`NamespaceClientPushdownOperation::QueryTable`]: Execute queries via `namespace.query_table()`
+    /// - [`NamespaceClientPushdownOperation::CreateTable`]: Execute table creation via `namespace.create_table()`
     ///
     /// By default, no operations are pushed down (all executed locally).
-    pub fn pushdown_operation(mut self, operation: PushdownOperation) -> Self {
+    pub fn pushdown_operation(mut self, operation: NamespaceClientPushdownOperation) -> Self {
         self.pushdown_operations.insert(operation);
         self
     }
@@ -1043,7 +1043,7 @@ impl ConnectNamespaceBuilder {
     /// See [`Self::pushdown_operation`] for details.
     pub fn pushdown_operations(
         mut self,
-        operations: impl IntoIterator<Item = PushdownOperation>,
+        operations: impl IntoIterator<Item = NamespaceClientPushdownOperation>,
     ) -> Self {
         self.pushdown_operations.extend(operations);
         self

--- a/rust/lancedb/src/database/namespace.rs
+++ b/rust/lancedb/src/database/namespace.rs
@@ -52,6 +52,27 @@ pub struct LanceNamespaceDatabase {
 }
 
 impl LanceNamespaceDatabase {
+    pub fn from_namespace_client(
+        namespace: Arc<dyn LanceNamespace>,
+        ns_impl: String,
+        ns_properties: HashMap<String, String>,
+        storage_options: HashMap<String, String>,
+        read_consistency_interval: Option<std::time::Duration>,
+        session: Option<Arc<lance::session::Session>>,
+        pushdown_operations: HashSet<PushdownOperation>,
+    ) -> Self {
+        Self {
+            namespace,
+            storage_options,
+            read_consistency_interval,
+            session,
+            uri: format!("namespace://{}", ns_impl),
+            pushdown_operations,
+            ns_impl,
+            ns_properties,
+        }
+    }
+
     pub async fn connect(
         ns_impl: &str,
         ns_properties: HashMap<String, String>,

--- a/rust/lancedb/src/database/namespace.rs
+++ b/rust/lancedb/src/database/namespace.rs
@@ -26,6 +26,7 @@ use crate::connection::NamespaceClientPushdownOperation;
 use crate::database::ReadConsistency;
 use crate::error::{Error, Result};
 use crate::table::NativeTable;
+use lance::dataset::WriteMode;
 
 use super::{
     BaseTable, CloneTableRequest, CreateTableMode, CreateTableRequest as DbCreateTableRequest,
@@ -184,6 +185,7 @@ impl Database for LanceNamespaceDatabase {
     async fn create_table(&self, request: DbCreateTableRequest) -> Result<Arc<dyn BaseTable>> {
         let mut table_id = request.namespace_path.clone();
         table_id.push(request.name.clone());
+        let mut existing_table = None;
 
         match request.mode {
             CreateTableMode::Create => {}
@@ -192,20 +194,7 @@ impl Database for LanceNamespaceDatabase {
                     id: Some(table_id.clone()),
                     ..Default::default()
                 };
-                let describe_result = self.namespace.describe_table(describe_request).await;
-                if describe_result.is_ok() {
-                    // Drop the existing table - must succeed
-                    let drop_request = DropTableRequest {
-                        id: Some(table_id.clone()),
-                        ..Default::default()
-                    };
-                    self.namespace
-                        .drop_table(drop_request)
-                        .await
-                        .map_err(|e| Error::Runtime {
-                            message: format!("Failed to drop existing table for overwrite: {}", e),
-                        })?;
-                }
+                existing_table = self.namespace.describe_table(describe_request).await.ok();
             }
             CreateTableMode::ExistOk(_) => {
                 let describe_request = DescribeTableRequest {
@@ -240,39 +229,54 @@ impl Database for LanceNamespaceDatabase {
         };
 
         let (location, initial_storage_options, managed_versioning) = {
-            let response = self
-                .namespace
-                .declare_table(declare_request)
-                .await
-                .map_err(|e| {
-                    let err_str = e.to_string();
-                    if matches!(request.mode, CreateTableMode::Create)
-                        && (err_str.contains("already exists")
-                            || err_str.contains("TableAlreadyExists")
-                            || err_str.contains("table already exists"))
-                    {
-                        Error::TableAlreadyExists {
-                            name: request.name.clone(),
-                        }
-                    } else {
-                        Error::Runtime {
-                            message: format!("Failed to declare table: {}", e),
-                        }
-                    }
+            if let Some(response) = existing_table {
+                let loc = response.location.ok_or_else(|| Error::Runtime {
+                    message: "Table location is missing from describe_table response".to_string(),
                 })?;
-            let loc = response.location.ok_or_else(|| Error::Runtime {
-                message: "Table location is missing from declare_table response".to_string(),
-            })?;
-            // Use storage options from response, fall back to self.storage_options
-            let opts = response
-                .storage_options
-                .or_else(|| Some(self.storage_options.clone()))
-                .filter(|o| !o.is_empty());
-            (loc, opts, response.managed_versioning)
+                let opts = response
+                    .storage_options
+                    .or_else(|| Some(self.storage_options.clone()))
+                    .filter(|o| !o.is_empty());
+                (loc, opts, response.managed_versioning)
+            } else {
+                let response = self
+                    .namespace
+                    .declare_table(declare_request)
+                    .await
+                    .map_err(|e| {
+                        let err_str = e.to_string();
+                        if matches!(request.mode, CreateTableMode::Create)
+                            && (err_str.contains("already exists")
+                                || err_str.contains("TableAlreadyExists")
+                                || err_str.contains("table already exists"))
+                        {
+                            Error::TableAlreadyExists {
+                                name: request.name.clone(),
+                            }
+                        } else {
+                            Error::Runtime {
+                                message: format!("Failed to declare table: {}", e),
+                            }
+                        }
+                    })?;
+                let loc = response.location.ok_or_else(|| Error::Runtime {
+                    message: "Table location is missing from declare_table response".to_string(),
+                })?;
+                // Use storage options from response, fall back to self.storage_options
+                let opts = response
+                    .storage_options
+                    .or_else(|| Some(self.storage_options.clone()))
+                    .filter(|o| !o.is_empty());
+                (loc, opts, response.managed_versioning)
+            }
         };
 
         // Build write params with storage options and commit handler
         let mut params = request.write_options.lance_write_params.unwrap_or_default();
+
+        if matches!(request.mode, CreateTableMode::Overwrite) {
+            params.mode = WriteMode::Overwrite;
+        }
 
         // Set up storage options if provided
         if let Some(storage_opts) = initial_storage_options {

--- a/rust/lancedb/src/database/namespace.rs
+++ b/rust/lancedb/src/database/namespace.rs
@@ -22,7 +22,7 @@ use lance_namespace_impls::ConnectBuilder;
 use lance_table::io::commit::CommitHandler;
 use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 
-use crate::connection::PushdownOperation;
+use crate::connection::NamespaceClientPushdownOperation;
 use crate::database::ReadConsistency;
 use crate::error::{Error, Result};
 use crate::table::NativeTable;
@@ -44,7 +44,7 @@ pub struct LanceNamespaceDatabase {
     // database URI
     uri: String,
     // Operations to push down to the namespace server
-    pushdown_operations: HashSet<PushdownOperation>,
+    pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
     // Namespace implementation type (e.g., "dir", "rest")
     ns_impl: String,
     // Namespace properties used to construct the namespace client
@@ -53,23 +53,23 @@ pub struct LanceNamespaceDatabase {
 
 impl LanceNamespaceDatabase {
     pub fn from_namespace_client(
-        namespace: Arc<dyn LanceNamespace>,
-        ns_impl: String,
-        ns_properties: HashMap<String, String>,
+        namespace_client: Arc<dyn LanceNamespace>,
+        namespace_client_impl: String,
+        namespace_client_properties: HashMap<String, String>,
         storage_options: HashMap<String, String>,
         read_consistency_interval: Option<std::time::Duration>,
         session: Option<Arc<lance::session::Session>>,
-        pushdown_operations: HashSet<PushdownOperation>,
+        namespace_client_pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
     ) -> Self {
         Self {
-            namespace,
+            namespace: namespace_client,
             storage_options,
             read_consistency_interval,
             session,
-            uri: format!("namespace://{}", ns_impl),
-            pushdown_operations,
-            ns_impl,
-            ns_properties,
+            uri: format!("namespace://{}", namespace_client_impl),
+            pushdown_operations: namespace_client_pushdown_operations,
+            ns_impl: namespace_client_impl,
+            ns_properties: namespace_client_properties,
         }
     }
 
@@ -79,7 +79,7 @@ impl LanceNamespaceDatabase {
         storage_options: HashMap<String, String>,
         read_consistency_interval: Option<std::time::Duration>,
         session: Option<Arc<lance::session::Session>>,
-        pushdown_operations: HashSet<PushdownOperation>,
+        pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
     ) -> Result<Self> {
         let mut builder = ConnectBuilder::new(ns_impl);
         for (key, value) in ns_properties.clone() {

--- a/rust/lancedb/src/database/namespace.rs
+++ b/rust/lancedb/src/database/namespace.rs
@@ -184,22 +184,15 @@ impl Database for LanceNamespaceDatabase {
     async fn create_table(&self, request: DbCreateTableRequest) -> Result<Arc<dyn BaseTable>> {
         let mut table_id = request.namespace_path.clone();
         table_id.push(request.name.clone());
-        let describe_request = DescribeTableRequest {
-            id: Some(table_id.clone()),
-            ..Default::default()
-        };
-
-        let describe_result = self.namespace.describe_table(describe_request).await;
 
         match request.mode {
-            CreateTableMode::Create => {
-                if describe_result.is_ok() {
-                    return Err(Error::TableAlreadyExists {
-                        name: request.name.clone(),
-                    });
-                }
-            }
+            CreateTableMode::Create => {}
             CreateTableMode::Overwrite => {
+                let describe_request = DescribeTableRequest {
+                    id: Some(table_id.clone()),
+                    ..Default::default()
+                };
+                let describe_result = self.namespace.describe_table(describe_request).await;
                 if describe_result.is_ok() {
                     // Drop the existing table - must succeed
                     let drop_request = DropTableRequest {
@@ -215,6 +208,11 @@ impl Database for LanceNamespaceDatabase {
                 }
             }
             CreateTableMode::ExistOk(_) => {
+                let describe_request = DescribeTableRequest {
+                    id: Some(table_id.clone()),
+                    ..Default::default()
+                };
+                let describe_result = self.namespace.describe_table(describe_request).await;
                 if describe_result.is_ok() {
                     let native_table = NativeTable::open_from_namespace(
                         self.namespace.clone(),
@@ -242,7 +240,26 @@ impl Database for LanceNamespaceDatabase {
         };
 
         let (location, initial_storage_options, managed_versioning) = {
-            let response = self.namespace.declare_table(declare_request).await?;
+            let response = self
+                .namespace
+                .declare_table(declare_request)
+                .await
+                .map_err(|e| {
+                    let err_str = e.to_string();
+                    if matches!(request.mode, CreateTableMode::Create)
+                        && (err_str.contains("already exists")
+                            || err_str.contains("TableAlreadyExists")
+                            || err_str.contains("table already exists"))
+                    {
+                        Error::TableAlreadyExists {
+                            name: request.name.clone(),
+                        }
+                    } else {
+                        Error::Runtime {
+                            message: format!("Failed to declare table: {}", e),
+                        }
+                    }
+                })?;
             let loc = response.location.ok_or_else(|| Error::Runtime {
                 message: "Table location is missing from declare_table response".to_string(),
             })?;

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -47,7 +47,7 @@ use std::format;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::connection::PushdownOperation;
+use crate::connection::NamespaceClientPushdownOperation;
 
 use crate::data::scannable::{PeekedScannable, Scannable, estimate_write_partitions};
 use crate::database::Database;
@@ -1272,7 +1272,7 @@ pub struct NativeTable {
     pub(crate) namespace_client: Option<Arc<dyn LanceNamespace>>,
     // Operations to push down to the namespace server.
     // pub(crate) so query.rs can access the field for server-side query execution.
-    pub(crate) pushdown_operations: HashSet<PushdownOperation>,
+    pub(crate) pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
 }
 
 impl std::fmt::Debug for NativeTable {
@@ -1359,7 +1359,7 @@ impl NativeTable {
         params: Option<ReadParams>,
         read_consistency_interval: Option<std::time::Duration>,
         namespace_client: Option<Arc<dyn LanceNamespace>>,
-        pushdown_operations: HashSet<PushdownOperation>,
+        pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
         managed_versioning: Option<bool>,
     ) -> Result<Self> {
         let params = params.unwrap_or_default();
@@ -1470,7 +1470,7 @@ impl NativeTable {
         write_store_wrapper: Option<Arc<dyn WrappingObjectStore>>,
         params: Option<ReadParams>,
         read_consistency_interval: Option<std::time::Duration>,
-        pushdown_operations: HashSet<PushdownOperation>,
+        pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
         session: Option<Arc<lance::session::Session>>,
     ) -> Result<Self> {
         let mut params = params.unwrap_or_default();
@@ -1518,7 +1518,7 @@ impl NativeTable {
         let id = Self::build_id(&namespace, name);
 
         let stored_namespace_client =
-            if pushdown_operations.contains(&PushdownOperation::QueryTable) {
+            if pushdown_operations.contains(&NamespaceClientPushdownOperation::QueryTable) {
                 Some(namespace_client)
             } else {
                 None
@@ -1588,7 +1588,7 @@ impl NativeTable {
         params: Option<WriteParams>,
         read_consistency_interval: Option<std::time::Duration>,
         namespace_client: Option<Arc<dyn LanceNamespace>>,
-        pushdown_operations: HashSet<PushdownOperation>,
+        pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
     ) -> Result<Self> {
         // Default params uses format v1.
         let params = params.unwrap_or(WriteParams {
@@ -1635,7 +1635,7 @@ impl NativeTable {
         params: Option<WriteParams>,
         read_consistency_interval: Option<std::time::Duration>,
         namespace_client: Option<Arc<dyn LanceNamespace>>,
-        pushdown_operations: HashSet<PushdownOperation>,
+        pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
     ) -> Result<Self> {
         let data: Box<dyn Scannable> = Box::new(RecordBatch::new_empty(schema));
         Self::create(
@@ -1685,7 +1685,7 @@ impl NativeTable {
         write_store_wrapper: Option<Arc<dyn WrappingObjectStore>>,
         params: Option<WriteParams>,
         read_consistency_interval: Option<std::time::Duration>,
-        pushdown_operations: HashSet<PushdownOperation>,
+        pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
         session: Option<Arc<lance::session::Session>>,
     ) -> Result<Self> {
         // Build table_id from namespace + name for the storage options provider
@@ -1738,7 +1738,7 @@ impl NativeTable {
         let id = Self::build_id(&namespace, name);
 
         let stored_namespace_client =
-            if pushdown_operations.contains(&PushdownOperation::QueryTable) {
+            if pushdown_operations.contains(&NamespaceClientPushdownOperation::QueryTable) {
                 Some(namespace_client)
             } else {
                 None

--- a/rust/lancedb/src/table/query.rs
+++ b/rust/lancedb/src/table/query.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use super::NativeTable;
-use crate::connection::PushdownOperation;
+use crate::connection::NamespaceClientPushdownOperation;
 use crate::error::{Error, Result};
 use crate::expr::expr_to_sql_string;
 use crate::query::{
@@ -44,7 +44,7 @@ pub async fn execute_query(
     // If QueryTable pushdown is enabled and namespace client is configured, use server-side query execution
     if table
         .pushdown_operations
-        .contains(&PushdownOperation::QueryTable)
+        .contains(&NamespaceClientPushdownOperation::QueryTable)
         && let Some(ref namespace_client) = table.namespace_client
     {
         return execute_namespace_query(table, namespace_client.clone(), query, options).await;


### PR DESCRIPTION
So far, I have been using a hacky approach that creates and opens namespace-backed table, by getting its location and use a temporary lancedb connection to create or open it. This was working for features like credentials vending but is no longer fully working for the managed versioning feature, recently geneva tests have been failing here and there and various patches are not addressing the root cause. This PR fully fixes this and implements proper rust binding for it. Specifically:

- build a real Rust namespace-backed connection from the Python namespace client
- route namespace table create/open through that connection instead of resolved-location temp connections
- keep namespace client naming consistent in the Rust bridge and preserve federated namespace + DuckDB behavior