### PR TITLE
fix: correct file path in postbuild:release script

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -75,7 +75,7 @@
     "build:debug": "napi build --platform --dts ../lancedb/native.d.ts --js ../lancedb/native.js --output-dir lancedb",
     "postbuild:debug": "shx mkdir -p dist && shx cp lancedb/*.node dist/",
     "build:release": "napi build --platform --release --dts ../lancedb/native.d.ts --js ../lancedb/native.js --output-dir dist",
-    "postbuild:release": "shx mkdir -p dist && shx cp lancedb/*.node dist/",
+    "postbuild:release": "shx mkdir -p dist",
     "build": "npm run build:debug && npm run tsc",
     "build-release": "npm run build:release && npm run tsc",
     "tsc": "tsc -b",


### PR DESCRIPTION
## Summary

Release builds use `napi build ... --output-dir dist`, so native binaries are written directly under `dist/`. `postbuild:release` still copied from `lancedb/*.node`, which matches only the debug layout (`--output-dir lancedb`) and fails when no matching files exist.

Remove the redundant copy step and keep ensuring `dist/` exists.

Fixes #3284.

Made with [Cursor](https://cursor.com)