### PR TITLE
ci: add CODEOWNERS file for sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# CODEOWNERS
+#
+# These owners will be the default owners for everything in the repo.
+# They will be requested for review when someone opens a pull request.
+#
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything
+* @jackye1995 @wjones127
+
+# Release and publish workflows — changes here can affect supply chain security
+/.github/workflows/ @jackye1995 @wjones127 @Xuanwo
+
+# Remote client and auth — sensitive networking and auth code
+/rust/lancedb/src/remote/ @jackye1995 @wjones127
+
+# Python FFI boundary
+/python/src/ @jackye1995 @wjones127 @AyushExel
+
+# NodeJS FFI boundary
+/nodejs/src/ @jackye1995 @wjones127


### PR DESCRIPTION
Fixes #3296

## Problem
The repository has no `CODEOWNERS` file, so there is no enforced review routing for sensitive areas such as release workflows, auth code, and FFI boundaries. This means changes to critical paths can be merged without an explicit codeowner review.

## Solution
Add `.github/CODEOWNERS` covering:

- `/.github/workflows/` — release/publish workflows (supply chain risk)
- `/rust/lancedb/src/remote/` — remote client & auth code
- `/python/src/` and `/nodejs/src/` — FFI language boundaries

The listed owners (`@jackye1995`, `@wjones127`, `@Xuanwo`, `@AyushExel`) are based on recent merge activity. Feel free to adjust to match the actual team structure or replace with GitHub team handles if preferred.

## Testing
No code change — only adds a metadata file. GitHub will start routing review requests automatically once this is merged and branch protection is configured to require codeowner approval.