### PR TITLE
ci: add Dependabot config for shipped Rust binaries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,13 @@
 version: 2
 
-# Scope: only the Rust crates that produce binaries we ship to users
-# (the Python and Node.js native extensions). The `rust/lancedb` crate
-# is published as a library, so its consumers pick dependency versions
-# themselves — we don't gate them on our lockfile.
-#
-# The Node.js binary is built from the root Cargo workspace (nodejs/ is
-# a workspace member), so we point Dependabot at `/`. The Python binary
-# is excluded from the workspace and has its own manifest under /python.
+# Scope: the root Cargo workspace, which produces the Rust binaries we
+# ship to users (the Node.js and Python native extensions). The
+# `rust/lancedb` library crate shares the same lockfile; its consumers
+# pick their own dependency versions, but bumping transitive deps here
+# keeps the binaries we ship current.
 updates:
   - package-ecosystem: cargo
     directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    groups:
-      rust-minor-patch:
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: cargo
-    directory: /python
     schedule:
       interval: weekly
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+# Scope: only the Rust crates that produce binaries we ship to users
+# (the Python and Node.js native extensions). The `rust/lancedb` crate
+# is published as a library, so its consumers pick dependency versions
+# themselves — we don't gate them on our lockfile.
+#
+# The Node.js binary is built from the root Cargo workspace (nodejs/ is
+# a workspace member), so we point Dependabot at `/`. The Python binary
+# is excluded from the workspace and has its own manifest under /python.
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      rust-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: /python
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      rust-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
 members = ["rust/lancedb", "nodejs", "python"]
-# Python package needs to be built by maturin.
-exclude = ["python"]
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
Adds `.github/dependabot.yml` enabling weekly cargo update PRs for the root workspace, which produces the Rust binaries we ship: the Node.js and Python native extensions. The `rust/lancedb` library crate shares the same lockfile — its consumers pick versions themselves, but bumping transitive deps here keeps the shipped binaries current.

Also removes the misleading `exclude = ["python"]` line from the root `Cargo.toml`: `python` is listed in `members`, and `cargo metadata` confirms it's a workspace member, so the exclude was dead code that implied the opposite.

Minor/patch updates are grouped to reduce PR noise.

Part of #3292. Only covers the cargo ecosystem; pip, npm, and github-actions can follow.