### PR TITLE
fix(python): reject repeated where clauses

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -43,6 +43,11 @@ from .util import flatten_columns
 
 BlobMode = Literal["lazy", "bytes", "descriptions"]
 
+MULTIPLE_WHERE_ERROR = (
+    "where() has already been called on this query; combine predicates with AND "
+    "in a single where() call"
+)
+
 _BLOB_MODE_TO_HANDLING = {
     "lazy": "blobs_descriptions",
     "bytes": "all_binary",
@@ -888,6 +893,10 @@ class LanceQueryBuilder(ABC):
         self._bypass_vector_index = None
         self._order_by = None
 
+    def _check_no_existing_where(self):
+        if self._where is not None:
+            raise ValueError(MULTIPLE_WHERE_ERROR)
+
     @deprecation.deprecated(
         deprecated_in="0.3.1",
         removed_in="0.4.0",
@@ -1149,6 +1158,7 @@ class LanceQueryBuilder(ABC):
         LanceQueryBuilder
             The LanceQueryBuilder object.
         """
+        self._check_no_existing_where()
         self._where = where
         self._postfilter = not prefilter
         return self
@@ -1694,6 +1704,7 @@ class LanceVectorQueryBuilder(LanceQueryBuilder):
         LanceQueryBuilder
             The LanceQueryBuilder object.
         """
+        self._check_no_existing_where()
         self._where = where
         if prefilter is not None:
             self._postfilter = not prefilter
@@ -2496,9 +2507,14 @@ class AsyncQueryBase(object):
         """
         self._inner = inner
         self._table = table
+        self._where = None
         self._with_row_address = None
         self._fragments = None
         self._fragment_ids = None
+
+    def _check_no_existing_where(self):
+        if self._where is not None:
+            raise ValueError(MULTIPLE_WHERE_ERROR)
 
     def to_query_object(self) -> Query:
         """
@@ -2895,6 +2911,8 @@ class AsyncStandardQuery(AsyncQueryBase):
         Filtering performance can often be improved by creating a scalar index
         on the filter column(s).
         """
+        self._check_no_existing_where()
+        self._where = predicate
         if isinstance(predicate, Expr):
             self._inner.where_expr(predicate._inner)
         else:

--- a/python/python/tests/test_query.py
+++ b/python/python/tests/test_query.py
@@ -1438,6 +1438,23 @@ def test_query_serialization_sync(table: lancedb.table.Table):
     check_set_props(q, full_text_query=FullTextSearchQuery(columns=[], query="foo"))
 
 
+def test_query_builder_rejects_multiple_where_calls(table: lancedb.table.Table):
+    query = table.search().where("id = 1")
+    with pytest.raises(ValueError, match=r"where\(\) has already been called"):
+        query.where("id = 2")
+    check_set_props(query.to_query_object(), filter="id = 1")
+
+    vector_query = table.search([5.0, 6.0]).where("id = 1")
+    with pytest.raises(ValueError, match=r"where\(\) has already been called"):
+        vector_query.where("id = 2")
+    check_set_props(
+        vector_query.to_query_object(),
+        vector_column="vector",
+        vector=[5.0, 6.0],
+        filter="id = 1",
+    )
+
+
 @pytest.mark.asyncio
 async def test_query_serialization_async(table_async: AsyncTable):
     # Simple queries
@@ -1618,6 +1635,14 @@ async def test_query_serialization_async(table_async: AsyncTable):
         full_text_query=FullTextSearchQuery(columns=None, query=phrase_query),
         with_row_id=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_async_query_rejects_multiple_where_calls(table_async: AsyncTable):
+    query = table_async.query().where("id = 1")
+    with pytest.raises(ValueError, match=r"where\(\) has already been called"):
+        query.where("id = 2")
+    check_set_props(query.to_query_object(), filter="id = 1", with_row_id=False)
 
 
 def test_query_schema(tmp_path):


### PR DESCRIPTION
## Summary
- reject a second `where()` call for sync and async Python query builders so filters are not silently replaced
- add regression coverage confirming the first filter remains in the serialized query object

Fixes #2649

## Tests
- `python3.13 -m py_compile python/python/lancedb/query.py python/python/tests/test_query.py`
- `/Users/neo/.cursor/extensions/charliermarsh.ruff-2026.48.0-darwin-arm64/bundled/libs/bin/ruff check python/python/lancedb/query.py python/python/tests/test_query.py`
- `git diff --check`

Not run locally: targeted pytest. `uv sync --python 3.13 --extra tests --extra dev -v` stalled during local dependency/native package setup after resolving packages, and direct pytest cannot import the uninstalled local package metadata.