### PR TITLE
feat(rust): split bad vector handling into value and dimension controls

### DIFF
--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -2411,7 +2411,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_preprocessing() {
-        use crate::table::NaNVectorBehavior;
+        use crate::table::BadVectorValueHandling;
         use arrow_array::{FixedSizeListArray, Float32Array, Int64Array};
 
         // The table schema: {id: Int64, vec: FixedSizeList<Float32>[3]}
@@ -2518,7 +2518,7 @@ mod tests {
 
         table
             .add(cast_data)
-            .on_nan_vectors(NaNVectorBehavior::Keep)
+            .on_bad_vector_values(BadVectorValueHandling::Keep)
             .execute()
             .await
             .unwrap();

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -80,7 +80,10 @@ pub mod write_progress;
 use crate::index::waiter::wait_for_index;
 #[cfg(feature = "remote")]
 pub(crate) use add_data::PreprocessingOutput;
-pub use add_data::{AddDataBuilder, AddDataMode, AddResult, NaNVectorBehavior};
+pub use add_data::{
+    AddDataBuilder, AddDataMode, AddResult, BadVectorDimensionHandling, BadVectorValueHandling,
+    NaNVectorBehavior,
+};
 pub use chrono::Duration;
 pub use delete::DeleteResult;
 use futures::future::join_all;
@@ -165,22 +168,6 @@ impl TableDefinition {
             .insert("lancedb::column_definitions".to_string(), lancedb_metadata);
         Arc::new(schema_with_metadata)
     }
-}
-
-/// Describes what happens when a vector either contains NaN or
-/// does not have enough values
-#[derive(Clone, Debug, Default)]
-#[allow(dead_code)] // https://github.com/lancedb/lancedb/issues/992
-enum BadVectorHandling {
-    /// An error is returned
-    #[default]
-    Error,
-    /// The offending row is droppped
-    Drop,
-    /// The invalid/missing items are replaced by fill_value
-    Fill(f32),
-    /// The invalid items are replaced by NULL
-    None,
 }
 
 /// Options to use when writing data

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -10,8 +10,9 @@ use serde::{Deserialize, Serialize};
 use crate::data::scannable::Scannable;
 use crate::data::scannable::scannable_with_embeddings;
 use crate::embeddings::EmbeddingRegistry;
+use crate::table::datafusion::bad_vector_dimensions::handle_bad_vector_dimensions;
+use crate::table::datafusion::bad_vector_values::handle_bad_vector_values;
 use crate::table::datafusion::cast::cast_to_table_schema;
-use crate::table::datafusion::reject_nan::reject_nan_vectors;
 use crate::table::datafusion::scannable_exec::ScannableExec;
 use crate::table::write_progress::ProgressCallback;
 use crate::table::write_progress::WriteProgress;
@@ -38,6 +39,44 @@ pub struct AddResult {
     pub version: u64,
 }
 
+/// Configures how vectors with NaN values are handled during [`crate::table::Table::add`].
+///
+/// See [`AddDataBuilder::on_bad_vector_values`] for details.
+#[derive(Debug, Default, Clone)]
+pub enum BadVectorValueHandling {
+    /// Reject any row whose vector contains a NaN (the default).
+    #[default]
+    Error,
+    /// Drop rows whose vector contains a NaN.
+    Drop,
+    /// Replace vectors containing NaN with null.
+    Null,
+    /// Replace NaN elements within the vector with the given fill value.
+    Fill(f64),
+    /// Allow NaN values through unchanged (legacy; not searchable).
+    #[doc(hidden)]
+    Keep,
+}
+
+/// Configures how vectors with the wrong number of dimensions are handled
+/// during [`crate::table::Table::add`].
+///
+/// See [`AddDataBuilder::on_bad_vector_dimensions`] for details.
+#[derive(Debug, Default, Clone)]
+pub enum BadVectorDimensionHandling {
+    /// Reject any row whose vector has the wrong number of dimensions (the default).
+    #[default]
+    Error,
+    /// Drop rows whose vector has the wrong number of dimensions.
+    Drop,
+    /// Replace wrong-dimension vectors with null.
+    Null,
+    /// Replace wrong-dimension vectors with a vector of the correct size filled with the given value.
+    Fill(f64),
+}
+
+/// Kept for backward compatibility. Prefer [`BadVectorValueHandling`] via
+/// [`AddDataBuilder::on_bad_vector_values`].
 #[derive(Debug, Default, Clone, Copy)]
 pub enum NaNVectorBehavior {
     /// Reject any vectors containing NaN values (the default)
@@ -53,7 +92,8 @@ pub struct AddDataBuilder {
     pub(crate) data: Box<dyn Scannable>,
     pub(crate) mode: AddDataMode,
     pub(crate) write_options: WriteOptions,
-    pub(crate) on_nan_vectors: NaNVectorBehavior,
+    pub(crate) on_bad_vector_values: BadVectorValueHandling,
+    pub(crate) on_bad_vector_dimensions: BadVectorDimensionHandling,
     pub(crate) embedding_registry: Option<Arc<dyn EmbeddingRegistry>>,
     pub(crate) progress_callback: Option<ProgressCallback>,
     pub(crate) write_parallelism: Option<usize>,
@@ -80,7 +120,8 @@ impl AddDataBuilder {
             data,
             mode: AddDataMode::Append,
             write_options: WriteOptions::default(),
-            on_nan_vectors: NaNVectorBehavior::default(),
+            on_bad_vector_values: BadVectorValueHandling::default(),
+            on_bad_vector_dimensions: BadVectorDimensionHandling::default(),
             embedding_registry,
             progress_callback: None,
             write_parallelism: None,
@@ -97,14 +138,41 @@ impl AddDataBuilder {
         self
     }
 
+    /// Configure how to handle vectors containing NaN values.
+    ///
+    /// By default ([`BadVectorValueHandling::Error`]), any row whose vector
+    /// contains NaN is rejected. Use `Drop` to silently discard those rows,
+    /// `Null` to store them as null, or `Fill(v)` to replace NaN elements with
+    /// `v`.
+    pub fn on_bad_vector_values(mut self, handling: BadVectorValueHandling) -> Self {
+        self.on_bad_vector_values = handling;
+        self
+    }
+
+    /// Configure how to handle vectors with the wrong number of dimensions.
+    ///
+    /// This applies to variable-length list columns (e.g. `List<f64>`) that
+    /// will be cast to a `FixedSizeList` in the table schema. By default
+    /// ([`BadVectorDimensionHandling::Error`]) a mismatch is an error. Use
+    /// `Drop` to discard those rows, `Null` to store null, or `Fill(v)` to
+    /// substitute a correctly-sized vector filled with `v`.
+    ///
+    /// This step runs before the `List → FixedSizeList` cast, so wrong-length
+    /// rows are handled before the cast would fail on them.
+    pub fn on_bad_vector_dimensions(mut self, handling: BadVectorDimensionHandling) -> Self {
+        self.on_bad_vector_dimensions = handling;
+        self
+    }
+
     /// Configure how to handle NaN values in vector columns.
     ///
-    /// By default, any vectors containing NaN values will be rejected with an
-    /// error, since NaNs cannot be indexed for search. Setting this to `Keep`
-    /// will allow NaN values to be added to the table, but they will not be
-    /// indexed and will not be searchable.
+    /// Deprecated: use [`Self::on_bad_vector_values`] instead.
+    #[deprecated(since = "0.29.0", note = "use on_bad_vector_values() instead")]
     pub fn on_nan_vectors(mut self, behavior: NaNVectorBehavior) -> Self {
-        self.on_nan_vectors = behavior;
+        self.on_bad_vector_values = match behavior {
+            NaNVectorBehavior::Error => BadVectorValueHandling::Error,
+            NaNVectorBehavior::Keep => BadVectorValueHandling::Keep,
+        };
         self
     }
 
@@ -178,15 +246,15 @@ impl AddDataBuilder {
             .map(|cb| Arc::new(WriteProgressTracker::new(cb, self.data.num_rows())));
         let plan: Arc<dyn datafusion_physical_plan::ExecutionPlan> =
             Arc::new(ScannableExec::new(self.data, tracker.clone()));
-        // Skip casting when overwriting — the input schema replaces the table schema.
+        // Skip casting and dimension/value checks when overwriting — the input
+        // schema replaces the table schema entirely.
         let plan = if overwrite {
             plan
         } else {
-            cast_to_table_schema(plan, table_schema)?
-        };
-        let plan = match self.on_nan_vectors {
-            NaNVectorBehavior::Error => reject_nan_vectors(plan)?,
-            NaNVectorBehavior::Keep => plan,
+            let plan =
+                handle_bad_vector_dimensions(plan, table_schema, &self.on_bad_vector_dimensions)?;
+            let plan = cast_to_table_schema(plan, table_schema)?;
+            handle_bad_vector_values(plan, &self.on_bad_vector_values)?
         };
 
         Ok(PreprocessingOutput {
@@ -267,10 +335,11 @@ mod tests {
         EmbeddingDefinition, EmbeddingFunction, EmbeddingRegistry, MemoryRegistry,
     };
     use crate::query::{ExecutableQuery, QueryBase, Select};
-    use crate::table::add_data::NaNVectorBehavior;
+    use crate::table::add_data::{BadVectorDimensionHandling, BadVectorValueHandling};
     use crate::table::{ColumnDefinition, ColumnKind, Table, TableDefinition, WriteOptions};
     use crate::test_utils::TestCustomError;
     use crate::test_utils::embeddings::MockEmbed;
+    use arrow_array::Array;
 
     use super::AddDataMode;
 
@@ -648,13 +717,214 @@ mod tests {
 
         table
             .add(batch)
-            .on_nan_vectors(NaNVectorBehavior::Keep)
+            .on_bad_vector_values(BadVectorValueHandling::Keep)
             .execute()
             .await
             .unwrap();
 
         let row_count = table.count_rows(None).await.unwrap();
         assert_eq!(row_count, 1);
+    }
+
+    async fn make_nan_table() -> (Table, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+            true,
+        )]));
+        let db = connect("memory://").execute().await.unwrap();
+        let table = db
+            .create_empty_table("nan_test", schema.clone())
+            .execute()
+            .await
+            .unwrap();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(
+                FixedSizeListArray::try_new(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    4,
+                    Arc::new(Float32Array::from(vec![
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0, // row 0 – valid
+                        0.1,
+                        f32::NAN,
+                        0.3,
+                        0.4, // row 1 – NaN
+                    ])),
+                    None,
+                )
+                .unwrap(),
+            )],
+        )
+        .unwrap();
+        (table, batch)
+    }
+
+    #[tokio::test]
+    async fn test_bad_value_drop() {
+        let (table, batch) = make_nan_table().await;
+        table
+            .add(batch)
+            .on_bad_vector_values(BadVectorValueHandling::Drop)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_bad_value_null() {
+        let (table, batch) = make_nan_table().await;
+        table
+            .add(batch)
+            .on_bad_vector_values(BadVectorValueHandling::Null)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+        assert_eq!(
+            table
+                .count_rows(Some("embedding IS NOT NULL".to_string()))
+                .await
+                .unwrap(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bad_value_fill() {
+        use crate::query::ExecutableQuery;
+        use futures::TryStreamExt;
+
+        let (table, batch) = make_nan_table().await;
+        table
+            .add(batch)
+            .on_bad_vector_values(BadVectorValueHandling::Fill(0.0))
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+
+        // The NaN row should have its NaN replaced with 0.0
+        let results: Vec<RecordBatch> = table
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 2);
+        for batch in &results {
+            let col = batch.column(0);
+            assert_eq!(col.null_count(), 0);
+            let fsl = col.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+            for i in 0..fsl.len() {
+                let row = fsl.value(i);
+                let floats = row.as_any().downcast_ref::<Float32Array>().unwrap();
+                for v in floats.iter().flatten() {
+                    assert!(!v.is_nan(), "expected no NaN after Fill, got {v}");
+                }
+            }
+        }
+    }
+
+    async fn make_bad_dim_table() -> (Table, RecordBatch) {
+        use arrow::datatypes::Float64Type;
+        let table_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+            true,
+        )]));
+        let input_schema = Arc::new(Schema::new(vec![Field::new(
+            "embedding",
+            DataType::List(Arc::new(Field::new("item", DataType::Float64, true))),
+            true,
+        )]));
+        let db = connect("memory://").execute().await.unwrap();
+        let table = db
+            .create_empty_table("dim_test", table_schema)
+            .execute()
+            .await
+            .unwrap();
+        let batch = RecordBatch::try_new(
+            input_schema,
+            vec![Arc::new(
+                ListArray::from_iter_primitive::<Float64Type, _, _>(vec![
+                    Some(vec![0.1, 0.2, 0.3, 0.4].into_iter().map(Some)), // correct dim
+                    Some(vec![0.5, 0.6, 0.8].into_iter().map(Some)),      // wrong dim (3)
+                ]),
+            )],
+        )
+        .unwrap();
+        (table, batch)
+    }
+
+    #[tokio::test]
+    async fn test_bad_dimension_drop() {
+        let (table, batch) = make_bad_dim_table().await;
+        table
+            .add(batch)
+            .on_bad_vector_dimensions(BadVectorDimensionHandling::Drop)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_bad_dimension_null() {
+        let (table, batch) = make_bad_dim_table().await;
+        table
+            .add(batch)
+            .on_bad_vector_dimensions(BadVectorDimensionHandling::Null)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+        assert_eq!(
+            table
+                .count_rows(Some("embedding IS NOT NULL".to_string()))
+                .await
+                .unwrap(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bad_dimension_fill() {
+        use crate::query::ExecutableQuery;
+        use futures::TryStreamExt;
+
+        let (table, batch) = make_bad_dim_table().await;
+        table
+            .add(batch)
+            .on_bad_vector_dimensions(BadVectorDimensionHandling::Fill(0.0))
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+
+        let results: Vec<RecordBatch> = table
+            .query()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let total: usize = results.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 2);
+        for batch in &results {
+            let col = batch.column(0);
+            assert_eq!(col.null_count(), 0, "no nulls expected after Fill");
+            let fsl = col.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+            assert_eq!(fsl.value_length(), 4, "all rows should have dim=4");
+        }
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table/datafusion.rs
+++ b/rust/lancedb/src/table/datafusion.rs
@@ -3,6 +3,8 @@
 
 //! This module contains adapters to allow LanceDB tables to be used as DataFusion table providers.
 
+pub mod bad_vector_dimensions;
+pub mod bad_vector_values;
 pub mod cast;
 pub mod insert;
 pub mod reject_nan;

--- a/rust/lancedb/src/table/datafusion/bad_vector_dimensions.rs
+++ b/rust/lancedb/src/table/datafusion/bad_vector_dimensions.rs
@@ -1,0 +1,633 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! Handles vectors with wrong dimensions before the List→FixedSizeList cast step.
+
+use std::any::Any;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_array::{Array, ArrayRef, BooleanArray, Float16Array, Float32Array, Float64Array};
+use arrow_array::{LargeListArray, ListArray};
+use arrow_schema::{DataType, Field, FieldRef, Schema};
+use datafusion_common::ScalarValue;
+use datafusion_common::config::ConfigOptions;
+use datafusion_expr::{
+    ColumnarValue, Operator, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_physical_expr::ScalarFunctionExpr;
+use datafusion_physical_expr::expressions::{BinaryExpr, Column};
+use datafusion_physical_plan::filter::FilterExec;
+use datafusion_physical_plan::projection::ProjectionExec;
+use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+
+use crate::table::add_data::BadVectorDimensionHandling;
+use crate::{Error, Result};
+
+struct AffectedCol {
+    input_idx: usize,
+    name: String,
+    expected_dim: i32,
+    is_large_list: bool,
+}
+
+/// Finds input columns that are variable-length float lists whose corresponding
+/// table column is a FixedSizeList, requiring a dimension check before casting.
+fn find_affected_cols(input_schema: &Schema, table_schema: &Schema) -> Vec<AffectedCol> {
+    let mut cols = Vec::new();
+    for (input_idx, input_field) in input_schema.fields().iter().enumerate() {
+        let Ok(table_field) = table_schema.field_with_name(input_field.name()) else {
+            continue;
+        };
+        let expected_dim = match table_field.data_type() {
+            DataType::FixedSizeList(child, dim)
+                if matches!(
+                    child.data_type(),
+                    DataType::Float16 | DataType::Float32 | DataType::Float64
+                ) =>
+            {
+                *dim
+            }
+            _ => continue,
+        };
+        let is_large_list = match input_field.data_type() {
+            DataType::List(child)
+                if matches!(
+                    child.data_type(),
+                    DataType::Float16 | DataType::Float32 | DataType::Float64
+                ) =>
+            {
+                false
+            }
+            DataType::LargeList(child)
+                if matches!(
+                    child.data_type(),
+                    DataType::Float16 | DataType::Float32 | DataType::Float64
+                ) =>
+            {
+                true
+            }
+            _ => continue,
+        };
+        cols.push(AffectedCol {
+            input_idx,
+            name: input_field.name().clone(),
+            expected_dim,
+            is_large_list,
+        });
+    }
+    cols
+}
+
+/// Wraps `input` with a plan that applies `handling` to variable-length float-list
+/// columns that will be cast to FixedSizeList by the table schema.
+///
+/// Must run *before* the cast step so that wrong-dimension rows are handled
+/// before the `List → FixedSizeList` cast fails on them.
+pub fn handle_bad_vector_dimensions(
+    input: Arc<dyn ExecutionPlan>,
+    table_schema: &Schema,
+    handling: &BadVectorDimensionHandling,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let input_schema = input.schema();
+    let affected = find_affected_cols(&input_schema, table_schema);
+    if affected.is_empty() {
+        return Ok(input);
+    }
+
+    let config = Arc::new(ConfigOptions::default());
+
+    match handling {
+        BadVectorDimensionHandling::Error => {
+            let exprs = wrap_affected_cols(&input_schema, &affected, |ac, col_expr, field| {
+                let udf = Arc::new(datafusion_expr::ScalarUDF::from(ErrorOnWrongDimUdf::new(
+                    ac.expected_dim,
+                    ac.is_large_list,
+                )));
+                Arc::new(ScalarFunctionExpr::new(
+                    &format!("error_wrong_dim({})", ac.name),
+                    udf,
+                    vec![col_expr],
+                    Arc::clone(field) as FieldRef,
+                    config.clone(),
+                )) as Arc<dyn PhysicalExpr>
+            });
+            Ok(Arc::new(
+                ProjectionExec::try_new(exprs, input).map_err(Error::from)?,
+            ))
+        }
+        BadVectorDimensionHandling::Drop => {
+            let bool_field = Arc::new(Field::new("", DataType::Boolean, false));
+            let mut predicate: Option<Arc<dyn PhysicalExpr>> = None;
+            for ac in &affected {
+                let col: Arc<dyn PhysicalExpr> = Arc::new(Column::new(&ac.name, ac.input_idx));
+                let udf = Arc::new(datafusion_expr::ScalarUDF::from(HasCorrectDimUdf::new(
+                    ac.expected_dim,
+                    ac.is_large_list,
+                )));
+                let check: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(
+                    &format!("has_correct_dim({})", ac.name),
+                    udf,
+                    vec![col],
+                    bool_field.clone(),
+                    config.clone(),
+                ));
+                predicate = Some(match predicate {
+                    None => check,
+                    Some(prev) => Arc::new(BinaryExpr::new(prev, Operator::And, check)),
+                });
+            }
+            Ok(Arc::new(
+                FilterExec::try_new(predicate.unwrap(), input).map_err(Error::from)?,
+            ))
+        }
+        BadVectorDimensionHandling::Null => {
+            let exprs = wrap_affected_cols(&input_schema, &affected, |ac, col_expr, field| {
+                let udf = Arc::new(datafusion_expr::ScalarUDF::from(NullIfWrongDimUdf::new(
+                    ac.expected_dim,
+                    ac.is_large_list,
+                )));
+                let nullable_field =
+                    Arc::new(Field::new(field.name(), field.data_type().clone(), true));
+                Arc::new(ScalarFunctionExpr::new(
+                    &format!("null_if_wrong_dim({})", ac.name),
+                    udf,
+                    vec![col_expr],
+                    nullable_field,
+                    config.clone(),
+                )) as Arc<dyn PhysicalExpr>
+            });
+            Ok(Arc::new(
+                ProjectionExec::try_new(exprs, input).map_err(Error::from)?,
+            ))
+        }
+        BadVectorDimensionHandling::Fill(v) => {
+            let exprs = wrap_affected_cols(&input_schema, &affected, |ac, col_expr, field| {
+                let udf = Arc::new(datafusion_expr::ScalarUDF::from(FillWrongDimUdf::new(
+                    ac.expected_dim,
+                    ac.is_large_list,
+                    *v,
+                )));
+                Arc::new(ScalarFunctionExpr::new(
+                    &format!("fill_wrong_dim({})", ac.name),
+                    udf,
+                    vec![col_expr],
+                    Arc::clone(field) as FieldRef,
+                    config.clone(),
+                )) as Arc<dyn PhysicalExpr>
+            });
+            Ok(Arc::new(
+                ProjectionExec::try_new(exprs, input).map_err(Error::from)?,
+            ))
+        }
+    }
+}
+
+fn wrap_affected_cols(
+    schema: &arrow_schema::Schema,
+    affected: &[AffectedCol],
+    make_expr: impl Fn(&AffectedCol, Arc<dyn PhysicalExpr>, &FieldRef) -> Arc<dyn PhysicalExpr>,
+) -> Vec<(Arc<dyn PhysicalExpr>, String)> {
+    schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(idx, field)| {
+            let col: Arc<dyn PhysicalExpr> = Arc::new(Column::new(field.name(), idx));
+            let name = field.name().clone();
+            if let Some(ac) = affected.iter().find(|a| a.input_idx == idx) {
+                (make_expr(ac, col, field), name)
+            } else {
+                (col, name)
+            }
+        })
+        .collect()
+}
+
+// ──────────────────────────────────────────────────────────────
+// Shared helpers
+// ──────────────────────────────────────────────────────────────
+
+fn list_row_count(array: &dyn Array) -> usize {
+    array.len()
+}
+
+fn list_row_len(array: &dyn Array, row: usize) -> i32 {
+    match array.data_type() {
+        DataType::List(_) => array
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap()
+            .value_length(row),
+        DataType::LargeList(_) => array
+            .as_any()
+            .downcast_ref::<LargeListArray>()
+            .unwrap()
+            .value_length(row) as i32,
+        _ => 0,
+    }
+}
+
+fn extract_item_field(array: &dyn Array) -> FieldRef {
+    match array.data_type() {
+        DataType::List(f) | DataType::LargeList(f) => f.clone(),
+        _ => unreachable!(),
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// UDF: ErrorOnWrongDim
+// ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct ErrorOnWrongDimUdf {
+    signature: Signature,
+    expected_dim: i32,
+    is_large_list: bool,
+}
+
+impl ErrorOnWrongDimUdf {
+    fn new(expected_dim: i32, is_large_list: bool) -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+            expected_dim,
+            is_large_list,
+        }
+    }
+}
+
+impl ScalarUDFImpl for ErrorOnWrongDimUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "error_wrong_dim"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(arg_types[0].clone())
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        match &args.args[0] {
+            ColumnarValue::Array(array) => {
+                for i in 0..list_row_count(array.as_ref()) {
+                    if !array.is_null(i) {
+                        let len = list_row_len(array.as_ref(), i);
+                        if len != self.expected_dim {
+                            return Err(datafusion_common::DataFusionError::ArrowError(
+                                Box::new(arrow_schema::ArrowError::InvalidArgumentError(format!(
+                                    "Vector has wrong dimension: expected {}, got {}",
+                                    self.expected_dim, len
+                                ))),
+                                None,
+                            ));
+                        }
+                    }
+                }
+                Ok(ColumnarValue::Array(array.clone()))
+            }
+            ColumnarValue::Scalar(s) => Ok(ColumnarValue::Scalar(s.clone())),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// UDF: HasCorrectDim (Drop — true = keep)
+// ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct HasCorrectDimUdf {
+    signature: Signature,
+    expected_dim: i32,
+    is_large_list: bool,
+}
+
+impl HasCorrectDimUdf {
+    fn new(expected_dim: i32, is_large_list: bool) -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+            expected_dim,
+            is_large_list,
+        }
+    }
+}
+
+impl ScalarUDFImpl for HasCorrectDimUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "has_correct_dim"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        match &args.args[0] {
+            ColumnarValue::Array(array) => {
+                let n = list_row_count(array.as_ref());
+                let keep: BooleanArray = (0..n)
+                    .map(|i| {
+                        if array.is_null(i) {
+                            Some(true)
+                        } else {
+                            Some(list_row_len(array.as_ref(), i) == self.expected_dim)
+                        }
+                    })
+                    .collect();
+                Ok(ColumnarValue::Array(Arc::new(keep)))
+            }
+            ColumnarValue::Scalar(_) => Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true)))),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// UDF: NullIfWrongDim
+// ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct NullIfWrongDimUdf {
+    signature: Signature,
+    expected_dim: i32,
+    is_large_list: bool,
+}
+
+impl NullIfWrongDimUdf {
+    fn new(expected_dim: i32, is_large_list: bool) -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+            expected_dim,
+            is_large_list,
+        }
+    }
+}
+
+impl ScalarUDFImpl for NullIfWrongDimUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "null_if_wrong_dim"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(arg_types[0].clone())
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        match &args.args[0] {
+            ColumnarValue::Array(array) => {
+                let n = list_row_count(array.as_ref());
+                let validity: Vec<bool> = (0..n)
+                    .map(|i| {
+                        !array.is_null(i) && list_row_len(array.as_ref(), i) == self.expected_dim
+                    })
+                    .collect();
+                let null_buf = NullBuffer::from(validity);
+                let item_field = extract_item_field(array.as_ref());
+                let new_array: ArrayRef = if self.is_large_list {
+                    let list =
+                        array
+                            .as_any()
+                            .downcast_ref::<LargeListArray>()
+                            .ok_or_else(|| {
+                                datafusion_common::DataFusionError::Internal(
+                                    "null_if_wrong_dim: expected LargeListArray".to_string(),
+                                )
+                            })?;
+                    Arc::new(LargeListArray::new(
+                        item_field,
+                        list.offsets().clone(),
+                        list.values().clone(),
+                        Some(null_buf),
+                    ))
+                } else {
+                    let list = array.as_any().downcast_ref::<ListArray>().ok_or_else(|| {
+                        datafusion_common::DataFusionError::Internal(
+                            "null_if_wrong_dim: expected ListArray".to_string(),
+                        )
+                    })?;
+                    Arc::new(ListArray::new(
+                        item_field,
+                        list.offsets().clone(),
+                        list.values().clone(),
+                        Some(null_buf),
+                    ))
+                };
+                Ok(ColumnarValue::Array(new_array))
+            }
+            ColumnarValue::Scalar(s) => Ok(ColumnarValue::Scalar(s.clone())),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// UDF: FillWrongDim
+// ──────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct FillWrongDimUdf {
+    signature: Signature,
+    expected_dim: i32,
+    is_large_list: bool,
+    fill_bits: u64,
+}
+
+impl FillWrongDimUdf {
+    fn new(expected_dim: i32, is_large_list: bool, fill: f64) -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+            expected_dim,
+            is_large_list,
+            fill_bits: fill.to_bits(),
+        }
+    }
+
+    fn fill_value(&self) -> f64 {
+        f64::from_bits(self.fill_bits)
+    }
+}
+
+impl Hash for FillWrongDimUdf {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.expected_dim.hash(state);
+        self.is_large_list.hash(state);
+        self.fill_bits.hash(state);
+    }
+}
+impl PartialEq for FillWrongDimUdf {
+    fn eq(&self, other: &Self) -> bool {
+        self.expected_dim == other.expected_dim
+            && self.is_large_list == other.is_large_list
+            && self.fill_bits == other.fill_bits
+    }
+}
+impl Eq for FillWrongDimUdf {}
+
+impl ScalarUDFImpl for FillWrongDimUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "fill_wrong_dim"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(arg_types[0].clone())
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        match &args.args[0] {
+            ColumnarValue::Array(array) => {
+                let fill = self.fill_value();
+                let item_field = extract_item_field(array.as_ref());
+                let new_array = fill_wrong_dim(
+                    array,
+                    &item_field,
+                    self.expected_dim,
+                    fill,
+                    self.is_large_list,
+                )?;
+                Ok(ColumnarValue::Array(new_array))
+            }
+            ColumnarValue::Scalar(s) => Ok(ColumnarValue::Scalar(s.clone())),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Fill implementation
+// ──────────────────────────────────────────────────────────────
+
+fn fill_wrong_dim(
+    array: &ArrayRef,
+    item_field: &FieldRef,
+    expected_dim: i32,
+    fill: f64,
+    is_large_list: bool,
+) -> datafusion_common::Result<ArrayRef> {
+    match item_field.data_type() {
+        DataType::Float32 => {
+            fill_list_f32(array, item_field, expected_dim, fill as f32, is_large_list)
+        }
+        DataType::Float64 => fill_list_f64(array, item_field, expected_dim, fill, is_large_list),
+        DataType::Float16 => fill_list_f16(
+            array,
+            item_field,
+            expected_dim,
+            half::f16::from_f64(fill),
+            is_large_list,
+        ),
+        _ => Ok(array.clone()),
+    }
+}
+
+macro_rules! impl_fill_list {
+    ($fn_name:ident, $FloatArr:ty, $float_ty:ty) => {
+        fn $fn_name(
+            array: &ArrayRef,
+            item_field: &FieldRef,
+            expected_dim: i32,
+            fill_val: $float_ty,
+            is_large_list: bool,
+        ) -> datafusion_common::Result<ArrayRef> {
+            let n = array.len();
+            let mut flat: Vec<Option<$float_ty>> = Vec::new();
+            let mut offsets_i32: Vec<i32> = vec![0];
+            let mut offsets_i64: Vec<i64> = vec![0];
+            let mut validity: Vec<bool> = Vec::with_capacity(n);
+
+            for i in 0..n {
+                if array.is_null(i) {
+                    if is_large_list {
+                        offsets_i64.push(*offsets_i64.last().unwrap());
+                    } else {
+                        offsets_i32.push(*offsets_i32.last().unwrap());
+                    }
+                    validity.push(false);
+                } else {
+                    let row_len = list_row_len(array.as_ref(), i);
+                    if row_len == expected_dim {
+                        let row: ArrayRef = if is_large_list {
+                            array
+                                .as_any()
+                                .downcast_ref::<LargeListArray>()
+                                .unwrap()
+                                .value(i)
+                        } else {
+                            array.as_any().downcast_ref::<ListArray>().unwrap().value(i)
+                        };
+                        let typed = row.as_any().downcast_ref::<$FloatArr>().ok_or_else(|| {
+                            datafusion_common::DataFusionError::Internal(
+                                concat!(
+                                    "fill_list: unexpected item type in ",
+                                    stringify!($fn_name)
+                                )
+                                .to_string(),
+                            )
+                        })?;
+                        for v in typed.iter() {
+                            flat.push(v);
+                        }
+                    } else {
+                        for _ in 0..expected_dim {
+                            flat.push(Some(fill_val));
+                        }
+                    }
+                    if is_large_list {
+                        offsets_i64.push(*offsets_i64.last().unwrap() + expected_dim as i64);
+                    } else {
+                        offsets_i32.push(*offsets_i32.last().unwrap() + expected_dim);
+                    }
+                    validity.push(true);
+                }
+            }
+
+            let item_arr: $FloatArr = flat.into_iter().collect();
+            let null_buf = NullBuffer::from(validity);
+
+            if is_large_list {
+                let offsets = OffsetBuffer::new(ScalarBuffer::from(offsets_i64));
+                Ok(Arc::new(LargeListArray::new(
+                    item_field.clone(),
+                    offsets,
+                    Arc::new(item_arr),
+                    Some(null_buf),
+                )))
+            } else {
+                let offsets = OffsetBuffer::new(ScalarBuffer::from(offsets_i32));
+                Ok(Arc::new(ListArray::new(
+                    item_field.clone(),
+                    offsets,
+                    Arc::new(item_arr),
+                    Some(null_buf),
+                )))
+            }
+        }
+    };
+}
+
+impl_fill_list!(fill_list_f32, Float32Array, f32);
+impl_fill_list!(fill_list_f64, Float64Array, f64);
+impl_fill_list!(fill_list_f16, Float16Array, half::f16);

--- a/rust/lancedb/src/table/datafusion/bad_vector_values.rs
+++ b/rust/lancedb/src/table/datafusion/bad_vector_values.rs
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! Handles bad (NaN-containing) vectors with configurable strategies.
+
+use std::any::Any;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow::buffer::NullBuffer;
+use arrow_array::{Array, ArrayRef, BooleanArray, FixedSizeListArray};
+use arrow_array::{Float16Array, Float32Array, Float64Array};
+use arrow_schema::{DataType, Field, FieldRef};
+use datafusion_common::ScalarValue;
+use datafusion_common::config::ConfigOptions;
+use datafusion_expr::{
+    ColumnarValue, Operator, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_physical_expr::ScalarFunctionExpr;
+use datafusion_physical_expr::expressions::{BinaryExpr, Column};
+use datafusion_physical_plan::filter::FilterExec;
+use datafusion_physical_plan::projection::ProjectionExec;
+use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+
+use crate::table::add_data::BadVectorValueHandling;
+use crate::{Error, Result};
+
+fn is_vector_field(field: &Field) -> bool {
+    if let DataType::FixedSizeList(child, _) = field.data_type() {
+        matches!(
+            child.data_type(),
+            DataType::Float16 | DataType::Float32 | DataType::Float64
+        )
+    } else {
+        false
+    }
+}
+
+fn row_has_nan(row: &dyn Array) -> bool {
+    match row.data_type() {
+        DataType::Float16 => row
+            .as_any()
+            .downcast_ref::<Float16Array>()
+            .unwrap()
+            .iter()
+            .any(|v| v.is_some_and(|v| v.is_nan())),
+        DataType::Float32 => row
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap()
+            .iter()
+            .any(|v| v.is_some_and(|v| v.is_nan())),
+        DataType::Float64 => row
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .iter()
+            .any(|v| v.is_some_and(|v| v.is_nan())),
+        _ => false,
+    }
+}
+
+fn child_field_of(fsl: &FixedSizeListArray) -> FieldRef {
+    if let DataType::FixedSizeList(f, _) = fsl.data_type() {
+        f.clone()
+    } else {
+        unreachable!()
+    }
+}
+
+/// Wraps `input` with a plan that applies `handling` to all vector columns.
+///
+/// Vector columns are `FixedSizeList<Float16|Float32|Float64>`. Non-vector
+/// columns pass through unchanged.
+pub fn handle_bad_vector_values(
+    input: Arc<dyn ExecutionPlan>,
+    handling: &BadVectorValueHandling,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let schema = input.schema();
+    let has_vector_cols = schema.fields().iter().any(|f| is_vector_field(f));
+    if !has_vector_cols {
+        return Ok(input);
+    }
+
+    let config = Arc::new(ConfigOptions::default());
+
+    match handling {
+        BadVectorValueHandling::Error => {
+            let udf = Arc::new(datafusion_expr::ScalarUDF::from(RejectNanUdf::new()));
+            let exprs = build_projection_exprs(&schema, |col_expr, field| {
+                Arc::new(ScalarFunctionExpr::new(
+                    &format!("reject_nan({})", field.name()),
+                    udf.clone(),
+                    vec![col_expr],
+                    Arc::clone(field) as FieldRef,
+                    config.clone(),
+                )) as Arc<dyn PhysicalExpr>
+            });
+            Ok(Arc::new(
+                ProjectionExec::try_new(exprs, input).map_err(Error::from)?,
+            ))
+        }
+        BadVectorValueHandling::Drop => {
+            let udf = Arc::new(datafusion_expr::ScalarUDF::from(HasNoNanUdf::new()));
+            let bool_field = Arc::new(Field::new("", DataType::Boolean, false));
+            let mut predicate: Option<Arc<dyn PhysicalExpr>> = None;
+
+            for (idx, field) in schema.fields().iter().enumerate() {
+                if !is_vector_field(field) {
+                    continue;
+                }
+                let col_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(field.name(), idx));
+                let check: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(
+                    &format!("has_no_nan({})", field.name()),
+                    udf.clone(),
+                    vec![col_expr],
+                    bool_field.clone(),
+                    config.clone(),
+                ));
+                predicate = Some(match predicate {
+                    None => check,
+                    Some(prev) => Arc::new(BinaryExpr::new(prev, Operator::And, check)),
+                });
+            }
+
+            Ok(Arc::new(
+                FilterExec::try_new(predicate.unwrap(), input).map_err(Error::from)?,
+            ))
+        }
+        BadVectorValueHandling::Null => {
+            let udf = Arc::new(datafusion_expr::ScalarUDF::from(NullIfNanUdf::new()));
+            let exprs = build_projection_exprs(&schema, |col_expr, field| {
+                let nullable_field =
+                    Arc::new(Field::new(field.name(), field.data_type().clone(), true));
+                Arc::new(ScalarFunctionExpr::new(
+                    &format!("null_if_nan({})", field.name()),
+                    udf.clone(),
+                    vec![col_expr],
+                    nullable_field,
+                    config.clone(),
+                )) as Arc<dyn PhysicalExpr>
+            });
+            Ok(Arc::new(
+                ProjectionExec::try_new(exprs, input).map_err(Error::from)?,
+            ))
+        }
+        BadVectorValueHandling::Fill(v) => {
+            let udf = Arc::new(datafusion_expr::ScalarUDF::from(FillNanUdf::new(*v)));
+            let exprs = build_projection_exprs(&schema, |col_expr, field| {
+                Arc::new(ScalarFunctionExpr::new(
+                    &format!("fill_nan({})", field.name()),
+                    udf.clone(),
+                    vec![col_expr],
+                    Arc::clone(field) as FieldRef,
+                    config.clone(),
+                )) as Arc<dyn PhysicalExpr>
+            });
+            Ok(Arc::new(
+                ProjectionExec::try_new(exprs, input).map_err(Error::from)?,
+            ))
+        }
+        BadVectorValueHandling::Keep => Ok(input),
+    }
+}
+
+fn build_projection_exprs(
+    schema: &arrow_schema::Schema,
+    wrap_fn: impl Fn(Arc<dyn PhysicalExpr>, &FieldRef) -> Arc<dyn PhysicalExpr>,
+) -> Vec<(Arc<dyn PhysicalExpr>, String)> {
+    schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(idx, field)| {
+            let col_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(field.name(), idx));
+            let name = field.name().clone();
+            if is_vector_field(field) {
+                (wrap_fn(col_expr, field), name)
+            } else {
+                (col_expr, name)
+            }
+        })
+        .collect()
+}
+
+// --- UDF: RejectNan (Error strategy) ---
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct RejectNanUdf {
+    signature: Signature,
+}
+
+impl RejectNanUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for RejectNanUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "reject_nan_values"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(arg_types[0].clone())
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        let arg = &args.args[0];
+        match arg {
+            ColumnarValue::Array(array) => {
+                check_no_nans(array.as_ref())?;
+                Ok(ColumnarValue::Array(array.clone()))
+            }
+            ColumnarValue::Scalar(_) => Ok(arg.clone()),
+        }
+    }
+}
+
+fn check_no_nans(array: &dyn Array) -> datafusion_common::Result<()> {
+    let fsl = array
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .ok_or_else(|| {
+            datafusion_common::DataFusionError::Internal(
+                "reject_nan expected FixedSizeList".to_string(),
+            )
+        })?;
+
+    let has_nan = (0..fsl.len()).filter(|i| fsl.is_valid(*i)).any(|i| {
+        let row = fsl.value(i);
+        row_has_nan(row.as_ref())
+    });
+
+    if has_nan {
+        return Err(datafusion_common::DataFusionError::ArrowError(
+            Box::new(arrow_schema::ArrowError::ComputeError(
+                "Vector column contains NaN values".to_string(),
+            )),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+// --- UDF: HasNoNan (Drop strategy predicate — true = keep) ---
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct HasNoNanUdf {
+    signature: Signature,
+}
+
+impl HasNoNanUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for HasNoNanUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "has_no_nan"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        match &args.args[0] {
+            ColumnarValue::Array(array) => {
+                let fsl = array
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        datafusion_common::DataFusionError::Internal(
+                            "has_no_nan expected FixedSizeList".to_string(),
+                        )
+                    })?;
+                let keep: BooleanArray = (0..fsl.len())
+                    .map(|i| {
+                        if fsl.is_null(i) {
+                            Some(true) // null rows are fine
+                        } else {
+                            let row = fsl.value(i);
+                            Some(!row_has_nan(row.as_ref()))
+                        }
+                    })
+                    .collect();
+                Ok(ColumnarValue::Array(Arc::new(keep)))
+            }
+            ColumnarValue::Scalar(_) => Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true)))),
+        }
+    }
+}
+
+// --- UDF: NullIfNan (Null strategy) ---
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct NullIfNanUdf {
+    signature: Signature,
+}
+
+impl NullIfNanUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for NullIfNanUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "null_if_nan"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(arg_types[0].clone())
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        match &args.args[0] {
+            ColumnarValue::Array(array) => {
+                let fsl = array
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        datafusion_common::DataFusionError::Internal(
+                            "null_if_nan expected FixedSizeList".to_string(),
+                        )
+                    })?;
+                let validity: Vec<bool> = (0..fsl.len())
+                    .map(|i| {
+                        if fsl.is_null(i) {
+                            false
+                        } else {
+                            let row = fsl.value(i);
+                            !row_has_nan(row.as_ref())
+                        }
+                    })
+                    .collect();
+                let null_buf = NullBuffer::from(validity);
+                let new_fsl = FixedSizeListArray::try_new(
+                    child_field_of(fsl),
+                    fsl.value_length(),
+                    fsl.values().clone(),
+                    Some(null_buf),
+                )
+                .map_err(|e| datafusion_common::DataFusionError::ArrowError(Box::new(e), None))?;
+                Ok(ColumnarValue::Array(Arc::new(new_fsl)))
+            }
+            ColumnarValue::Scalar(s) => Ok(ColumnarValue::Scalar(s.clone())),
+        }
+    }
+}
+
+// --- UDF: FillNan (Fill strategy) ---
+
+#[derive(Debug)]
+struct FillNanUdf {
+    signature: Signature,
+    fill_bits: u64,
+}
+
+impl FillNanUdf {
+    fn new(fill: f64) -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+            fill_bits: fill.to_bits(),
+        }
+    }
+
+    fn fill_value(&self) -> f64 {
+        f64::from_bits(self.fill_bits)
+    }
+}
+
+impl Hash for FillNanUdf {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.fill_bits.hash(state);
+    }
+}
+impl PartialEq for FillNanUdf {
+    fn eq(&self, other: &Self) -> bool {
+        self.fill_bits == other.fill_bits
+    }
+}
+impl Eq for FillNanUdf {}
+
+impl ScalarUDFImpl for FillNanUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "fill_nan"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(arg_types[0].clone())
+    }
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        match &args.args[0] {
+            ColumnarValue::Array(array) => {
+                let fsl = array
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        datafusion_common::DataFusionError::Internal(
+                            "fill_nan expected FixedSizeList".to_string(),
+                        )
+                    })?;
+                let fill = self.fill_value();
+                let new_values = fill_nans_in_values(fsl.values(), fill)?;
+                let new_fsl = FixedSizeListArray::try_new(
+                    child_field_of(fsl),
+                    fsl.value_length(),
+                    new_values,
+                    fsl.nulls().cloned(),
+                )
+                .map_err(|e| datafusion_common::DataFusionError::ArrowError(Box::new(e), None))?;
+                Ok(ColumnarValue::Array(Arc::new(new_fsl)))
+            }
+            ColumnarValue::Scalar(s) => Ok(ColumnarValue::Scalar(s.clone())),
+        }
+    }
+}
+
+fn fill_nans_in_values(values: &ArrayRef, fill: f64) -> datafusion_common::Result<ArrayRef> {
+    match values.data_type() {
+        DataType::Float16 => {
+            let fill_f16 = half::f16::from_f64(fill);
+            let arr = values.as_any().downcast_ref::<Float16Array>().unwrap();
+            let new_arr: Float16Array = arr
+                .iter()
+                .map(|v| match v {
+                    Some(x) if x.is_nan() => Some(fill_f16),
+                    other => other,
+                })
+                .collect();
+            Ok(Arc::new(new_arr))
+        }
+        DataType::Float32 => {
+            let fill_f32 = fill as f32;
+            let arr = values.as_any().downcast_ref::<Float32Array>().unwrap();
+            let new_arr: Float32Array = arr
+                .iter()
+                .map(|v| match v {
+                    Some(x) if x.is_nan() => Some(fill_f32),
+                    other => other,
+                })
+                .collect();
+            Ok(Arc::new(new_arr))
+        }
+        DataType::Float64 => {
+            let arr = values.as_any().downcast_ref::<Float64Array>().unwrap();
+            let new_arr: Float64Array = arr
+                .iter()
+                .map(|v| match v {
+                    Some(x) if x.is_nan() => Some(fill),
+                    other => other,
+                })
+                .collect();
+            Ok(Arc::new(new_arr))
+        }
+        _ => Ok(values.clone()),
+    }
+}

--- a/rust/lancedb/src/table/datafusion/scannable_exec.rs
+++ b/rust/lancedb/src/table/datafusion/scannable_exec.rs
@@ -4,7 +4,10 @@
 use core::fmt;
 use std::sync::{Arc, Mutex};
 
-use datafusion_common::{DataFusionError, Result as DFResult, Statistics, stats::Precision};
+use datafusion_common::{
+    DataFusionError, Result as DFResult, Statistics,
+    stats::{ColumnStatistics, Precision},
+};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
@@ -122,13 +125,14 @@ impl ExecutionPlan for ScannableExec {
     }
 
     fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Statistics> {
+        let num_cols = self.schema().fields().len();
         Ok(Statistics {
             num_rows: self
                 .num_rows
                 .map(Precision::Exact)
                 .unwrap_or(Precision::Absent),
             total_byte_size: Precision::Absent,
-            column_statistics: vec![],
+            column_statistics: vec![ColumnStatistics::new_unknown(); num_cols],
         })
     }
 }


### PR DESCRIPTION
Replace NaNVectorBehavior (Error/Keep) with two independent enums:
- BadVectorValueHandling — handles NaN values in vectors (Error/Drop/Null/Fill/Keep)
- BadVectorDimensionHandling — handles wrong-dimension vectors before List→FSL cast (Error/Drop/Null/Fill) Pipeline order: ScannableExec → handle_bad_dimensions → cast → handle_bad_values. Both strategies are implemented as DataFusion physical plan nodes using scalar UDFs. Deprecated on_nan_vectors() wraps the new API for one release cycle. Fixes #992.