### PR TITLE
fix(pydantic): bare Tuple/List crashes to_arrow_schema with AttributeError

### DIFF
--- a/python/python/lancedb/pydantic.py
+++ b/python/python/lancedb/pydantic.py
@@ -274,7 +274,9 @@ def _py_type_to_arrow_type(py_type: Type[Any], field: FieldInfo) -> pa.DataType:
     elif py_type is datetime:
         tz = get_extras(field, "tz")
         return pa.timestamp("us", tz=tz)
-    elif getattr(py_type, "__origin__", None) in (list, tuple):
+    elif getattr(py_type, "__origin__", None) in (list, tuple) and getattr(
+        py_type, "__args__", None
+    ):
         child = py_type.__args__[0]
         return _pydantic_list_child_to_arrow(child, field)
     raise TypeError(

--- a/python/python/tests/test_pydantic.py
+++ b/python/python/tests/test_pydantic.py
@@ -463,6 +463,14 @@ def test_fixed_size_list_validation():
     TestModel(vec=range(8))
 
 
+def test_bare_tuple_raises_type_error():
+    class TestModel(LanceModel):
+        items: Tuple
+
+    with pytest.raises(TypeError):
+        TestModel.to_arrow_schema()
+
+
 def test_lance_model():
     class TestModel(LanceModel):
         vector: Vector(16) = Field(default=[0.0] * 16)


### PR DESCRIPTION
## What's broken

A bare `typing.Tuple`/`typing.List` field on a `LanceModel` crashes `to_arrow_schema()`:

```python
class Doc(LanceModel):
    items: Tuple
Doc.to_arrow_schema()
# AttributeError: __args__
```

In `_py_type_to_arrow_type`, the list/tuple branch matches on `__origin__` (which a bare generic has) and then reads `py_type.__args__[0]` (which a bare generic does not have). Other unsupported types raise a clean `TypeError`, so this path is inconsistent.

## Why it happens

A bare `typing.List`/`typing.Tuple` has `__origin__` set but no `__args__`.

## Fix

Also require `__args__` on the branch condition. Bare generics then fall through to the existing `raise TypeError("... unsupported type ...")`, matching the contract used for every other unsupported type. Parameterised `List[int]`/`Tuple[int, ...]` still convert as before.

## Test

Added a case asserting a bare `Tuple` field makes `to_arrow_schema()` raise `TypeError` (it raised `AttributeError` before the fix).

Fixes #3502