### PR TITLE
fix: allow appending arrow.json data into lance.json tables

### DIFF
--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -818,5 +818,122 @@ mod tests {
         table.add(batch).execute().await.unwrap();
 
         assert_eq!(table.count_rows(None).await.unwrap(), 3);
+
+        // Verify the data was correctly written by reading it back.
+        // Lance stores JSON as JSONB (binary format), so we read as large_binary
+        // and verify the content can be parsed.
+        let results: Vec<RecordBatch> = table
+            .query()
+            .select(Select::columns(&["data"]))
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 3);
+
+        // Verify null value is preserved
+        assert!(batch.column(0).is_null(0));
+
+        // Verify JSON values are correctly stored (as JSONB binary)
+        let json_col = batch.column(0);
+        let json_bytes: &arrow_array::LargeBinaryArray = json_col.as_binary();
+
+        // Row 1: {"a": 1}
+        assert!(!json_bytes.is_null(1));
+        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
+        assert!(json1.contains("\"a\":") || json1.contains("a"));
+
+        // Row 2: {"b": 2}
+        assert!(!json_bytes.is_null(2));
+        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
+        assert!(json2.contains("\"b\":") || json2.contains("b"));
+    }
+
+    /// Test that LargeUtf8-backed arrow.json can be appended to a lance.json table.
+    /// This is similar to the Utf8 case but uses LargeUtf8 which is the default for
+    /// PyArrow's pa.large_string() or when creating pa.json_() with certain versions.
+    #[tokio::test]
+    async fn test_add_arrow_json_large_utf8_into_lance_json_table() {
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
+
+        // Build a table whose "data" column is lance.json (LargeBinary +
+        // ARROW:extension:name = "lance.json").
+        let lance_json_field = lance_arrow::json::json_field("data", true);
+        let table_schema = Arc::new(Schema::new(vec![lance_json_field.clone()]));
+
+        let db = connect("memory://").execute().await.unwrap();
+        let table = db
+            .create_empty_table("json_test_large_utf8", table_schema)
+            .execute()
+            .await
+            .unwrap();
+
+        // Verify the table schema looks like lance.json.
+        let stored_field = table.schema().await.unwrap();
+        let data_field = stored_field.field_with_name("data").unwrap();
+        assert_eq!(data_field.data_type(), &DataType::LargeBinary);
+        assert_eq!(
+            data_field.metadata().get("ARROW:extension:name").map(|s| s.as_str()),
+            Some(JSON_EXT_NAME),
+        );
+
+        // Now append using a LargeUtf8-backed arrow.json typed field.
+        let mut arrow_json_metadata = std::collections::HashMap::new();
+        arrow_json_metadata.insert(
+            "ARROW:extension:name".to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let arrow_json_field = Field::new("data", DataType::LargeUtf8, true)
+            .with_metadata(arrow_json_metadata);
+        let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
+
+        let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"x": 10}"#), Some(r#"{"y": 20}"#)];
+        let string_array: Arc<dyn arrow_array::Array> = Arc::new(
+            arrow_array::LargeStringArray::from(json_values),
+        );
+        let batch =
+            RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
+
+        // This must not fail with a schema-mismatch error.
+        table.add(batch).execute().await.unwrap();
+
+        assert_eq!(table.count_rows(None).await.unwrap(), 3);
+
+        // Verify the data was correctly written by reading it back.
+        let results: Vec<RecordBatch> = table
+            .query()
+            .select(Select::columns(&["data"]))
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 3);
+
+        // Verify null value is preserved
+        assert!(batch.column(0).is_null(0));
+
+        // Verify JSON values are correctly stored (as JSONB binary)
+        let json_col = batch.column(0);
+        let json_bytes: &arrow_array::LargeBinaryArray = json_col.as_binary();
+
+        // Row 1: {"x": 10}
+        assert!(!json_bytes.is_null(1));
+        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
+        assert!(json1.contains("\"x\":") || json1.contains("x"));
+
+        // Row 2: {"y": 20}
+        assert!(!json_bytes.is_null(2));
+        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
+        assert!(json2.contains("\"y\":") || json2.contains("y"));
     }
 }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -761,4 +761,62 @@ mod tests {
         table2.add(struct_batch).execute().await.unwrap();
         assert_eq!(table2.count_rows(None).await.unwrap(), 2);
     }
+
+    /// Regression test: appending `arrow.json` (PyArrow `pa.json_()`) data into a table
+    /// whose schema was created with `pa.json_()` (internally stored as `lance.json`, backed
+    /// by `LargeBinary`) must succeed without a schema-mismatch error.
+    ///
+    /// Previously `build_field_exprs` would attempt a `Utf8 → LargeBinary` DataFusion cast,
+    /// which produced a field whose Arrow extension metadata still read `arrow.json` instead
+    /// of `lance.json`.  Lance-core then rejected the append with
+    /// `"json vs large_binary" schema mismatch`.
+    #[tokio::test]
+    async fn test_add_arrow_json_into_lance_json_table() {
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
+
+        // Build a table whose "data" column is lance.json (LargeBinary +
+        // ARROW:extension:name = "lance.json").  We use json_field() helper from
+        // lance-arrow which produces exactly this shape.
+        let lance_json_field = lance_arrow::json::json_field("data", true);
+        let table_schema = Arc::new(Schema::new(vec![lance_json_field.clone()]));
+
+        let db = connect("memory://").execute().await.unwrap();
+        let table = db
+            .create_empty_table("json_test", table_schema)
+            .execute()
+            .await
+            .unwrap();
+
+        // Verify the table schema looks like lance.json.
+        let stored_field = table.schema().await.unwrap();
+        let data_field = stored_field.field_with_name("data").unwrap();
+        assert_eq!(data_field.data_type(), &DataType::LargeBinary);
+        assert_eq!(
+            data_field.metadata().get("ARROW:extension:name").map(|s| s.as_str()),
+            Some(JSON_EXT_NAME),
+        );
+
+        // Now append using an arrow.json typed field (Utf8 + arrow.json extension).
+        // This is what PyArrow produces for pa.json_() arrays.
+        let mut arrow_json_metadata = std::collections::HashMap::new();
+        arrow_json_metadata.insert(
+            "ARROW:extension:name".to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let arrow_json_field = Field::new("data", DataType::Utf8, true)
+            .with_metadata(arrow_json_metadata);
+        let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
+
+        let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"a": 1}"#), Some(r#"{"b": 2}"#)];
+        let string_array: Arc<dyn arrow_array::Array> = Arc::new(
+            arrow_array::StringArray::from(json_values),
+        );
+        let batch =
+            RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
+
+        // This must not fail with a schema-mismatch error.
+        table.add(batch).execute().await.unwrap();
+
+        assert_eq!(table.count_rows(None).await.unwrap(), 3);
+    }
 }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -845,13 +845,15 @@ mod tests {
 
         // Row 1: {"a": 1}
         assert!(!json_bytes.is_null(1));
-        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
-        assert!(json1.contains("\"a\":") || json1.contains("a"));
+        let json1 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(1).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json1, serde_json::json!({"a": 1}));
 
         // Row 2: {"b": 2}
         assert!(!json_bytes.is_null(2));
-        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
-        assert!(json2.contains("\"b\":") || json2.contains("b"));
+        let json2 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(2).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json2, serde_json::json!({"b": 2}));
     }
 
     /// Test that LargeUtf8-backed arrow.json can be appended to a lance.json table.
@@ -928,12 +930,14 @@ mod tests {
 
         // Row 1: {"x": 10}
         assert!(!json_bytes.is_null(1));
-        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
-        assert!(json1.contains("\"x\":") || json1.contains("x"));
+        let json1 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(1).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json1, serde_json::json!({"x": 10}));
 
         // Row 2: {"y": 20}
         assert!(!json_bytes.is_null(2));
-        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
-        assert!(json2.contains("\"y\":") || json2.contains("y"));
+        let json2 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(2).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json2, serde_json::json!({"y": 20}));
     }
 }

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -641,7 +641,7 @@ mod tests {
     /// batch with a "json vs large_binary" schema-mismatch error.
     #[tokio::test]
     async fn test_arrow_json_passthrough_to_lance_json() {
-        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME, json_field};
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, json_field};
         use lance_arrow::ARROW_EXT_NAME_KEY;
 
         // Build a table schema with a lance.json field (LargeBinary + lance.json metadata).

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -13,6 +13,7 @@ use datafusion_physical_expr::expressions::{CastExpr, Literal};
 use datafusion_physical_plan::expressions::Column;
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+use lance_arrow::json::{is_arrow_json_field, is_json_field};
 
 use crate::{Error, Result};
 
@@ -63,6 +64,18 @@ fn build_field_exprs(
 
         let input_field = &input_fields[input_idx];
         let input_expr = get_input_expr(input_idx);
+
+        // Special case: input is arrow.json (PyArrow pa.json_() extension type backed by
+        // Utf8/LargeUtf8) and the table field is lance.json (backed by LargeBinary).
+        // Lance-core's write path already handles the arrow.json → lance.json conversion
+        // (including JSONB encoding), so we pass the expression through unchanged and let
+        // lance-core deal with it. Attempting to cast Utf8 → LargeBinary here would
+        // produce a field whose metadata still identifies it as arrow.json, which then
+        // causes a schema-mismatch error inside lance-core.
+        if is_arrow_json_field(input_field) && is_json_field(table_field) {
+            result.push((input_expr, Arc::clone(input_field) as FieldRef));
+            continue;
+        }
 
         let expr = match (input_field.data_type(), table_field.data_type()) {
             // Both are structs: recurse into sub-fields to handle subschemas and casts.
@@ -617,5 +630,61 @@ mod tests {
             .downcast_ref()
             .unwrap();
         assert_eq!(a.values(), &[1, 3]);
+    }
+
+    /// `arrow.json` input (PyArrow `pa.json_()`, Utf8 + extension metadata) against a
+    /// `lance.json` table field (LargeBinary + extension metadata) must be passed through
+    /// without a cast so that lance-core can perform its own arrow.json → JSONB conversion.
+    ///
+    /// Before the fix, `cast_to_table_schema` attempted a `Utf8 → LargeBinary` DataFusion
+    /// cast that preserved the wrong extension metadata, causing lance-core to reject the
+    /// batch with a "json vs large_binary" schema-mismatch error.
+    #[tokio::test]
+    async fn test_arrow_json_passthrough_to_lance_json() {
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME, json_field};
+        use lance_arrow::ARROW_EXT_NAME_KEY;
+
+        // Build a table schema with a lance.json field (LargeBinary + lance.json metadata).
+        let lance_field = json_field("data", true);
+        let table_schema = Schema::new(vec![lance_field]);
+
+        // Build an input batch with an arrow.json field (Utf8 + arrow.json metadata).
+        let mut arrow_meta = std::collections::HashMap::new();
+        arrow_meta.insert(ARROW_EXT_NAME_KEY.to_string(), ARROW_JSON_EXT_NAME.to_string());
+        let arrow_field = Field::new("data", DataType::Utf8, true).with_metadata(arrow_meta);
+        let input_schema = Arc::new(Schema::new(vec![arrow_field]));
+        let input_batch = RecordBatch::try_new(
+            input_schema,
+            vec![Arc::new(StringArray::from(vec![
+                Some(r#"{"x": 1}"#),
+                None,
+                Some(r#"{"y": 2}"#),
+            ]))],
+        )
+        .unwrap();
+
+        let plan = plan_from_batch(input_batch).await;
+        let projected = cast_to_table_schema(plan, &table_schema).unwrap();
+
+        // The projected schema's "data" field must carry arrow.json metadata
+        // (the input field), not be silently dropped or miscast.
+        let out_field = projected.schema().field_with_name("data").unwrap().clone();
+        assert_eq!(out_field.data_type(), &DataType::Utf8);
+        assert_eq!(
+            out_field
+                .metadata()
+                .get(ARROW_EXT_NAME_KEY)
+                .map(|s| s.as_str()),
+            Some(ARROW_JSON_EXT_NAME),
+            "output field must still carry arrow.json metadata so lance-core can handle it"
+        );
+
+        // The data must flow through correctly (3 rows, no panic).
+        let result = collect(projected).await;
+        assert_eq!(result.num_rows(), 3);
+        let col: &StringArray = result.column(0).as_any().downcast_ref().unwrap();
+        assert_eq!(col.value(0), r#"{"x": 1}"#);
+        assert!(result.column(0).is_null(1));
+        assert_eq!(col.value(2), r#"{"y": 2}"#);
     }
 }


### PR DESCRIPTION
Bug Description
fixes: https://github.com/lancedb/lancedb/issues/3144

  When a table is created with pa.json_() (PyArrow's JSON extension type), it is internally stored as lance.json (backed by LargeBinary with ARROW:extension:name: lance.json field metadata). However, calling
  table.add() with pa.json_() data fails with:

   1 RuntimeError: lance error: Append with different schema:
   2   `data` should have type json but type was large_binary

  Root Cause

  In rust/lancedb/src/table/datafusion/cast.rs, the build_field_exprs function sees that the input field type (Utf8 with arrow.json metadata) differs from the table field type (LargeBinary with lance.json metadata).
  Since can_cast_types(Utf8, LargeBinary) == true, it inserts a DataFusion CastExpr(Utf8 → LargeBinary).

  The problem is that this cast preserves the input field's extension metadata (arrow.json) rather than adopting the table field's metadata (lance.json). When lance-core receives a LargeBinary field with arrow.json
  metadata, it detects a schema mismatch and rejects the append.

  Fix

  Add a special case in build_field_exprs to detect when:
   - Input field is arrow.json (PyArrow pa.json_(), backed by Utf8/LargeUtf8)
   - Table field is lance.json (backed by LargeBinary)

  In this case, pass the expression through unchanged without casting. Lance-core's write path already handles the arrow.json → lance.json conversion (including JSONB encoding), so no DataFusion cast is needed.

  Changes

   - rust/lancedb/src/table/datafusion/cast.rs:
     - Added import for lance_arrow::json::{is_arrow_json_field, is_json_field}
     - Added special case in build_field_exprs to bypass casting for arrow.json → lance.json
     - Added unit test test_arrow_json_passthrough_to_lance_json

   - rust/lancedb/src/table/add_data.rs:
     - Added integration test test_add_arrow_json_into_lance_json_table

  Testing

   - Unit test verifies that cast_to_table_schema preserves arrow.json metadata when the table expects lance.json
   - Integration test verifies that table.add() with pa.json_() data succeeds on a table created with pa.json_()