### PR TITLE
docs: add missing Python index classes to API reference

### DIFF
--- a/docs/src/python/python.md
+++ b/docs/src/python/python.md
@@ -166,6 +166,12 @@ lists the indices that LanceDb supports.
 
 ::: lancedb.index.IvfFlat
 
+::: lancedb.index.IvfSq
+
+::: lancedb.index.IvfRq
+
+::: lancedb.index.HnswFlat
+
 ::: lancedb.table.IndexStatistics
 
 ## Querying (Asynchronous)


### PR DESCRIPTION
Adds three index configuration classes to the Python API Reference that were missing from the documentation:

- `IvfSq` - IVF Scalar Quantization index
- `IvfRq` - IVF RabitQ Quantization index
- `HnswFlat` - HNSW without quantization (stores raw vectors)

These classes are exported in `lancedb.index.__all__` and have complete docstrings in the source, but weren't showing up in the rendered docs at https://lancedb.github.io/lancedb/python/python/#indices-asynchronous.

Closes #1855
