### PR TITLE
ci: stop release builds on pull requests

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -13,11 +13,10 @@
 name: Build and publish Java packages
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
-  pull_request:
-    paths:
-      - .github/workflows/java-publish.yml
 
 permissions:
   contents: read
@@ -48,8 +47,8 @@ jobs:
         run: |
           git config --global user.email "dev+gha@lancedb.com"
           git config --global user.name "LanceDB Github Runner"
-      - name: Dry run
-        if: github.event_name == 'pull_request'
+      - name: Build package
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           ./mvnw --batch-mode -DskipTests package -pl lancedb-core -am
       - name: Publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,12 +14,6 @@ on:
       - main
     tags:
       - "v*"
-  pull_request:
-    # This should trigger a dry run (we skip the final publish step)
-    paths:
-      - .github/workflows/npm-publish.yml
-      - Cargo.toml # Change in dependency frequently breaks builds
-      - Cargo.lock
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,10 @@ on:
       - main
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - Cargo.toml
+      - Cargo.lock
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,17 +2,10 @@ name: PyPI Publish
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'python-v*'
-  pull_request:
-    # This should trigger a dry run (we skip the final publish step)
-    paths:
-      - .github/workflows/pypi-publish.yml
-      - .github/workflows/build_linux_wheel/action.yml
-      - .github/workflows/build_mac_wheel/action.yml
-      - .github/workflows/build_windows_wheel/action.yml
-      - Cargo.toml # Change in dependency frequently breaks builds
-      - Cargo.lock
 
 env:
   PIP_EXTRA_INDEX_URL: "https://pypi.fury.io/lance-format/ https://pypi.fury.io/lancedb/"


### PR DESCRIPTION
Release packaging workflows currently run on pull_request for dependency or workflow changes, which adds release build noise to normal PRs. This keeps the NPM release compatibility check for PRs that update Cargo dependency files, where dependency bumps have previously broken Node release builds. PyPI and Java publish workflows now run from main or release tag pushes, with publish steps still gated to release tags where applicable.
