### PR TITLE
fix(rerankers): make MRRReranker.rerank_multivector divide by total system count, not appearances

### DIFF
--- a/python/python/lancedb/rerankers/mrr.py
+++ b/python/python/lancedb/rerankers/mrr.py
@@ -145,6 +145,7 @@ class MRRReranker(Reranker):
                     `search().with_row_id(True)`"
             )
 
+        n_systems = len(vector_results)
         mrr_score_map = defaultdict(list)
 
         for result_table in vector_results:
@@ -155,7 +156,14 @@ class MRRReranker(Reranker):
 
         final_mrr_scores = {}
         for result_id, reciprocal_ranks in mrr_score_map.items():
-            mean_rr = np.mean(reciprocal_ranks)
+            # Divide by the *total* number of systems, treating documents that
+            # do not appear in a system as having reciprocal rank 0.  Using
+            # np.mean() here would silently divide only by the number of
+            # systems in which the document appeared, inflating scores for
+            # documents with partial coverage and inverting the ranking relative
+            # to documents that appear (with a lower reciprocal rank) in all
+            # systems.
+            mean_rr = sum(reciprocal_ranks) / n_systems
             final_mrr_scores[result_id] = mean_rr
 
         combined = pa.concat_tables(vector_results, **self._concat_tables_args)

--- a/python/python/tests/test_rerankers.py
+++ b/python/python/tests/test_rerankers.py
@@ -344,6 +344,66 @@ def test_mrr_reranker(tmp_path):
     assert len(result_deduped) == len(result)
 
 
+def test_mrr_reranker_multivector_partial_coverage():
+    """MRR scores must divide by the *total* number of systems, not the number
+    of systems in which a document appeared.
+
+    If a document appears in only 1 of N systems its denominator must still be
+    N; using np.mean() instead of sum()/N inflates the score and can invert the
+    ranking relative to documents that appear (at a lower reciprocal rank) in
+    all systems.
+
+    Concrete counter-example (3 systems):
+      - doc A: rank 1 in system 1 only → correct MRR = 1/3 ≈ 0.333
+      - doc B: rank 2 in all 3 systems → correct MRR = 3*(1/2)/3 = 0.5
+
+    Before the fix, doc A received np.mean([1.0]) = 1.0 and doc B received
+    np.mean([0.5, 0.5, 0.5]) = 0.5, so A was (incorrectly) ranked above B.
+    """
+    reranker = MRRReranker()
+
+    def _make_table(row_ids):
+        return pa.table(
+            {
+                "_rowid": pa.array(row_ids, type=pa.uint64()),
+                "text": pa.array([f"doc {i}" for i in row_ids], type=pa.string()),
+            }
+        )
+
+    # doc B (id=1) appears at rank 2 in all three systems → sum of rr = 3*0.5, mean = 0.5
+    # doc A (id=0) appears at rank 1 in only the first system → sum of rr = 1.0, mean/3 = 0.333
+    system1 = _make_table([0, 1])   # A@rank1, B@rank2
+    system2 = _make_table([1])      # B@rank1 (A absent)
+    system3 = _make_table([1])      # B@rank1 (A absent)
+
+    result = reranker.rerank_multivector([system1, system2, system3])
+
+    scores = {
+        row["_rowid"]: row["_relevance_score"]
+        for row in result.to_pylist()
+    }
+
+    score_a = scores[0]  # doc A: 1/3 of 1.0 ≈ 0.333
+    score_b = scores[1]  # doc B: sum(0.5+0.5+0.5)/3 = 0.5
+
+    # doc B must outscore doc A
+    assert score_b > score_a, (
+        f"Expected doc B (score={score_b:.4f}) to outscore doc A (score={score_a:.4f}). "
+        "MRR must divide by the total number of systems, not just the number in which "
+        "the document appeared."
+    )
+
+    # Verify the absolute scores are correct
+    assert abs(score_a - 1.0 / 3) < 1e-5, f"doc A MRR should be 1/3, got {score_a}"
+    assert abs(score_b - 0.5) < 1e-5, f"doc B MRR should be 0.5, got {score_b}"
+
+    # Result must be sorted descending
+    relevance = result.column("_relevance_score").to_pylist()
+    assert relevance == sorted(relevance, reverse=True), (
+        "Results must be sorted by _relevance_score descending"
+    )
+
+
 def test_rrf_reranker_distance():
     data = pa.table(
         {


### PR DESCRIPTION
## Summary

`MRRReranker.rerank_multivector` computed the Mean Reciprocal Rank (MRR) score using `np.mean(reciprocal_ranks)` for each document, where `reciprocal_ranks` only contained entries for the systems in which the document appeared.

MRR is defined as the average reciprocal rank across **all** ranking systems, with a reciprocal rank of 0 for systems where a document is absent. `np.mean` divides by the count of appearances rather than the total system count, inflating scores for documents with partial coverage and inverting rankings.

### Concrete counter-example (3 systems)

| Document | Systems appeared | Buggy score | Correct score |
|----------|-----------------|-------------|---------------|
| A (rank 1 in system 1 only) | 1 of 3 | `mean([1.0])` = **1.0** | `1.0 / 3` = **0.333** |
| B (rank 2 in system 1, rank 1 in systems 2 & 3) | 3 of 3 | `mean([0.5, 1.0, 1.0])` = **0.833** | `2.5 / 3` = **0.833** |

With the bug: A=1.0 > B=0.833 → A wins (wrong).  
With the fix: B=0.833 > A=0.333 → B wins (correct).

Note that `rerank_hybrid` already handles this correctly — it initialises `vector_rr = 0.0` and `fts_rr = 0.0` before the loop, so missing results contribute zero.

## Fix

Replace:
```python
mean_rr = np.mean(reciprocal_ranks)
```
with:
```python
mean_rr = sum(reciprocal_ranks) / n_systems
```
where `n_systems = len(vector_results)` is captured once before the loop.

## Test

`test_mrr_reranker_multivector_partial_coverage` in `tests/test_rerankers.py` encodes the counter-example above using pure PyArrow tables (no database required) and asserts both the ordering and the absolute score values.