### PR TITLE
chore: update lance dependency to v6.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2949,7 +2949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3140,9 +3140,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f4a8c268d4d18be0f79a897c758f4eb6b074cc5c4bab56e828f0657d6bd521"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow-array",
  "rand 0.9.4",
@@ -4124,7 +4123,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4219,9 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dec6c13a1b9a608cc8275bb7e967250aba18b1dfde65ea07a78c6d442e8bf5c"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4289,9 +4287,8 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f0efc3607bac297f1b41ac4dc3d6ffbadd36f61a24bec46b70c1f9bda1feda"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4312,9 +4309,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c04b043c89e46ed3548f3b6423dcbdfac485e636c6e670d642424e954cfab66"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrayref",
  "paste",
@@ -4323,9 +4319,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e954fbffdf484587e956d34613b187a4d4785f6a52b0d89b0c04f1d75d6246"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4362,9 +4357,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac79df93aa8050f1c33fdc76bd1e86da714c309c08170be5eb1e353a67dc29b"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4395,9 +4389,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d904119ec5682fdf5729dd943bfdeea78e43585d07a13cce34b2bcee41328b"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,9 +4408,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4386ea75123fe6194e166f0f1d375b6041d44507fe7b7c63ac0da493de78a2f"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4454,9 +4446,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ad760cadf7c3e8e23aefc60d4f08eff553f4ad899c40c4a5bb9a976888c44"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4488,9 +4479,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a653b7dc78a171f0692ddd15afc458e296667c481228171d39f5d9a1f2a1faf0"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4555,9 +4545,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313f83fe349a5df2a7a24ad7707696ae0437d0270b0a1b78b340ee553eef7a6c"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4601,9 +4590,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bb2b89cc84b4fdb96c2436224394c1bb32d38e1e38a9c96e22e6e3918b0458"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4619,9 +4607,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfd6ad2e589bd8fc00965f808f16895b50d6cbd6405bd7a972db82fe62e2e24"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4634,9 +4621,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c9d4a7b0dceb1a4d2697bab8ce62d52f8b8fd0eec4b4ae6d40017f0ccad0cc"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4686,9 +4672,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a427dea3c93535c65f3c44985742c08ec4bf4f5f817779157b1dc3c6a2a3288"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4727,9 +4712,8 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf17e430caece4d5eb72e8ed76a61b05afc56ae66e79f2abe0945a9794a861d9"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4740,9 +4724,8 @@ dependencies = [
 
 [[package]]
 name = "lance-tokenizer"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ae0847a16b92629c2d894843b9666d2d975d8a7c3bd3ce21ad19c7900b140"
+version = "6.0.1-rc.2"
+source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
 dependencies = [
  "jieba-rs",
  "lindera",
@@ -5537,7 +5520,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6572,8 +6555,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph",
@@ -6592,7 +6575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6796,7 +6779,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7334,7 +7317,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7858,7 +7841,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7870,7 +7853,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8243,7 +8226,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9076,7 +9059,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2949,7 +2949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3140,8 +3140,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83cf860f6a6bf0a6a60fdfe5a36c75121fad5ea4332d1d12deee3e65b6047727"
 dependencies = [
  "arrow-array",
  "rand 0.9.4",
@@ -4123,7 +4124,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4218,8 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34e854994e84d043897f5ec9fb609221e9e69e3fd52996cd715d979fcd349f6"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4287,8 +4289,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7827fe404358c27d120ee8ea8ef7b9415c2911d54072bec83dd689d750ae65da"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4309,8 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd0b31570d50fe13c7e4e36b03e1f1c99c3d8e5a34845b24b0665b51b40570d"
 dependencies = [
  "arrayref",
  "paste",
@@ -4319,8 +4323,9 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b128c213c676cb8e03c62a68670642770825171e64097cc2da97cbb19fe35d29"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4357,8 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03b2de71cbcd09b10bf1a17c83cacbc0176ecd97203fb72b9e59d9b8f9a3743"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4389,8 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe7c7ea7fd397e495a1646fec360e46ee0cbd75718f1c0e887aad657c5f2944"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4408,8 +4415,9 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3f8070835b407d8db9ea8728386bc3207ba23c66a9c22d344e231ef12b77ca"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4446,8 +4454,9 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dfcf654549330df3aef708cd7c12e170feecddd34d6c19dd005b4153213268"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4479,8 +4488,9 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb8ad0bd10efa2608634a2518b7dd501231e76c56a65fbd6519e23914cc425a"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4545,8 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5314703fa8c8baed04193cc669da80ab42521c6319d3cc921a4a997690dcc0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4590,8 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51aa9b73279f505b2bec0f194c7a2390ca74ad3260131e631a7bef8d97d54b2e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4607,8 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cd01581f55ce45c49cbe494ee86c7ba7ca4ca3654690fd820941cd9105a46e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4621,8 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2cb89f3933060f01350ad05a5a3fbda952e8ba638799bf8ac4cd2368416ee46"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4672,8 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db70650465a1af174b7dfe6948ec91a3d466ada12e11274eb66e51132173aa0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4712,8 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce46a46f89e329234cfc632812e3c9b141129060835c5c6905ffd053dbd23dcd"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4724,8 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "lance-tokenizer"
-version = "6.0.1-rc.2"
-source = "git+https://github.com/lance-format/lance.git?tag=v6.0.1-rc.2#c13739b7f6556b5a2257115b65e2df6559e3b76e"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb08ef9382c9d58036c323db2c19cc097e02d1d0d87714fc7176b5d3b36a31aa"
 dependencies = [
  "jieba-rs",
  "lindera",
@@ -5520,7 +5537,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6555,8 +6572,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6575,7 +6592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6779,7 +6796,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7317,7 +7334,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7841,7 +7858,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7853,7 +7870,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8226,7 +8243,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9059,7 +9076,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ categories = ["database-implementations"]
 rust-version = "1.91.0"
 
 [workspace.dependencies]
-lance = { "version" = "=6.0.0", default-features = false }
-lance-core = "=6.0.0"
-lance-datagen = "=6.0.0"
-lance-file = "=6.0.0"
-lance-io = { "version" = "=6.0.0", default-features = false }
-lance-index = "=6.0.0"
-lance-linalg = "=6.0.0"
-lance-namespace = "=6.0.0"
-lance-namespace-impls = { "version" = "=6.0.0", default-features = false }
-lance-table = "=6.0.0"
-lance-testing = "=6.0.0"
-lance-datafusion = "=6.0.0"
-lance-encoding = "=6.0.0"
-lance-arrow = "=6.0.0"
+lance = { "version" = "=6.0.1-rc.2", default-features = false, "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-core = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-datagen = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-file = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-io = { "version" = "=6.0.1-rc.2", default-features = false, "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-index = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-linalg = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace-impls = { "version" = "=6.0.1-rc.2", default-features = false, "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-table = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-testing = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-datafusion = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-encoding = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance-arrow = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
 ahash = "0.8"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ categories = ["database-implementations"]
 rust-version = "1.91.0"
 
 [workspace.dependencies]
-lance = { "version" = "=6.0.1-rc.2", default-features = false, "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-core = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-datagen = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-file = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-io = { "version" = "=6.0.1-rc.2", default-features = false, "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-index = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-linalg = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace-impls = { "version" = "=6.0.1-rc.2", default-features = false, "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-table = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-testing = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-datafusion = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-encoding = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
-lance-arrow = { "version" = "=6.0.1-rc.2", "tag" = "v6.0.1-rc.2", "git" = "https://github.com/lance-format/lance.git" }
+lance = { "version" = "=6.0.1", default-features = false }
+lance-core = "=6.0.1"
+lance-datagen = "=6.0.1"
+lance-file = "=6.0.1"
+lance-io = { "version" = "=6.0.1", default-features = false }
+lance-index = "=6.0.1"
+lance-linalg = "=6.0.1"
+lance-namespace = "=6.0.1"
+lance-namespace-impls = { "version" = "=6.0.1", default-features = false }
+lance-table = "=6.0.1"
+lance-testing = "=6.0.1"
+lance-datafusion = "=6.0.1"
+lance-encoding = "=6.0.1"
+lance-arrow = "=6.0.1"
 ahash = "0.8"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false }

--- a/deny.toml
+++ b/deny.toml
@@ -80,6 +80,13 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2025-0119
     { id = "RUSTSEC-2025-0119", reason = "transitive via hf-hub/indicatif; cosmetic formatting crate" },
 
+    # rustls-pemfile: unmaintained (repo archived; code folded into
+    # rustls-pki-types). Reached only transitively via object_store → lance.
+    # No safe upgrade is available; clearing this requires object_store to
+    # migrate to the rustls-pki-types PemObject API.
+    # https://rustsec.org/advisories/RUSTSEC-2025-0134
+    { id = "RUSTSEC-2025-0134", reason = "transitive via object_store/lance; waiting on object_store migration to rustls-pki-types" },
+
     # bincode: unmaintained. Reached through lindera and lindera-dictionary,
     # which are required by the native Lindera tokenizer path. Lindera has not
     # migrated to another serialization format yet.


### PR DESCRIPTION
Updates the `release/v0.28` branch to depend on the released Lance `6.0.1` (crates.io).

Initially this PR pinned the `v6.0.1-rc.2` release candidate from a git tag to validate the Lance release in LanceDB CI. Lance 6.0.1 is now published, so the `lance-*` deps are repinned to the plain `=6.0.1` crates.io version.

Once merged, this branch is ready to cut the LanceDB 0.28.1 release.