### PR TITLE
feat(python): add table serialization

### DIFF
--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -309,6 +309,46 @@ def deserialize_conn(
         raise ValueError(f"Unknown connection_type: {connection_type}")
 
 
+def deserialize_table(
+    data: str,
+    *,
+    for_worker: bool = False,
+) -> Table:
+    """Reconstruct a Table from a serialized string.
+
+    The string must have been produced by :meth:`Table.serialize`.
+
+    Parameters
+    ----------
+    data : str
+        String produced by ``Table.serialize()``.
+    for_worker : bool, default False
+        Forwarded to :func:`deserialize_conn` so worker endpoint overrides
+        stored in the serialized connection can be applied.
+
+    Returns
+    -------
+    Table
+        A table reopened through the serialized LanceDB connection.
+    """
+    import json
+
+    parsed = json.loads(data)
+    version = parsed.get("serialization_version")
+    if version != 1:
+        raise ValueError(f"Unknown table serialization_version: {version}")
+
+    conn = deserialize_conn(parsed["connection"], for_worker=for_worker)
+    table = conn.open_table(
+        parsed["name"],
+        namespace_path=parsed.get("namespace_path") or [],
+    )
+    table_version = parsed.get("table_version")
+    if table_version is not None:
+        table.checkout(table_version)
+    return table
+
+
 async def connect_async(
     uri: URI,
     *,
@@ -420,6 +460,8 @@ __all__ = [
     "connect_async",
     "connect_namespace",
     "connect_namespace_async",
+    "deserialize_conn",
+    "deserialize_table",
     "AsyncConnection",
     "AsyncLanceNamespaceDBConnection",
     "AsyncTable",

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -686,6 +686,15 @@ class Table(ABC):
         """The number of rows in this Table"""
         return self.count_rows(None)
 
+    def serialize(self) -> str:
+        """Serialize this table so it can be reopened elsewhere.
+
+        The returned string can be passed to :func:`lancedb.deserialize_table`.
+        Implementations should include enough connection and table identity
+        state to reopen an equivalent table.
+        """
+        raise NotImplementedError("serialize is not supported for this table type")
+
     @property
     @abstractmethod
     def embedding_functions(self) -> Dict[str, EmbeddingFunctionConfig]:
@@ -1851,6 +1860,26 @@ class LanceTable(Table):
         if self._namespace_path:
             return "$".join(self._namespace_path + [self.name])
         return self.name
+
+    def serialize(self) -> str:
+        """Serialize this table so it can be reopened elsewhere.
+
+        The payload is intentionally connection-centric: it stores the
+        serialized LanceDB connection plus the table identifier.  Connection
+        details such as namespace implementation and worker endpoint overrides
+        stay owned by the LanceDB connection serializer.
+        """
+        import json
+
+        return json.dumps(
+            {
+                "serialization_version": 1,
+                "connection": self._conn.serialize(),
+                "name": self.name,
+                "namespace_path": self._namespace_path,
+                "table_version": self.version,
+            }
+        )
 
     @classmethod
     def from_inner(cls, tbl: LanceDBTable):

--- a/python/python/tests/test_namespace.py
+++ b/python/python/tests/test_namespace.py
@@ -104,6 +104,22 @@ class TestNamespaceConnection:
         assert len(result) == 0
         assert list(result.columns) == ["id", "vector"]
 
+    def test_serialize_table_through_namespace(self):
+        """Test serializing and reopening a namespace table."""
+        db = lancedb.connect_namespace("dir", {"root": self.temp_dir})
+        db.create_namespace(["test_ns"])
+        data = [
+            {"id": 1, "vector": [1.0, 2.0]},
+            {"id": 2, "vector": [3.0, 4.0]},
+        ]
+
+        table = db.create_table("test_table", data=data, namespace_path=["test_ns"])
+        restored = lancedb.deserialize_table(table.serialize())
+
+        assert restored.name == "test_table"
+        assert restored.namespace == ["test_ns"]
+        assert restored.to_arrow() == table.to_arrow()
+
     def test_drop_table_through_namespace(self):
         """Test dropping a table through namespace."""
         db = lancedb.connect_namespace("dir", {"root": self.temp_dir})

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -47,6 +47,35 @@ def test_basic(mem_db: DBConnection):
     assert table.to_arrow() == expected_data
 
 
+def test_table_serialize_roundtrip(tmp_db: DBConnection):
+    data = [
+        {"vector": [3.1, 4.1], "item": "foo", "price": 10.0},
+        {"vector": [5.9, 26.5], "item": "bar", "price": 20.0},
+    ]
+    table = tmp_db.create_table("serialize_roundtrip", data=data)
+
+    restored = lancedb.deserialize_table(table.serialize())
+
+    assert restored.name == "serialize_roundtrip"
+    assert restored.namespace == []
+    assert restored.version == table.version
+    assert restored.to_arrow() == table.to_arrow()
+
+
+def test_table_serialize_preserves_checked_out_version(tmp_db: DBConnection):
+    table = tmp_db.create_table(
+        "serialize_version",
+        data=[{"vector": [3.1, 4.1], "item": "foo"}],
+    )
+    table.add([{"vector": [5.9, 26.5], "item": "bar"}])
+    table.checkout(1)
+
+    restored = lancedb.deserialize_table(table.serialize())
+
+    assert restored.version == 1
+    assert restored.count_rows() == 1
+
+
 def test_create_table_infers_large_int_vectors(mem_db: DBConnection):
     data = [{"vector": [0, 300]}]
 


### PR DESCRIPTION
Adds Table.serialize() and lancedb.deserialize_table() so Python table handles can be reopened from serialized connection and table identity, including namespace paths and checked-out versions.