### PR TITLE
docs: fix ci docs build by removing non-existent links

### DIFF
--- a/docs/src/python/python.md
+++ b/docs/src/python/python.md
@@ -92,14 +92,6 @@ of raw SQL strings with [where][lancedb.query.LanceQueryBuilder.where] and
 
 ::: lancedb.context.Contextualizer
 
-## Full text search
-
-::: lancedb.fts.create_index
-
-::: lancedb.fts.populate_index
-
-::: lancedb.fts.search_index
-
 ## Utilities
 
 ::: lancedb.schema.vector


### PR DESCRIPTION
The docs these links used to point to were removed when we removed tantivy