### PR TITLE
fix(python): make remote error classes pickleable

### DIFF
--- a/python/python/lancedb/remote/errors.py
+++ b/python/python/lancedb/remote/errors.py
@@ -27,6 +27,9 @@ class LanceDBClientError(RuntimeError):
         self.request_id = request_id
         self.status_code = status_code
 
+    def __reduce__(self):
+        return (self.__class__, (str(self), self.request_id, self.status_code))
+
 
 class HttpError(LanceDBClientError):
     """An error that occurred during an HTTP request.
@@ -101,3 +104,19 @@ class RetryError(LanceDBClientError):
         self.max_request_failures = max_request_failures
         self.max_connect_failures = max_connect_failures
         self.max_read_failures = max_read_failures
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (
+                str(self),
+                self.request_id,
+                self.request_failures,
+                self.connect_failures,
+                self.read_failures,
+                self.max_request_failures,
+                self.max_connect_failures,
+                self.max_read_failures,
+                self.status_code,
+            ),
+        )

--- a/python/python/lancedb/remote/errors.py
+++ b/python/python/lancedb/remote/errors.py
@@ -27,7 +27,7 @@ class LanceDBClientError(RuntimeError):
         self.request_id = request_id
         self.status_code = status_code
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple:
         return (self.__class__, (str(self), self.request_id, self.status_code))
 
 
@@ -105,7 +105,7 @@ class RetryError(LanceDBClientError):
         self.max_connect_failures = max_connect_failures
         self.max_read_failures = max_read_failures
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple:
         return (
             self.__class__,
             (

--- a/python/python/tests/test_remote_errors.py
+++ b/python/python/tests/test_remote_errors.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+import pickle
+
+from lancedb.remote.errors import HttpError, LanceDBClientError, RetryError
+
+
+def _assert_roundtrip(exc, attrs):
+    out = pickle.loads(pickle.dumps(exc))
+    assert type(out) is type(exc)
+    assert str(out) == str(exc)
+    for name in attrs:
+        assert getattr(out, name) == getattr(exc, name)
+
+
+def test_lancedb_client_error_pickle_roundtrip():
+    e = LanceDBClientError("connection reset", request_id="abc-123", status_code=503)
+    _assert_roundtrip(e, ["request_id", "status_code"])
+
+
+def test_http_error_pickle_roundtrip():
+    e = HttpError("500 internal", request_id="req-1", status_code=500)
+    _assert_roundtrip(e, ["request_id", "status_code"])
+
+
+def test_retry_error_pickle_roundtrip():
+    e = RetryError(
+        "retries exhausted",
+        request_id="req-2",
+        request_failures=3,
+        connect_failures=0,
+        read_failures=0,
+        max_request_failures=3,
+        max_connect_failures=3,
+        max_read_failures=3,
+        status_code=503,
+    )
+    _assert_roundtrip(
+        e,
+        [
+            "request_id",
+            "request_failures",
+            "connect_failures",
+            "read_failures",
+            "max_request_failures",
+            "max_connect_failures",
+            "max_read_failures",
+            "status_code",
+        ],
+    )


### PR DESCRIPTION
 ## Summary

  `LanceDBClientError` and `RetryError` stored `request_id` (and other required-constructor args) as instance attributes outside `self.args`. The default `BaseException.__reduce__` therefore produced an args tuple missing required parameters, so any code that pickled these exception (multiprocessing.Queue, ProcessPoolExecutor, ray, dask) crashed on unpickle with a `TypeError`, masking the original server-side failure.

  ## Fix

  Add explicit `__reduce__` to `LanceDBClientError` and `RetryError` that returns every constructor argument needed to reconstruct the instance. `HttpError` inherits `__init__` from the base, so it's covered by the base fix.

  ## Test plan

  New `python/python/tests/test_remote_errors.py`:
  - `test_lancedb_client_error_pickle_roundtrip` — base class, asserts `request_id` and `status_code` survive
  - `test_http_error_pickle_roundtrip` — verifies the inheritance story
  - `test_retry_error_pickle_roundtrip` — all 8 extra attributes survive

  All three fail on `main` with the exact `TypeError` from the issue; all three pass with this change.

  Closes #3447