### PR TITLE
test: verify LanceHybridQueryBuilder.where() default is prefilter mode

### DIFF
--- a/python/python/tests/test_hybrid_query.py
+++ b/python/python/tests/test_hybrid_query.py
@@ -231,6 +231,27 @@ def test_hybrid_prefilter_explain_plan(table_with_id: Table):
     )
 
 
+def test_hybrid_prefilter_default(table_with_id: Table):
+    plan_default = (
+        table_with_id.search(query_type="hybrid")
+        .vector([0.0, 0.0])
+        .text("dog")
+        .where("id = 1")
+        .limit(2)
+        .explain_plan(verbose=True)
+    )
+
+    assert "full_filter=id = Int64(1)" in plan_default, (
+        f"Default .where() should act as prefilter=True and push filter into the scan."
+        f"\nPlan:\n{plan_default}"
+    )
+
+    assert "full_filter=id = Int64(1)" in plan_default, (
+        f"Default .where() should act as prefilter=True and push filter into the scan."
+        f"\nPlan:\n{plan_default}"
+    )
+
+
 def test_normalize_scores():
     cases = [
         (pa.array([0.1, 0.4]), pa.array([0.0, 1.0])),


### PR DESCRIPTION
## Summary

Closes #3095

The root cause of #3095 was that `_create_query_builders()` in `LanceHybridQueryBuilder` passed `self._postfilter` directly to the sub-query `.where()` calls instead of `not self._postfilter`, inverting the prefilter/postfilter semantics. This was already fixed in #3096.

This PR adds a regression test that was missing: it verifies that calling `.where()` with no explicit `prefilter=` argument (the default) correctly pushes the filter into the scan (prefilter mode), rather than applying it as a postfilter.

## What changed

- `python/python/tests/test_hybrid_query.py`: added `test_hybrid_prefilter_default` which asserts that `.where("id = 1")` on a hybrid query produces an explain plan containing `full_filter=id = Int64(1)` (the scan-level pushdown marker), confirming prefilter-by-default behaviour.

## Why this test fills a gap

The existing `test_hybrid_prefilter_explain_plan` only tested explicit `prefilter=True` and explicit `prefilter=False`. It did not test the no-argument default, which is the common user-facing API and the exact scenario described in #3095.