### PR TITLE
fix: allow appending arrow.json data into lance.json tables

### DIFF
--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -993,6 +993,7 @@ mod tests {
     /// `"json vs large_binary" schema mismatch`.
     #[tokio::test]
     async fn test_add_arrow_json_into_lance_json_table() {
+        use arrow_array::{Array, cast::AsArray};
         use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
 
         // Build a table whose "data" column is lance.json (LargeBinary +
@@ -1013,7 +1014,10 @@ mod tests {
         let data_field = stored_field.field_with_name("data").unwrap();
         assert_eq!(data_field.data_type(), &DataType::LargeBinary);
         assert_eq!(
-            data_field.metadata().get("ARROW:extension:name").map(|s| s.as_str()),
+            data_field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(|s| s.as_str()),
             Some(JSON_EXT_NAME),
         );
 
@@ -1024,25 +1028,22 @@ mod tests {
             "ARROW:extension:name".to_string(),
             ARROW_JSON_EXT_NAME.to_string(),
         );
-        let arrow_json_field = Field::new("data", DataType::Utf8, true)
-            .with_metadata(arrow_json_metadata);
+        let arrow_json_field =
+            Field::new("data", DataType::Utf8, true).with_metadata(arrow_json_metadata);
         let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
 
         let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"a": 1}"#), Some(r#"{"b": 2}"#)];
-        let string_array: Arc<dyn arrow_array::Array> = Arc::new(
-            arrow_array::StringArray::from(json_values),
-        );
-        let batch =
-            RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
+        let string_array: Arc<dyn arrow_array::Array> =
+            Arc::new(arrow_array::StringArray::from(json_values));
+        let batch = RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
 
         // This must not fail with a schema-mismatch error.
         table.add(batch).execute().await.unwrap();
 
         assert_eq!(table.count_rows(None).await.unwrap(), 3);
 
-        // Verify the data was correctly written by reading it back.
-        // Lance stores JSON as JSONB (binary format), so we read as large_binary
-        // and verify the content can be parsed.
+        // Verify the data was correctly written by reading it back. A lance.json
+        // column is read back as Utf8 carrying arrow.json extension metadata.
         let results: Vec<RecordBatch> = table
             .query()
             .select(Select::columns(&["data"]))
@@ -1060,19 +1061,20 @@ mod tests {
         // Verify null value is preserved
         assert!(batch.column(0).is_null(0));
 
-        // Verify JSON values are correctly stored (as JSONB binary)
+        // Verify JSON values are correctly stored.
         let json_col = batch.column(0);
-        let json_bytes: &arrow_array::LargeBinaryArray = json_col.as_binary();
+        assert_eq!(json_col.data_type(), &DataType::Utf8);
+        let json_strs = json_col.as_string::<i32>();
 
         // Row 1: {"a": 1}
-        assert!(!json_bytes.is_null(1));
-        let json1 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(1).as_ref())
+        assert!(!json_strs.is_null(1));
+        let json1 = serde_json::from_str::<serde_json::Value>(json_strs.value(1))
             .expect("JSON should be valid");
         assert_eq!(json1, serde_json::json!({"a": 1}));
 
         // Row 2: {"b": 2}
-        assert!(!json_bytes.is_null(2));
-        let json2 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(2).as_ref())
+        assert!(!json_strs.is_null(2));
+        let json2 = serde_json::from_str::<serde_json::Value>(json_strs.value(2))
             .expect("JSON should be valid");
         assert_eq!(json2, serde_json::json!({"b": 2}));
     }
@@ -1082,6 +1084,7 @@ mod tests {
     /// PyArrow's pa.large_string() or when creating pa.json_() with certain versions.
     #[tokio::test]
     async fn test_add_arrow_json_large_utf8_into_lance_json_table() {
+        use arrow_array::{Array, cast::AsArray};
         use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
 
         // Build a table whose "data" column is lance.json (LargeBinary +
@@ -1101,7 +1104,10 @@ mod tests {
         let data_field = stored_field.field_with_name("data").unwrap();
         assert_eq!(data_field.data_type(), &DataType::LargeBinary);
         assert_eq!(
-            data_field.metadata().get("ARROW:extension:name").map(|s| s.as_str()),
+            data_field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(|s| s.as_str()),
             Some(JSON_EXT_NAME),
         );
 
@@ -1111,16 +1117,14 @@ mod tests {
             "ARROW:extension:name".to_string(),
             ARROW_JSON_EXT_NAME.to_string(),
         );
-        let arrow_json_field = Field::new("data", DataType::LargeUtf8, true)
-            .with_metadata(arrow_json_metadata);
+        let arrow_json_field =
+            Field::new("data", DataType::LargeUtf8, true).with_metadata(arrow_json_metadata);
         let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
 
         let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"x": 10}"#), Some(r#"{"y": 20}"#)];
-        let string_array: Arc<dyn arrow_array::Array> = Arc::new(
-            arrow_array::LargeStringArray::from(json_values),
-        );
-        let batch =
-            RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
+        let string_array: Arc<dyn arrow_array::Array> =
+            Arc::new(arrow_array::LargeStringArray::from(json_values));
+        let batch = RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
 
         // This must not fail with a schema-mismatch error.
         table.add(batch).execute().await.unwrap();
@@ -1145,19 +1149,20 @@ mod tests {
         // Verify null value is preserved
         assert!(batch.column(0).is_null(0));
 
-        // Verify JSON values are correctly stored (as JSONB binary)
+        // Verify JSON values are correctly stored.
         let json_col = batch.column(0);
-        let json_bytes: &arrow_array::LargeBinaryArray = json_col.as_binary();
+        assert_eq!(json_col.data_type(), &DataType::Utf8);
+        let json_strs = json_col.as_string::<i32>();
 
         // Row 1: {"x": 10}
-        assert!(!json_bytes.is_null(1));
-        let json1 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(1).as_ref())
+        assert!(!json_strs.is_null(1));
+        let json1 = serde_json::from_str::<serde_json::Value>(json_strs.value(1))
             .expect("JSON should be valid");
         assert_eq!(json1, serde_json::json!({"x": 10}));
 
         // Row 2: {"y": 20}
-        assert!(!json_bytes.is_null(2));
-        let json2 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(2).as_ref())
+        assert!(!json_strs.is_null(2));
+        let json2 = serde_json::from_str::<serde_json::Value>(json_strs.value(2))
             .expect("JSON should be valid");
         assert_eq!(json2, serde_json::json!({"y": 20}));
     }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -1039,5 +1039,122 @@ mod tests {
         table.add(batch).execute().await.unwrap();
 
         assert_eq!(table.count_rows(None).await.unwrap(), 3);
+
+        // Verify the data was correctly written by reading it back.
+        // Lance stores JSON as JSONB (binary format), so we read as large_binary
+        // and verify the content can be parsed.
+        let results: Vec<RecordBatch> = table
+            .query()
+            .select(Select::columns(&["data"]))
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 3);
+
+        // Verify null value is preserved
+        assert!(batch.column(0).is_null(0));
+
+        // Verify JSON values are correctly stored (as JSONB binary)
+        let json_col = batch.column(0);
+        let json_bytes: &arrow_array::LargeBinaryArray = json_col.as_binary();
+
+        // Row 1: {"a": 1}
+        assert!(!json_bytes.is_null(1));
+        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
+        assert!(json1.contains("\"a\":") || json1.contains("a"));
+
+        // Row 2: {"b": 2}
+        assert!(!json_bytes.is_null(2));
+        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
+        assert!(json2.contains("\"b\":") || json2.contains("b"));
+    }
+
+    /// Test that LargeUtf8-backed arrow.json can be appended to a lance.json table.
+    /// This is similar to the Utf8 case but uses LargeUtf8 which is the default for
+    /// PyArrow's pa.large_string() or when creating pa.json_() with certain versions.
+    #[tokio::test]
+    async fn test_add_arrow_json_large_utf8_into_lance_json_table() {
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
+
+        // Build a table whose "data" column is lance.json (LargeBinary +
+        // ARROW:extension:name = "lance.json").
+        let lance_json_field = lance_arrow::json::json_field("data", true);
+        let table_schema = Arc::new(Schema::new(vec![lance_json_field.clone()]));
+
+        let db = connect("memory://").execute().await.unwrap();
+        let table = db
+            .create_empty_table("json_test_large_utf8", table_schema)
+            .execute()
+            .await
+            .unwrap();
+
+        // Verify the table schema looks like lance.json.
+        let stored_field = table.schema().await.unwrap();
+        let data_field = stored_field.field_with_name("data").unwrap();
+        assert_eq!(data_field.data_type(), &DataType::LargeBinary);
+        assert_eq!(
+            data_field.metadata().get("ARROW:extension:name").map(|s| s.as_str()),
+            Some(JSON_EXT_NAME),
+        );
+
+        // Now append using a LargeUtf8-backed arrow.json typed field.
+        let mut arrow_json_metadata = std::collections::HashMap::new();
+        arrow_json_metadata.insert(
+            "ARROW:extension:name".to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let arrow_json_field = Field::new("data", DataType::LargeUtf8, true)
+            .with_metadata(arrow_json_metadata);
+        let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
+
+        let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"x": 10}"#), Some(r#"{"y": 20}"#)];
+        let string_array: Arc<dyn arrow_array::Array> = Arc::new(
+            arrow_array::LargeStringArray::from(json_values),
+        );
+        let batch =
+            RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
+
+        // This must not fail with a schema-mismatch error.
+        table.add(batch).execute().await.unwrap();
+
+        assert_eq!(table.count_rows(None).await.unwrap(), 3);
+
+        // Verify the data was correctly written by reading it back.
+        let results: Vec<RecordBatch> = table
+            .query()
+            .select(Select::columns(&["data"]))
+            .execute()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 3);
+
+        // Verify null value is preserved
+        assert!(batch.column(0).is_null(0));
+
+        // Verify JSON values are correctly stored (as JSONB binary)
+        let json_col = batch.column(0);
+        let json_bytes: &arrow_array::LargeBinaryArray = json_col.as_binary();
+
+        // Row 1: {"x": 10}
+        assert!(!json_bytes.is_null(1));
+        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
+        assert!(json1.contains("\"x\":") || json1.contains("x"));
+
+        // Row 2: {"y": 20}
+        assert!(!json_bytes.is_null(2));
+        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
+        assert!(json2.contains("\"y\":") || json2.contains("y"));
     }
 }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -991,147 +991,65 @@ mod tests {
     /// which produced a field whose Arrow extension metadata still read `arrow.json` instead
     /// of `lance.json`.  Lance-core then rejected the append with
     /// `"json vs large_binary" schema mismatch`.
-    #[tokio::test]
-    async fn test_add_arrow_json_into_lance_json_table() {
+    ///
+    /// PyArrow's `pa.json_()` may be backed by either `Utf8` or `LargeUtf8` depending on the
+    /// constructor used, so the helper is parameterized over the input backing type.
+    async fn append_arrow_json_into_lance_json_table(
+        input_type: DataType,
+        table_name: &str,
+        rows: Vec<Option<&str>>,
+    ) {
         use arrow_array::{Array, cast::AsArray};
-        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
-
-        // Build a table whose "data" column is lance.json (LargeBinary +
-        // ARROW:extension:name = "lance.json").  We use json_field() helper from
-        // lance-arrow which produces exactly this shape.
-        let lance_json_field = lance_arrow::json::json_field("data", true);
-        let table_schema = Arc::new(Schema::new(vec![lance_json_field.clone()]));
-
-        let db = connect("memory://").execute().await.unwrap();
-        let table = db
-            .create_empty_table("json_test", table_schema)
-            .execute()
-            .await
-            .unwrap();
-
-        // Verify the table schema looks like lance.json.
-        let stored_field = table.schema().await.unwrap();
-        let data_field = stored_field.field_with_name("data").unwrap();
-        assert_eq!(data_field.data_type(), &DataType::LargeBinary);
-        assert_eq!(
-            data_field
-                .metadata()
-                .get("ARROW:extension:name")
-                .map(|s| s.as_str()),
-            Some(JSON_EXT_NAME),
-        );
-
-        // Now append using an arrow.json typed field (Utf8 + arrow.json extension).
-        // This is what PyArrow produces for pa.json_() arrays.
-        let mut arrow_json_metadata = std::collections::HashMap::new();
-        arrow_json_metadata.insert(
-            "ARROW:extension:name".to_string(),
-            ARROW_JSON_EXT_NAME.to_string(),
-        );
-        let arrow_json_field =
-            Field::new("data", DataType::Utf8, true).with_metadata(arrow_json_metadata);
-        let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
-
-        let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"a": 1}"#), Some(r#"{"b": 2}"#)];
-        let string_array: Arc<dyn arrow_array::Array> =
-            Arc::new(arrow_array::StringArray::from(json_values));
-        let batch = RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
-
-        // This must not fail with a schema-mismatch error.
-        table.add(batch).execute().await.unwrap();
-
-        assert_eq!(table.count_rows(None).await.unwrap(), 3);
-
-        // Verify the data was correctly written by reading it back. A lance.json
-        // column is read back as Utf8 carrying arrow.json extension metadata.
-        let results: Vec<RecordBatch> = table
-            .query()
-            .select(Select::columns(&["data"]))
-            .execute()
-            .await
-            .unwrap()
-            .try_collect()
-            .await
-            .unwrap();
-
-        assert_eq!(results.len(), 1);
-        let batch = &results[0];
-        assert_eq!(batch.num_rows(), 3);
-
-        // Verify null value is preserved
-        assert!(batch.column(0).is_null(0));
-
-        // Verify JSON values are correctly stored.
-        let json_col = batch.column(0);
-        assert_eq!(json_col.data_type(), &DataType::Utf8);
-        let json_strs = json_col.as_string::<i32>();
-
-        // Row 1: {"a": 1}
-        assert!(!json_strs.is_null(1));
-        let json1 = serde_json::from_str::<serde_json::Value>(json_strs.value(1))
-            .expect("JSON should be valid");
-        assert_eq!(json1, serde_json::json!({"a": 1}));
-
-        // Row 2: {"b": 2}
-        assert!(!json_strs.is_null(2));
-        let json2 = serde_json::from_str::<serde_json::Value>(json_strs.value(2))
-            .expect("JSON should be valid");
-        assert_eq!(json2, serde_json::json!({"b": 2}));
-    }
-
-    /// Test that LargeUtf8-backed arrow.json can be appended to a lance.json table.
-    /// This is similar to the Utf8 case but uses LargeUtf8 which is the default for
-    /// PyArrow's pa.large_string() or when creating pa.json_() with certain versions.
-    #[tokio::test]
-    async fn test_add_arrow_json_large_utf8_into_lance_json_table() {
-        use arrow_array::{Array, cast::AsArray};
+        use lance_arrow::ARROW_EXT_NAME_KEY;
         use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
 
         // Build a table whose "data" column is lance.json (LargeBinary +
         // ARROW:extension:name = "lance.json").
         let lance_json_field = lance_arrow::json::json_field("data", true);
-        let table_schema = Arc::new(Schema::new(vec![lance_json_field.clone()]));
+        let table_schema = Arc::new(Schema::new(vec![lance_json_field]));
 
         let db = connect("memory://").execute().await.unwrap();
         let table = db
-            .create_empty_table("json_test_large_utf8", table_schema)
+            .create_empty_table(table_name, table_schema)
             .execute()
             .await
             .unwrap();
 
-        // Verify the table schema looks like lance.json.
+        // Sanity-check the stored schema.
         let stored_field = table.schema().await.unwrap();
         let data_field = stored_field.field_with_name("data").unwrap();
         assert_eq!(data_field.data_type(), &DataType::LargeBinary);
         assert_eq!(
             data_field
                 .metadata()
-                .get("ARROW:extension:name")
+                .get(ARROW_EXT_NAME_KEY)
                 .map(|s| s.as_str()),
             Some(JSON_EXT_NAME),
         );
 
-        // Now append using a LargeUtf8-backed arrow.json typed field.
-        let mut arrow_json_metadata = std::collections::HashMap::new();
-        arrow_json_metadata.insert(
-            "ARROW:extension:name".to_string(),
+        // Build an arrow.json input field (Utf8/LargeUtf8 + arrow.json extension).
+        // This is what PyArrow produces for pa.json_() arrays.
+        let arrow_json_metadata = std::collections::HashMap::from([(
+            ARROW_EXT_NAME_KEY.to_string(),
             ARROW_JSON_EXT_NAME.to_string(),
-        );
+        )]);
         let arrow_json_field =
-            Field::new("data", DataType::LargeUtf8, true).with_metadata(arrow_json_metadata);
+            Field::new("data", input_type.clone(), true).with_metadata(arrow_json_metadata);
         let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
 
-        let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"x": 10}"#), Some(r#"{"y": 20}"#)];
-        let string_array: Arc<dyn arrow_array::Array> =
-            Arc::new(arrow_array::LargeStringArray::from(json_values));
+        let string_array: Arc<dyn arrow_array::Array> = match input_type {
+            DataType::Utf8 => Arc::new(arrow_array::StringArray::from(rows.clone())),
+            DataType::LargeUtf8 => Arc::new(arrow_array::LargeStringArray::from(rows.clone())),
+            other => panic!("unsupported arrow.json backing type for this test: {other:?}"),
+        };
         let batch = RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
 
         // This must not fail with a schema-mismatch error.
         table.add(batch).execute().await.unwrap();
 
-        assert_eq!(table.count_rows(None).await.unwrap(), 3);
+        assert_eq!(table.count_rows(None).await.unwrap(), rows.len());
 
-        // Verify the data was correctly written by reading it back.
+        // A lance.json column is read back as Utf8 carrying arrow.json extension metadata.
         let results: Vec<RecordBatch> = table
             .query()
             .select(Select::columns(&["data"]))
@@ -1144,26 +1062,44 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         let batch = &results[0];
-        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_rows(), rows.len());
 
-        // Verify null value is preserved
-        assert!(batch.column(0).is_null(0));
-
-        // Verify JSON values are correctly stored.
         let json_col = batch.column(0);
         assert_eq!(json_col.data_type(), &DataType::Utf8);
         let json_strs = json_col.as_string::<i32>();
 
-        // Row 1: {"x": 10}
-        assert!(!json_strs.is_null(1));
-        let json1 = serde_json::from_str::<serde_json::Value>(json_strs.value(1))
-            .expect("JSON should be valid");
-        assert_eq!(json1, serde_json::json!({"x": 10}));
+        for (i, expected) in rows.iter().enumerate() {
+            match expected {
+                None => assert!(json_strs.is_null(i), "row {i} expected null"),
+                Some(raw) => {
+                    assert!(!json_strs.is_null(i), "row {i} expected non-null");
+                    let actual: serde_json::Value = serde_json::from_str(json_strs.value(i))
+                        .expect("read-back JSON should be valid");
+                    let expected: serde_json::Value =
+                        serde_json::from_str(raw).expect("expected JSON should be valid");
+                    assert_eq!(actual, expected, "row {i} JSON mismatch");
+                }
+            }
+        }
+    }
 
-        // Row 2: {"y": 20}
-        assert!(!json_strs.is_null(2));
-        let json2 = serde_json::from_str::<serde_json::Value>(json_strs.value(2))
-            .expect("JSON should be valid");
-        assert_eq!(json2, serde_json::json!({"y": 20}));
+    #[tokio::test]
+    async fn test_add_arrow_json_into_lance_json_table() {
+        append_arrow_json_into_lance_json_table(
+            DataType::Utf8,
+            "json_test",
+            vec![None, Some(r#"{"a": 1}"#), Some(r#"{"b": 2}"#)],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_add_arrow_json_large_utf8_into_lance_json_table() {
+        append_arrow_json_into_lance_json_table(
+            DataType::LargeUtf8,
+            "json_test_large_utf8",
+            vec![None, Some(r#"{"x": 10}"#), Some(r#"{"y": 20}"#)],
+        )
+        .await;
     }
 }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -993,12 +993,12 @@ mod tests {
     /// `"json vs large_binary" schema mismatch`.
     ///
     /// PyArrow's `pa.json_()` may be backed by either `Utf8` or `LargeUtf8` depending on the
-    /// constructor used, so the helper is parameterized over the input backing type.
-    async fn append_arrow_json_into_lance_json_table(
-        input_type: DataType,
-        table_name: &str,
-        rows: Vec<Option<&str>>,
-    ) {
+    /// constructor used, so the test is parameterized over the input backing type.
+    #[rstest::rstest]
+    #[case::utf8(DataType::Utf8)]
+    #[case::large_utf8(DataType::LargeUtf8)]
+    #[tokio::test]
+    async fn test_add_arrow_json_into_lance_json_table(#[case] input_type: DataType) {
         use arrow_array::{Array, cast::AsArray};
         use lance_arrow::ARROW_EXT_NAME_KEY;
         use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
@@ -1010,7 +1010,7 @@ mod tests {
 
         let db = connect("memory://").execute().await.unwrap();
         let table = db
-            .create_empty_table(table_name, table_schema)
+            .create_empty_table("json_test", table_schema)
             .execute()
             .await
             .unwrap();
@@ -1037,6 +1037,7 @@ mod tests {
             Field::new("data", input_type.clone(), true).with_metadata(arrow_json_metadata);
         let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
 
+        let rows: Vec<Option<&str>> = vec![None, Some(r#"{"a": 1}"#), Some(r#"{"b": 2}"#)];
         let string_array: Arc<dyn arrow_array::Array> = match input_type {
             DataType::Utf8 => Arc::new(arrow_array::StringArray::from(rows.clone())),
             DataType::LargeUtf8 => Arc::new(arrow_array::LargeStringArray::from(rows.clone())),
@@ -1081,25 +1082,5 @@ mod tests {
                 }
             }
         }
-    }
-
-    #[tokio::test]
-    async fn test_add_arrow_json_into_lance_json_table() {
-        append_arrow_json_into_lance_json_table(
-            DataType::Utf8,
-            "json_test",
-            vec![None, Some(r#"{"a": 1}"#), Some(r#"{"b": 2}"#)],
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_add_arrow_json_large_utf8_into_lance_json_table() {
-        append_arrow_json_into_lance_json_table(
-            DataType::LargeUtf8,
-            "json_test_large_utf8",
-            vec![None, Some(r#"{"x": 10}"#), Some(r#"{"y": 20}"#)],
-        )
-        .await;
     }
 }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -982,4 +982,62 @@ mod tests {
         table2.add(struct_batch).execute().await.unwrap();
         assert_eq!(table2.count_rows(None).await.unwrap(), 2);
     }
+
+    /// Regression test: appending `arrow.json` (PyArrow `pa.json_()`) data into a table
+    /// whose schema was created with `pa.json_()` (internally stored as `lance.json`, backed
+    /// by `LargeBinary`) must succeed without a schema-mismatch error.
+    ///
+    /// Previously `build_field_exprs` would attempt a `Utf8 → LargeBinary` DataFusion cast,
+    /// which produced a field whose Arrow extension metadata still read `arrow.json` instead
+    /// of `lance.json`.  Lance-core then rejected the append with
+    /// `"json vs large_binary" schema mismatch`.
+    #[tokio::test]
+    async fn test_add_arrow_json_into_lance_json_table() {
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME};
+
+        // Build a table whose "data" column is lance.json (LargeBinary +
+        // ARROW:extension:name = "lance.json").  We use json_field() helper from
+        // lance-arrow which produces exactly this shape.
+        let lance_json_field = lance_arrow::json::json_field("data", true);
+        let table_schema = Arc::new(Schema::new(vec![lance_json_field.clone()]));
+
+        let db = connect("memory://").execute().await.unwrap();
+        let table = db
+            .create_empty_table("json_test", table_schema)
+            .execute()
+            .await
+            .unwrap();
+
+        // Verify the table schema looks like lance.json.
+        let stored_field = table.schema().await.unwrap();
+        let data_field = stored_field.field_with_name("data").unwrap();
+        assert_eq!(data_field.data_type(), &DataType::LargeBinary);
+        assert_eq!(
+            data_field.metadata().get("ARROW:extension:name").map(|s| s.as_str()),
+            Some(JSON_EXT_NAME),
+        );
+
+        // Now append using an arrow.json typed field (Utf8 + arrow.json extension).
+        // This is what PyArrow produces for pa.json_() arrays.
+        let mut arrow_json_metadata = std::collections::HashMap::new();
+        arrow_json_metadata.insert(
+            "ARROW:extension:name".to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let arrow_json_field = Field::new("data", DataType::Utf8, true)
+            .with_metadata(arrow_json_metadata);
+        let arrow_json_schema = Arc::new(Schema::new(vec![arrow_json_field]));
+
+        let json_values: Vec<Option<&str>> = vec![None, Some(r#"{"a": 1}"#), Some(r#"{"b": 2}"#)];
+        let string_array: Arc<dyn arrow_array::Array> = Arc::new(
+            arrow_array::StringArray::from(json_values),
+        );
+        let batch =
+            RecordBatch::try_new(arrow_json_schema, vec![string_array]).unwrap();
+
+        // This must not fail with a schema-mismatch error.
+        table.add(batch).execute().await.unwrap();
+
+        assert_eq!(table.count_rows(None).await.unwrap(), 3);
+    }
 }

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -1066,13 +1066,15 @@ mod tests {
 
         // Row 1: {"a": 1}
         assert!(!json_bytes.is_null(1));
-        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
-        assert!(json1.contains("\"a\":") || json1.contains("a"));
+        let json1 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(1).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json1, serde_json::json!({"a": 1}));
 
         // Row 2: {"b": 2}
         assert!(!json_bytes.is_null(2));
-        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
-        assert!(json2.contains("\"b\":") || json2.contains("b"));
+        let json2 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(2).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json2, serde_json::json!({"b": 2}));
     }
 
     /// Test that LargeUtf8-backed arrow.json can be appended to a lance.json table.
@@ -1149,12 +1151,14 @@ mod tests {
 
         // Row 1: {"x": 10}
         assert!(!json_bytes.is_null(1));
-        let json1 = String::from_utf8_lossy(json_bytes.value(1).as_ref());
-        assert!(json1.contains("\"x\":") || json1.contains("x"));
+        let json1 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(1).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json1, serde_json::json!({"x": 10}));
 
         // Row 2: {"y": 20}
         assert!(!json_bytes.is_null(2));
-        let json2 = String::from_utf8_lossy(json_bytes.value(2).as_ref());
-        assert!(json2.contains("\"y\":") || json2.contains("y"));
+        let json2 = serde_json::from_slice::<serde_json::Value>(json_bytes.value(2).as_ref())
+            .expect("JSON should be valid");
+        assert_eq!(json2, serde_json::json!({"y": 20}));
     }
 }

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -641,7 +641,7 @@ mod tests {
     /// batch with a "json vs large_binary" schema-mismatch error.
     #[tokio::test]
     async fn test_arrow_json_passthrough_to_lance_json() {
-        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME, json_field};
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, json_field};
         use lance_arrow::ARROW_EXT_NAME_KEY;
 
         // Build a table schema with a lance.json field (LargeBinary + lance.json metadata).

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -13,6 +13,7 @@ use datafusion_physical_expr::expressions::{CastExpr, Literal};
 use datafusion_physical_plan::expressions::Column;
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+use lance_arrow::json::{is_arrow_json_field, is_json_field};
 
 use crate::{Error, Result};
 
@@ -63,6 +64,18 @@ fn build_field_exprs(
 
         let input_field = &input_fields[input_idx];
         let input_expr = get_input_expr(input_idx);
+
+        // Special case: input is arrow.json (PyArrow pa.json_() extension type backed by
+        // Utf8/LargeUtf8) and the table field is lance.json (backed by LargeBinary).
+        // Lance-core's write path already handles the arrow.json → lance.json conversion
+        // (including JSONB encoding), so we pass the expression through unchanged and let
+        // lance-core deal with it. Attempting to cast Utf8 → LargeBinary here would
+        // produce a field whose metadata still identifies it as arrow.json, which then
+        // causes a schema-mismatch error inside lance-core.
+        if is_arrow_json_field(input_field) && is_json_field(table_field) {
+            result.push((input_expr, Arc::clone(input_field) as FieldRef));
+            continue;
+        }
 
         let expr = match (input_field.data_type(), table_field.data_type()) {
             // Both are structs: recurse into sub-fields to handle subschemas and casts.
@@ -617,5 +630,61 @@ mod tests {
             .downcast_ref()
             .unwrap();
         assert_eq!(a.values(), &[1, 3]);
+    }
+
+    /// `arrow.json` input (PyArrow `pa.json_()`, Utf8 + extension metadata) against a
+    /// `lance.json` table field (LargeBinary + extension metadata) must be passed through
+    /// without a cast so that lance-core can perform its own arrow.json → JSONB conversion.
+    ///
+    /// Before the fix, `cast_to_table_schema` attempted a `Utf8 → LargeBinary` DataFusion
+    /// cast that preserved the wrong extension metadata, causing lance-core to reject the
+    /// batch with a "json vs large_binary" schema-mismatch error.
+    #[tokio::test]
+    async fn test_arrow_json_passthrough_to_lance_json() {
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JSON_EXT_NAME, json_field};
+        use lance_arrow::ARROW_EXT_NAME_KEY;
+
+        // Build a table schema with a lance.json field (LargeBinary + lance.json metadata).
+        let lance_field = json_field("data", true);
+        let table_schema = Schema::new(vec![lance_field]);
+
+        // Build an input batch with an arrow.json field (Utf8 + arrow.json metadata).
+        let mut arrow_meta = std::collections::HashMap::new();
+        arrow_meta.insert(ARROW_EXT_NAME_KEY.to_string(), ARROW_JSON_EXT_NAME.to_string());
+        let arrow_field = Field::new("data", DataType::Utf8, true).with_metadata(arrow_meta);
+        let input_schema = Arc::new(Schema::new(vec![arrow_field]));
+        let input_batch = RecordBatch::try_new(
+            input_schema,
+            vec![Arc::new(StringArray::from(vec![
+                Some(r#"{"x": 1}"#),
+                None,
+                Some(r#"{"y": 2}"#),
+            ]))],
+        )
+        .unwrap();
+
+        let plan = plan_from_batch(input_batch).await;
+        let projected = cast_to_table_schema(plan, &table_schema).unwrap();
+
+        // The projected schema's "data" field must carry arrow.json metadata
+        // (the input field), not be silently dropped or miscast.
+        let out_field = projected.schema().field_with_name("data").unwrap().clone();
+        assert_eq!(out_field.data_type(), &DataType::Utf8);
+        assert_eq!(
+            out_field
+                .metadata()
+                .get(ARROW_EXT_NAME_KEY)
+                .map(|s| s.as_str()),
+            Some(ARROW_JSON_EXT_NAME),
+            "output field must still carry arrow.json metadata so lance-core can handle it"
+        );
+
+        // The data must flow through correctly (3 rows, no panic).
+        let result = collect(projected).await;
+        assert_eq!(result.num_rows(), 3);
+        let col: &StringArray = result.column(0).as_any().downcast_ref().unwrap();
+        assert_eq!(col.value(0), r#"{"x": 1}"#);
+        assert!(result.column(0).is_null(1));
+        assert_eq!(col.value(2), r#"{"y": 2}"#);
     }
 }

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -641,8 +641,8 @@ mod tests {
     /// batch with a "json vs large_binary" schema-mismatch error.
     #[tokio::test]
     async fn test_arrow_json_passthrough_to_lance_json() {
-        use lance_arrow::json::{ARROW_JSON_EXT_NAME, json_field};
         use lance_arrow::ARROW_EXT_NAME_KEY;
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, json_field};
 
         // Build a table schema with a lance.json field (LargeBinary + lance.json metadata).
         let lance_field = json_field("data", true);
@@ -650,7 +650,10 @@ mod tests {
 
         // Build an input batch with an arrow.json field (Utf8 + arrow.json metadata).
         let mut arrow_meta = std::collections::HashMap::new();
-        arrow_meta.insert(ARROW_EXT_NAME_KEY.to_string(), ARROW_JSON_EXT_NAME.to_string());
+        arrow_meta.insert(
+            ARROW_EXT_NAME_KEY.to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
         let arrow_field = Field::new("data", DataType::Utf8, true).with_metadata(arrow_meta);
         let input_schema = Arc::new(Schema::new(vec![arrow_field]));
         let input_batch = RecordBatch::try_new(

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -639,7 +639,11 @@ mod tests {
     /// Before the fix, `cast_to_table_schema` attempted a `Utf8 → LargeBinary` DataFusion
     /// cast that preserved the wrong extension metadata, causing lance-core to reject the
     /// batch with a "json vs large_binary" schema-mismatch error.
-    async fn run_arrow_json_passthrough_to_lance_json(input_type: DataType) {
+    #[rstest::rstest]
+    #[case::utf8(DataType::Utf8)]
+    #[case::large_utf8(DataType::LargeUtf8)]
+    #[tokio::test]
+    async fn test_arrow_json_passthrough_to_lance_json(#[case] input_type: DataType) {
         use lance_arrow::ARROW_EXT_NAME_KEY;
         use lance_arrow::json::{ARROW_JSON_EXT_NAME, json_field};
 
@@ -697,15 +701,5 @@ mod tests {
         assert_eq!(v0, r#"{"x": 1}"#);
         assert!(result.column(0).is_null(1));
         assert_eq!(v2, r#"{"y": 2}"#);
-    }
-
-    #[tokio::test]
-    async fn test_arrow_json_passthrough_to_lance_json() {
-        run_arrow_json_passthrough_to_lance_json(DataType::Utf8).await;
-    }
-
-    #[tokio::test]
-    async fn test_arrow_json_passthrough_to_lance_json_large_utf8() {
-        run_arrow_json_passthrough_to_lance_json(DataType::LargeUtf8).await;
     }
 }

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -632,15 +632,14 @@ mod tests {
         assert_eq!(a.values(), &[1, 3]);
     }
 
-    /// `arrow.json` input (PyArrow `pa.json_()`, Utf8 + extension metadata) against a
+    /// `arrow.json` input (PyArrow `pa.json_()`, Utf8/LargeUtf8 + extension metadata) against a
     /// `lance.json` table field (LargeBinary + extension metadata) must be passed through
     /// without a cast so that lance-core can perform its own arrow.json → JSONB conversion.
     ///
     /// Before the fix, `cast_to_table_schema` attempted a `Utf8 → LargeBinary` DataFusion
     /// cast that preserved the wrong extension metadata, causing lance-core to reject the
     /// batch with a "json vs large_binary" schema-mismatch error.
-    #[tokio::test]
-    async fn test_arrow_json_passthrough_to_lance_json() {
+    async fn run_arrow_json_passthrough_to_lance_json(input_type: DataType) {
         use lance_arrow::ARROW_EXT_NAME_KEY;
         use lance_arrow::json::{ARROW_JSON_EXT_NAME, json_field};
 
@@ -648,23 +647,21 @@ mod tests {
         let lance_field = json_field("data", true);
         let table_schema = Schema::new(vec![lance_field]);
 
-        // Build an input batch with an arrow.json field (Utf8 + arrow.json metadata).
-        let mut arrow_meta = std::collections::HashMap::new();
-        arrow_meta.insert(
+        // Build an input batch with an arrow.json field (Utf8/LargeUtf8 + arrow.json metadata).
+        let arrow_meta = std::collections::HashMap::from([(
             ARROW_EXT_NAME_KEY.to_string(),
             ARROW_JSON_EXT_NAME.to_string(),
-        );
-        let arrow_field = Field::new("data", DataType::Utf8, true).with_metadata(arrow_meta);
+        )]);
+        let arrow_field = Field::new("data", input_type.clone(), true).with_metadata(arrow_meta);
         let input_schema = Arc::new(Schema::new(vec![arrow_field]));
-        let input_batch = RecordBatch::try_new(
-            input_schema,
-            vec![Arc::new(StringArray::from(vec![
-                Some(r#"{"x": 1}"#),
-                None,
-                Some(r#"{"y": 2}"#),
-            ]))],
-        )
-        .unwrap();
+
+        let values = vec![Some(r#"{"x": 1}"#), None, Some(r#"{"y": 2}"#)];
+        let input_array: Arc<dyn arrow_array::Array> = match input_type {
+            DataType::Utf8 => Arc::new(StringArray::from(values)),
+            DataType::LargeUtf8 => Arc::new(arrow_array::LargeStringArray::from(values)),
+            other => panic!("unsupported arrow.json backing type for this test: {other:?}"),
+        };
+        let input_batch = RecordBatch::try_new(input_schema, vec![input_array]).unwrap();
 
         let plan = plan_from_batch(input_batch).await;
         let projected = cast_to_table_schema(plan, &table_schema).unwrap();
@@ -672,7 +669,7 @@ mod tests {
         // The projected schema's "data" field must carry arrow.json metadata
         // (the input field), not be silently dropped or miscast.
         let out_field = projected.schema().field_with_name("data").unwrap().clone();
-        assert_eq!(out_field.data_type(), &DataType::Utf8);
+        assert_eq!(out_field.data_type(), &input_type);
         assert_eq!(
             out_field
                 .metadata()
@@ -685,9 +682,30 @@ mod tests {
         // The data must flow through correctly (3 rows, no panic).
         let result = collect(projected).await;
         assert_eq!(result.num_rows(), 3);
-        let col: &StringArray = result.column(0).as_any().downcast_ref().unwrap();
-        assert_eq!(col.value(0), r#"{"x": 1}"#);
+        let (v0, v2) = match input_type {
+            DataType::Utf8 => {
+                let col: &StringArray = result.column(0).as_any().downcast_ref().unwrap();
+                (col.value(0).to_string(), col.value(2).to_string())
+            }
+            DataType::LargeUtf8 => {
+                let col: &arrow_array::LargeStringArray =
+                    result.column(0).as_any().downcast_ref().unwrap();
+                (col.value(0).to_string(), col.value(2).to_string())
+            }
+            _ => unreachable!(),
+        };
+        assert_eq!(v0, r#"{"x": 1}"#);
         assert!(result.column(0).is_null(1));
-        assert_eq!(col.value(2), r#"{"y": 2}"#);
+        assert_eq!(v2, r#"{"y": 2}"#);
+    }
+
+    #[tokio::test]
+    async fn test_arrow_json_passthrough_to_lance_json() {
+        run_arrow_json_passthrough_to_lance_json(DataType::Utf8).await;
+    }
+
+    #[tokio::test]
+    async fn test_arrow_json_passthrough_to_lance_json_large_utf8() {
+        run_arrow_json_passthrough_to_lance_json(DataType::LargeUtf8).await;
     }
 }


### PR DESCRIPTION
When a table is created with `pa.json_()` (PyArrow's JSON extension type),
it is stored internally as `lance.json` (LargeBinary with `lance.json`
extension metadata). Calling `table.add()` with `pa.json_()` data failed
with:

```
RuntimeError: lance error: Append with different schema:
  `data` should have type json but type was large_binary
```

`build_field_exprs` in `rust/lancedb/src/table/datafusion/cast.rs` saw that
the input field (`Utf8` with `arrow.json` metadata) differed from the table
field (`LargeBinary` with `lance.json` metadata). Since
`can_cast_types(Utf8, LargeBinary)` is true, it inserted a DataFusion
`Utf8 → LargeBinary` cast. That cast preserved the input field's `arrow.json`
extension metadata instead of adopting the table's `lance.json` metadata, so
lance-core detected a schema mismatch and rejected the append.

This adds a special case in `build_field_exprs`: when the input is
`arrow.json` and the table field is `lance.json`, the expression is passed
through unchanged. Lance-core's write path already handles the
`arrow.json → lance.json` conversion (including JSONB encoding), so no
DataFusion cast is needed.

Fixes #3144

Continues #3291 from a fork (the original author's branch could not be
pushed to). The original commits are preserved; an additional commit fixes
the CI failures on that PR — formatting, a missing trait import, and
read-back assertions that assumed binary storage when a lance.json column
is read back as `Utf8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)