### PR TITLE
feat(rust): add blob v2 schema declaration and write path

### DIFF
--- a/rust/lancedb/src/blob.rs
+++ b/rust/lancedb/src/blob.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! Lance blob v2 columns store large binary payloads out of line.
+//!
+//! Declare a column with [`blob`]. On write, [`crate::table::Table::add`] coerces
+//! raw `Binary` / `LargeBinary` into the blob struct layout. Queries return
+//! small descriptors, not bytes.
+//!
+//! Blob tables require Lance file format >= 2.2 and stable row ids at create.
+
+use arrow_schema::{Field, Schema};
+use lance::dataset::WriteParams;
+use lance_arrow::FieldExt;
+use lance_encoding::version::LanceFileVersion;
+
+/// Creates an Arrow field for a Lance blob v2 column.
+///
+/// `Struct<data, uri>` with the `lance.blob.v2` marker. Same layout Lance
+/// expects on write.
+///
+/// ```
+/// use arrow_schema::{DataType, Field, Schema};
+///
+/// let schema = Schema::new(vec![
+///     Field::new("id", DataType::Int64, false),
+///     lancedb::blob("image", true),
+/// ]);
+/// ```
+///
+/// Blob tables use Lance file format >= 2.2 and stable row ids at create.
+pub fn blob(name: impl AsRef<str>, nullable: bool) -> Field {
+    lance::blob::blob_field(name.as_ref(), nullable)
+}
+
+/// Returns true if `schema` declares any blob v2 column.
+pub(crate) fn has_blob_columns(schema: &Schema) -> bool {
+    schema.fields().iter().any(|field| field.is_blob_v2())
+}
+
+/// Bumps storage format to at least [`LanceFileVersion::V2_2`] for blob schemas.
+pub(crate) fn ensure_blob_storage_version(schema: &Schema, params: &mut WriteParams) {
+    if !has_blob_columns(schema) {
+        return;
+    }
+
+    let resolved = params
+        .data_storage_version
+        .unwrap_or(LanceFileVersion::Stable)
+        .resolve();
+    if resolved < LanceFileVersion::V2_2 {
+        params.data_storage_version = Some(LanceFileVersion::V2_2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::DataType;
+    use lance_arrow::ARROW_EXT_NAME_KEY;
+
+    fn blob_schema() -> Schema {
+        Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            blob("image", true),
+        ])
+    }
+
+    #[test]
+    fn blob_field_carries_v2_extension_marker() {
+        let field = blob("image", true);
+        assert_eq!(
+            field.metadata().get(ARROW_EXT_NAME_KEY).map(String::as_str),
+            Some("lance.blob.v2")
+        );
+        assert!(matches!(field.data_type(), DataType::Struct(_)));
+    }
+
+    #[test]
+    fn has_blob_columns_detects_blob_fields() {
+        assert!(has_blob_columns(&blob_schema()));
+        let plain = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        assert!(!has_blob_columns(&plain));
+    }
+
+    #[test]
+    fn storage_version_bumps_to_v2_2() {
+        let mut params = WriteParams::default();
+        ensure_blob_storage_version(&blob_schema(), &mut params);
+        assert_eq!(
+            params.data_storage_version.unwrap().resolve(),
+            LanceFileVersion::V2_2
+        );
+    }
+
+    #[test]
+    fn storage_version_overrides_lower_explicit_version() {
+        let mut params = WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_0),
+            ..Default::default()
+        };
+        ensure_blob_storage_version(&blob_schema(), &mut params);
+        assert_eq!(
+            params.data_storage_version.unwrap().resolve(),
+            LanceFileVersion::V2_2
+        );
+    }
+
+    #[test]
+    fn storage_version_keeps_higher_explicit_version() {
+        let mut params = WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_3),
+            ..Default::default()
+        };
+        ensure_blob_storage_version(&blob_schema(), &mut params);
+        assert_eq!(params.data_storage_version.unwrap(), LanceFileVersion::V2_3);
+    }
+
+    #[test]
+    fn storage_version_noop_without_blob_columns() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let mut params = WriteParams::default();
+        ensure_blob_storage_version(&schema, &mut params);
+        assert!(params.data_storage_version.is_none());
+    }
+}

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -18,6 +18,7 @@ use lance_table::io::commit::commit_handler_from_url;
 use object_store::local::LocalFileSystem;
 use snafu::ResultExt;
 
+use crate::blob::{ensure_blob_storage_version, has_blob_columns};
 use crate::connection::ConnectRequest;
 use crate::database::ReadConsistency;
 use crate::database::namespace::LanceNamespaceDatabase;
@@ -838,12 +839,15 @@ impl ListingDatabase {
             write_params.enable_v2_manifest_paths = enable_v2_manifest_paths;
         }
 
-        // Apply enable_stable_row_ids: table-level override takes precedence over connection config
-        if let Some(enable_stable_row_ids) =
-            stable_row_ids_override.or(self.new_table_config.enable_stable_row_ids)
+        let data_schema = request.data.arrow_schema();
+        if let Some(enable_stable_row_ids) = stable_row_ids_override
+            .or(self.new_table_config.enable_stable_row_ids)
+            .or(has_blob_columns(&data_schema).then_some(true))
         {
             write_params.enable_stable_row_ids = enable_stable_row_ids;
         }
+
+        ensure_blob_storage_version(&data_schema, &mut write_params);
 
         if matches!(&request.mode, CreateTableMode::Overwrite) {
             write_params.mode = WriteMode::Overwrite;

--- a/rust/lancedb/src/database/namespace.rs
+++ b/rust/lancedb/src/database/namespace.rs
@@ -23,6 +23,7 @@ use lance_namespace_impls::ConnectBuilder;
 use lance_table::io::commit::CommitHandler;
 use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 
+use crate::blob::{ensure_blob_storage_version, has_blob_columns};
 use crate::connection::NamespaceClientPushdownOperation;
 use crate::database::ReadConsistency;
 use crate::database::listing::{
@@ -214,11 +215,15 @@ impl LanceNamespaceDatabase {
             params.enable_v2_manifest_paths = enable_v2_manifest_paths;
         }
 
-        if let Some(enable_stable_row_ids) =
-            stable_row_ids_override.or(self.new_table_config.enable_stable_row_ids)
+        let data_schema = request.data.schema();
+        if let Some(enable_stable_row_ids) = stable_row_ids_override
+            .or(self.new_table_config.enable_stable_row_ids)
+            .or(has_blob_columns(data_schema.as_ref()).then_some(true))
         {
             params.enable_stable_row_ids = enable_stable_row_ids;
         }
+
+        ensure_blob_storage_version(data_schema.as_ref(), params);
 
         Ok(())
     }

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -163,6 +163,7 @@
 //! ```
 
 pub mod arrow;
+pub mod blob;
 pub mod connection;
 pub mod data;
 pub mod database;
@@ -188,6 +189,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
+pub use blob::blob;
 pub use connection::{ConnectNamespaceBuilder, Connection};
 pub use error::{Error, Result};
 use lance_linalg::distance::DistanceType as LanceDistanceType;

--- a/rust/lancedb/src/table/add_data.rs
+++ b/rust/lancedb/src/table/add_data.rs
@@ -26,6 +26,9 @@ pub enum AddDataMode {
     #[default]
     Append,
     /// The existing table will be overwritten with the new data
+    ///
+    /// On overwrite, raw binary is not coerced into a blob struct. The input
+    /// must declare blob v2 for the column to stay a blob column.
     Overwrite,
 }
 

--- a/rust/lancedb/src/table/datafusion.rs
+++ b/rust/lancedb/src/table/datafusion.rs
@@ -3,6 +3,7 @@
 
 //! This module contains adapters to allow LanceDB tables to be used as DataFusion table providers.
 
+mod blob_coerce;
 pub mod cast;
 pub mod insert;
 pub mod reject_nan;

--- a/rust/lancedb/src/table/datafusion/blob_coerce.rs
+++ b/rust/lancedb/src/table/datafusion/blob_coerce.rs
@@ -1,0 +1,521 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! Coerces write-path input into blob v2 struct columns.
+//!
+//! [`coerce_blob_expr`] is invoked from [`super::cast::cast_to_table_schema`].
+
+use std::any::Any;
+use std::sync::{Arc, LazyLock};
+
+use arrow_array::{Array, ArrayRef, StructArray, new_null_array};
+use arrow_schema::{DataType, Field, FieldRef, Fields};
+use datafusion_common::config::ConfigOptions;
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_physical_expr::ScalarFunctionExpr;
+use datafusion_physical_plan::PhysicalExpr;
+
+use crate::error::{Error, Result};
+
+static COERCE_BLOB_UDF: LazyLock<Arc<ScalarUDF>> =
+    LazyLock::new(|| Arc::new(ScalarUDF::from(CoerceBlobUdf::new())));
+
+/// Build a projection expression coercing `input_expr` into the blob struct
+/// declared by `table_field`.
+///
+/// The table field (metadata included) is the expression return field. Raw
+/// binary lands in `data`; struct input is normalized to the declared layout.
+pub(super) fn coerce_blob_expr(
+    input_expr: Arc<dyn PhysicalExpr>,
+    input_field: &Field,
+    table_field: &FieldRef,
+    config: &Arc<ConfigOptions>,
+) -> Result<(Arc<dyn PhysicalExpr>, FieldRef)> {
+    match input_field.data_type() {
+        DataType::Binary | DataType::LargeBinary => {}
+        DataType::Struct(children) => {
+            if !children
+                .iter()
+                .any(|c| c.name() == "data" || c.name() == "uri")
+            {
+                return Err(Error::InvalidInput {
+                    message: format!(
+                        "blob struct input for column '{}' must contain a 'data' or 'uri' child",
+                        table_field.name()
+                    ),
+                });
+            }
+        }
+        other => {
+            return Err(Error::InvalidInput {
+                message: format!(
+                    "cannot coerce column '{}' with type {} into a blob v2 struct. \
+                     expected Binary, LargeBinary, or a Struct with a 'data' or 'uri' child",
+                    table_field.name(),
+                    other,
+                ),
+            });
+        }
+    }
+
+    let expr: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(
+        &format!("coerce_blob({})", table_field.name()),
+        COERCE_BLOB_UDF.clone(),
+        vec![input_expr],
+        table_field.clone(),
+        config.clone(),
+    ));
+    Ok((expr, table_field.clone()))
+}
+
+/// Scalar UDF rewriting binary or struct input into the declared blob layout.
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct CoerceBlobUdf {
+    signature: Signature,
+}
+
+impl CoerceBlobUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for CoerceBlobUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "coerce_blob"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        Err(datafusion_common::DataFusionError::Internal(
+            "coerce_blob is only usable through coerce_blob_expr".into(),
+        ))
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        let array = match &args.args[0] {
+            ColumnarValue::Array(array) => array.clone(),
+            ColumnarValue::Scalar(scalar) => scalar.to_array_of_size(args.number_rows)?,
+        };
+        let coerced = coerce_array(&array, args.return_field.as_ref())
+            .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?;
+        Ok(ColumnarValue::Array(coerced))
+    }
+}
+
+fn coerce_array(column: &ArrayRef, field: &Field) -> Result<ArrayRef> {
+    let DataType::Struct(declared_fields) = field.data_type() else {
+        return Err(Error::InvalidInput {
+            message: format!(
+                "blob v2 column '{}' must be a struct, table declares {}",
+                field.name(),
+                field.data_type()
+            ),
+        });
+    };
+
+    match column.data_type() {
+        DataType::Binary | DataType::LargeBinary => {
+            let bytes = if column.data_type() == &DataType::Binary {
+                arrow_cast::cast(column, &DataType::LargeBinary).map_err(|e| {
+                    Error::InvalidInput {
+                        message: format!(
+                            "failed to cast blob column '{}' to large binary: {}",
+                            field.name(),
+                            e
+                        ),
+                    }
+                })?
+            } else {
+                column.clone()
+            };
+            binary_to_blob_struct(&bytes, declared_fields)
+        }
+        DataType::Struct(_) => struct_to_blob_struct(column, declared_fields),
+        other => Err(Error::InvalidInput {
+            message: format!(
+                "cannot coerce column '{}' with type {} into a blob v2 struct. \
+                 expected Binary, LargeBinary, or a Struct with a 'data' or 'uri' child",
+                field.name(),
+                other,
+            ),
+        }),
+    }
+}
+
+fn binary_to_blob_struct(bytes: &ArrayRef, declared_fields: &Fields) -> Result<ArrayRef> {
+    let children: Vec<ArrayRef> = declared_fields
+        .iter()
+        .map(|field| {
+            if field.name() == "data" {
+                bytes.clone()
+            } else {
+                new_null_array(field.data_type(), bytes.len())
+            }
+        })
+        .collect();
+
+    let blob_struct =
+        StructArray::try_new(declared_fields.clone(), children, bytes.nulls().cloned()).map_err(
+            |e| Error::Runtime {
+                message: format!("failed to build blob struct: {e}"),
+            },
+        )?;
+    Ok(Arc::new(blob_struct))
+}
+
+fn struct_to_blob_struct(column: &ArrayRef, declared_fields: &Fields) -> Result<ArrayRef> {
+    let input = column
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| Error::InvalidInput {
+            message: "expected struct array for blob coercion".into(),
+        })?;
+
+    let children: Result<Vec<ArrayRef>> = declared_fields
+        .iter()
+        .map(|field| {
+            let Some(child) = input.column_by_name(field.name()) else {
+                return Ok(new_null_array(field.data_type(), input.len()));
+            };
+            if child.data_type() == field.data_type() {
+                return Ok(child.clone());
+            }
+            arrow_cast::cast(child, field.data_type()).map_err(|e| Error::InvalidInput {
+                message: format!(
+                    "failed to cast blob child '{}' to {}: {}",
+                    field.name(),
+                    field.data_type(),
+                    e
+                ),
+            })
+        })
+        .collect();
+
+    let blob_struct =
+        StructArray::try_new(declared_fields.clone(), children?, input.nulls().cloned()).map_err(
+            |e| Error::Runtime {
+                message: format!("failed to build blob struct: {e}"),
+            },
+        )?;
+    Ok(Arc::new(blob_struct))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::cast::cast_to_table_schema;
+    use super::*;
+    use crate::blob::blob;
+    use arrow_array::{
+        BinaryArray, Int32Array, Int64Array, LargeBinaryArray, RecordBatch, StringArray,
+        UInt8Array, UInt64Array,
+    };
+    use arrow_schema::Schema;
+    use datafusion::prelude::SessionContext;
+    use datafusion_catalog::MemTable;
+    use datafusion_physical_plan::ExecutionPlan;
+    use futures::TryStreamExt;
+    use lance_arrow::FieldExt;
+    use std::collections::HashMap;
+
+    /// Four-child layout from pyarrow `lance.blob.v2`.
+    fn wide_blob_field(name: &str) -> Field {
+        Field::new(
+            name,
+            DataType::Struct(
+                vec![
+                    Field::new("data", DataType::LargeBinary, true),
+                    Field::new("uri", DataType::Utf8, true),
+                    Field::new("position", DataType::UInt64, true),
+                    Field::new("size", DataType::UInt64, true),
+                ]
+                .into(),
+            ),
+            true,
+        )
+        .with_metadata(HashMap::from([(
+            "ARROW:extension:name".to_string(),
+            "lance.blob.v2".to_string(),
+        )]))
+    }
+
+    fn blob_table_schema() -> Schema {
+        Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            blob("image", true),
+        ])
+    }
+
+    fn batch_with_image(image_field: Field, image: ArrayRef) -> RecordBatch {
+        let len = image.len();
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                image_field,
+            ])),
+            vec![Arc::new(Int64Array::from_iter_values(0..len as i64)), image],
+        )
+        .unwrap()
+    }
+
+    fn image_struct(batch: &RecordBatch) -> &StructArray {
+        batch
+            .column_by_name("image")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+    }
+
+    async fn plan_from_batch(batch: RecordBatch) -> Arc<dyn ExecutionPlan> {
+        let schema = batch.schema();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(table)).unwrap();
+        let df = ctx.table("t").await.unwrap();
+        df.create_physical_plan().await.unwrap()
+    }
+
+    async fn coerce(batch: RecordBatch, table_schema: &Schema) -> RecordBatch {
+        let plan = plan_from_batch(batch).await;
+        let plan = cast_to_table_schema(plan, table_schema).unwrap();
+        let ctx = SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        arrow_select::concat::concat_batches(&plan.schema(), &batches).unwrap()
+    }
+
+    async fn coerce_err(batch: RecordBatch, table_schema: &Schema) -> Error {
+        let plan = plan_from_batch(batch).await;
+        cast_to_table_schema(plan, table_schema).unwrap_err()
+    }
+
+    #[tokio::test]
+    async fn large_binary_coerces_to_declared_blob_struct() {
+        let batch = batch_with_image(
+            Field::new("image", DataType::LargeBinary, true),
+            Arc::new(LargeBinaryArray::from_iter_values([b"hello".as_slice()])),
+        );
+        let coerced = coerce(batch, &blob_table_schema()).await;
+        let image_field = coerced.schema().field_with_name("image").unwrap().clone();
+        assert!(image_field.is_blob_v2());
+        assert!(matches!(image_field.data_type(), DataType::Struct(_)));
+        let data = image_struct(&coerced).column_by_name("data").unwrap();
+        let data: &LargeBinaryArray = data.as_any().downcast_ref().unwrap();
+        assert_eq!(data.value(0), b"hello");
+    }
+
+    #[tokio::test]
+    async fn binary_coerces_to_declared_blob_struct() {
+        let batch = batch_with_image(
+            Field::new("image", DataType::Binary, true),
+            Arc::new(BinaryArray::from_iter_values([b"hi".as_slice()])),
+        );
+        let coerced = coerce(batch, &blob_table_schema()).await;
+        assert!(
+            coerced
+                .schema()
+                .field_with_name("image")
+                .unwrap()
+                .is_blob_v2()
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_nulls_stay_null_after_coercion() {
+        let batch = batch_with_image(
+            Field::new("image", DataType::Binary, true),
+            Arc::new(BinaryArray::from_iter(vec![
+                Some(b"present".as_slice()),
+                None,
+            ])),
+        );
+        let coerced = coerce(batch, &blob_table_schema()).await;
+        let image = image_struct(&coerced);
+        assert!(!image.is_null(0));
+        assert!(image.is_null(1), "null input rows become null blob rows");
+        let data = image.column_by_name("data").unwrap();
+        assert!(!data.is_null(0));
+        assert!(data.is_null(1));
+    }
+
+    #[tokio::test]
+    async fn binary_coerces_into_four_child_blob_layout() {
+        let table_schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            wide_blob_field("image"),
+        ]);
+        let batch = batch_with_image(
+            Field::new("image", DataType::LargeBinary, true),
+            Arc::new(LargeBinaryArray::from_iter(vec![
+                Some(b"alpha".as_slice()),
+                None,
+            ])),
+        );
+        let coerced = coerce(batch, &table_schema).await;
+        let image = image_struct(&coerced);
+        assert_eq!(
+            image.num_columns(),
+            4,
+            "coerced struct keeps the declared layout"
+        );
+        assert!(image.column_by_name("position").unwrap().is_null(0));
+        assert!(image.column_by_name("size").unwrap().is_null(0));
+        assert!(!image.column_by_name("data").unwrap().is_null(0));
+        assert!(image.column_by_name("data").unwrap().is_null(1));
+    }
+
+    #[tokio::test]
+    async fn prebuilt_struct_gains_blob_field_metadata() {
+        let DataType::Struct(children) = blob("image", true).data_type().clone() else {
+            unreachable!("blob field is a struct")
+        };
+        let prebuilt = StructArray::new(
+            children,
+            vec![
+                Arc::new(LargeBinaryArray::from_iter_values([b"prebuilt".as_slice()])),
+                Arc::new(StringArray::from(vec![None::<&str>])),
+            ],
+            None,
+        );
+        let batch = batch_with_image(
+            Field::new("image", prebuilt.data_type().clone(), true),
+            Arc::new(prebuilt),
+        );
+        let coerced = coerce(batch, &blob_table_schema()).await;
+        assert!(
+            coerced
+                .schema()
+                .field_with_name("image")
+                .unwrap()
+                .is_blob_v2()
+        );
+    }
+
+    #[tokio::test]
+    async fn prebuilt_narrow_struct_widens_to_declared_layout() {
+        let DataType::Struct(narrow_children) = blob("image", true).data_type().clone() else {
+            unreachable!("blob field is a struct")
+        };
+        let prebuilt = StructArray::new(
+            narrow_children,
+            vec![
+                Arc::new(LargeBinaryArray::from_iter_values([b"prebuilt".as_slice()])),
+                Arc::new(StringArray::from(vec![None::<&str>])),
+            ],
+            None,
+        );
+        let table_schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            wide_blob_field("image"),
+        ]);
+        let batch = batch_with_image(
+            Field::new("image", prebuilt.data_type().clone(), true),
+            Arc::new(prebuilt),
+        );
+        let coerced = coerce(batch, &table_schema).await;
+        let image = image_struct(&coerced);
+        assert_eq!(image.num_columns(), 4);
+        assert!(image.column_by_name("position").unwrap().is_null(0));
+        assert!(image.column_by_name("size").unwrap().is_null(0));
+    }
+
+    #[tokio::test]
+    async fn descriptor_struct_without_value_child_is_rejected() {
+        let descriptor = StructArray::new(
+            vec![
+                Field::new("kind", DataType::UInt8, false),
+                Field::new("position", DataType::UInt64, false),
+                Field::new("size", DataType::UInt64, false),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from(vec![0])),
+                Arc::new(UInt64Array::from(vec![0])),
+                Arc::new(UInt64Array::from(vec![0])),
+            ],
+            None,
+        );
+        let batch = batch_with_image(
+            Field::new("image", descriptor.data_type().clone(), true),
+            Arc::new(descriptor),
+        );
+        let err = coerce_err(batch, &blob_table_schema()).await;
+        assert!(err.to_string().contains("'data' or 'uri'"));
+        assert!(err.to_string().contains("image"));
+    }
+
+    #[tokio::test]
+    async fn unsupported_input_type_is_rejected_with_column_name() {
+        let batch = batch_with_image(
+            Field::new("image", DataType::Utf8, true),
+            Arc::new(StringArray::from(vec!["not bytes"])),
+        );
+        let err = coerce_err(batch, &blob_table_schema()).await;
+        assert!(matches!(err, Error::InvalidInput { .. }), "got {err:?}");
+        assert!(err.to_string().contains("image"));
+    }
+
+    #[tokio::test]
+    async fn blob_metadata_survives_cast_of_sibling_column() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("image", DataType::LargeBinary, true),
+            ])),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(LargeBinaryArray::from_iter_values([b"x".as_slice()])),
+            ],
+        )
+        .unwrap();
+        let coerced = coerce(batch, &blob_table_schema()).await;
+
+        let image_field = coerced.schema().field_with_name("image").unwrap().clone();
+        assert!(
+            image_field.is_blob_v2(),
+            "expected blob marker on image field, got {:?}",
+            image_field.metadata()
+        );
+        assert_eq!(
+            coerced.schema().field_with_name("id").unwrap().data_type(),
+            &DataType::Int64
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_blob_input_passes_through_unchanged() {
+        let DataType::Struct(children) = blob("image", true).data_type().clone() else {
+            unreachable!("blob field is a struct")
+        };
+        let image = StructArray::new(
+            children,
+            vec![
+                Arc::new(LargeBinaryArray::from_iter_values([b"exact".as_slice()])),
+                Arc::new(StringArray::from(vec![None::<&str>])),
+            ],
+            None,
+        );
+        let batch = batch_with_image(blob("image", true), Arc::new(image));
+        let table_schema = blob_table_schema();
+
+        let input = plan_from_batch(batch).await;
+        let input_ptr = Arc::as_ptr(&input);
+        let plan = cast_to_table_schema(input, &table_schema).unwrap();
+        assert_eq!(Arc::as_ptr(&plan), input_ptr, "no projection inserted");
+    }
+}

--- a/rust/lancedb/src/table/datafusion/blob_coerce.rs
+++ b/rust/lancedb/src/table/datafusion/blob_coerce.rs
@@ -34,7 +34,7 @@ pub(super) fn coerce_blob_expr(
     config: &Arc<ConfigOptions>,
 ) -> Result<(Arc<dyn PhysicalExpr>, FieldRef)> {
     match input_field.data_type() {
-        DataType::Binary | DataType::LargeBinary => {}
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {}
         DataType::Struct(children) => {
             if !children
                 .iter()
@@ -52,7 +52,7 @@ pub(super) fn coerce_blob_expr(
             return Err(Error::InvalidInput {
                 message: format!(
                     "cannot coerce column '{}' with type {} into a blob v2 struct. \
-                     expected Binary, LargeBinary, or a Struct with a 'data' or 'uri' child",
+                     expected Binary, LargeBinary, BinaryView, or a Struct with a 'data' or 'uri' child",
                     table_field.name(),
                     other,
                 ),
@@ -129,8 +129,10 @@ fn coerce_array(column: &ArrayRef, field: &Field) -> Result<ArrayRef> {
     };
 
     match column.data_type() {
-        DataType::Binary | DataType::LargeBinary => {
-            let bytes = if column.data_type() == &DataType::Binary {
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
+            let bytes = if column.data_type() == &DataType::LargeBinary {
+                column.clone()
+            } else {
                 arrow_cast::cast(column, &DataType::LargeBinary).map_err(|e| {
                     Error::InvalidInput {
                         message: format!(
@@ -140,8 +142,6 @@ fn coerce_array(column: &ArrayRef, field: &Field) -> Result<ArrayRef> {
                         ),
                     }
                 })?
-            } else {
-                column.clone()
             };
             binary_to_blob_struct(&bytes, declared_fields)
         }
@@ -149,7 +149,7 @@ fn coerce_array(column: &ArrayRef, field: &Field) -> Result<ArrayRef> {
         other => Err(Error::InvalidInput {
             message: format!(
                 "cannot coerce column '{}' with type {} into a blob v2 struct. \
-                 expected Binary, LargeBinary, or a Struct with a 'data' or 'uri' child",
+                 expected Binary, LargeBinary, BinaryView, or a Struct with a 'data' or 'uri' child",
                 field.name(),
                 other,
             ),
@@ -221,8 +221,8 @@ mod tests {
     use super::*;
     use crate::blob::blob;
     use arrow_array::{
-        BinaryArray, Int32Array, Int64Array, LargeBinaryArray, RecordBatch, StringArray,
-        UInt8Array, UInt64Array,
+        BinaryArray, BinaryViewArray, Int32Array, Int64Array, LargeBinaryArray, RecordBatch,
+        StringArray, UInt8Array, UInt64Array,
     };
     use arrow_schema::Schema;
     use datafusion::prelude::SessionContext;
@@ -333,6 +333,18 @@ mod tests {
                 .unwrap()
                 .is_blob_v2()
         );
+    }
+
+    #[tokio::test]
+    async fn binary_view_coerces_to_declared_blob_struct() {
+        let batch = batch_with_image(
+            Field::new("image", DataType::BinaryView, true),
+            Arc::new(BinaryViewArray::from_iter_values([b"view".as_slice()])),
+        );
+        let coerced = coerce(batch, &blob_table_schema()).await;
+        let data = image_struct(&coerced).column_by_name("data").unwrap();
+        let data: &LargeBinaryArray = data.as_any().downcast_ref().unwrap();
+        assert_eq!(data.value(0), b"view");
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table/datafusion/blob_coerce.rs
+++ b/rust/lancedb/src/table/datafusion/blob_coerce.rs
@@ -3,38 +3,40 @@
 
 //! Coerces write-path input into blob v2 struct columns.
 //!
-//! [`coerce_blob_expr`] is invoked from [`super::cast::cast_to_table_schema`].
+//! [`super::cast::cast_to_table_schema`] calls [`coerce_blob_expr`].
 
-use std::any::Any;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
-use arrow_array::{Array, ArrayRef, StructArray, new_null_array};
-use arrow_schema::{DataType, Field, FieldRef, Fields};
+use arrow_schema::{DataType, Field, FieldRef};
+use datafusion::functions::core::{get_field, named_struct};
+use datafusion_common::ScalarValue;
 use datafusion_common::config::ConfigOptions;
-use datafusion_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
-};
 use datafusion_physical_expr::ScalarFunctionExpr;
+use datafusion_physical_expr::expressions::{CastExpr, Literal};
 use datafusion_physical_plan::PhysicalExpr;
 
 use crate::error::{Error, Result};
 
-static COERCE_BLOB_UDF: LazyLock<Arc<ScalarUDF>> =
-    LazyLock::new(|| Arc::new(ScalarUDF::from(CoerceBlobUdf::new())));
-
 /// Build a projection expression coercing `input_expr` into the blob struct
-/// declared by `table_field`.
-///
-/// The table field (metadata included) is the expression return field. Raw
-/// binary lands in `data`; struct input is normalized to the declared layout.
+/// declared by `table_field`, composing `named_struct` / `get_field` / `cast`.
 pub(super) fn coerce_blob_expr(
     input_expr: Arc<dyn PhysicalExpr>,
     input_field: &Field,
     table_field: &FieldRef,
     config: &Arc<ConfigOptions>,
 ) -> Result<(Arc<dyn PhysicalExpr>, FieldRef)> {
-    match input_field.data_type() {
-        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {}
+    let DataType::Struct(declared_fields) = table_field.data_type() else {
+        return Err(Error::InvalidInput {
+            message: format!(
+                "blob v2 column '{}' must be a struct, table declares {}",
+                table_field.name(),
+                table_field.data_type()
+            ),
+        });
+    };
+
+    let input_struct_children = match input_field.data_type() {
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => None,
         DataType::Struct(children) => {
             if !children
                 .iter()
@@ -47,6 +49,7 @@ pub(super) fn coerce_blob_expr(
                     ),
                 });
             }
+            Some(children)
         }
         other => {
             return Err(Error::InvalidInput {
@@ -58,161 +61,70 @@ pub(super) fn coerce_blob_expr(
                 ),
             });
         }
+    };
+
+    let mut ns_args: Vec<Arc<dyn PhysicalExpr>> = Vec::with_capacity(declared_fields.len() * 2);
+    for declared in declared_fields.iter() {
+        ns_args.push(Arc::new(Literal::new(ScalarValue::from(
+            declared.name().as_str(),
+        ))));
+
+        let value: Arc<dyn PhysicalExpr> = match input_struct_children {
+            // Raw binary lands in `data` and everything else is a typed null.
+            None => {
+                if declared.name() == "data" {
+                    Arc::new(CastExpr::new(
+                        input_expr.clone(),
+                        declared.data_type().clone(),
+                        None,
+                    ))
+                } else {
+                    typed_null(declared.data_type())?
+                }
+            }
+            Some(children) => match children.iter().find(|c| c.name() == declared.name()) {
+                Some(child) => {
+                    let field_expr: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(
+                        &format!("get_field({})", declared.name()),
+                        get_field(),
+                        vec![
+                            input_expr.clone(),
+                            Arc::new(Literal::new(ScalarValue::from(declared.name().as_str()))),
+                        ],
+                        Arc::new(child.as_ref().clone()),
+                        config.clone(),
+                    ));
+                    if child.data_type() == declared.data_type() {
+                        field_expr
+                    } else {
+                        Arc::new(CastExpr::new(
+                            field_expr,
+                            declared.data_type().clone(),
+                            None,
+                        ))
+                    }
+                }
+                None => typed_null(declared.data_type())?,
+            },
+        };
+        ns_args.push(value);
     }
 
     let expr: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(
-        &format!("coerce_blob({})", table_field.name()),
-        COERCE_BLOB_UDF.clone(),
-        vec![input_expr],
+        &format!("named_struct({})", table_field.name()),
+        named_struct(),
+        ns_args,
         table_field.clone(),
         config.clone(),
     ));
     Ok((expr, table_field.clone()))
 }
 
-/// Scalar UDF rewriting binary or struct input into the declared blob layout.
-#[derive(Debug, Hash, PartialEq, Eq)]
-struct CoerceBlobUdf {
-    signature: Signature,
-}
-
-impl CoerceBlobUdf {
-    fn new() -> Self {
-        Self {
-            signature: Signature::any(1, Volatility::Immutable),
-        }
-    }
-}
-
-impl ScalarUDFImpl for CoerceBlobUdf {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &str {
-        "coerce_blob"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
-        Err(datafusion_common::DataFusionError::Internal(
-            "coerce_blob is only usable through coerce_blob_expr".into(),
-        ))
-    }
-
-    fn invoke_with_args(
-        &self,
-        args: ScalarFunctionArgs,
-    ) -> datafusion_common::Result<ColumnarValue> {
-        let array = match &args.args[0] {
-            ColumnarValue::Array(array) => array.clone(),
-            ColumnarValue::Scalar(scalar) => scalar.to_array_of_size(args.number_rows)?,
-        };
-        let coerced = coerce_array(&array, args.return_field.as_ref())
-            .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?;
-        Ok(ColumnarValue::Array(coerced))
-    }
-}
-
-fn coerce_array(column: &ArrayRef, field: &Field) -> Result<ArrayRef> {
-    let DataType::Struct(declared_fields) = field.data_type() else {
-        return Err(Error::InvalidInput {
-            message: format!(
-                "blob v2 column '{}' must be a struct, table declares {}",
-                field.name(),
-                field.data_type()
-            ),
-        });
-    };
-
-    match column.data_type() {
-        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
-            let bytes = if column.data_type() == &DataType::LargeBinary {
-                column.clone()
-            } else {
-                arrow_cast::cast(column, &DataType::LargeBinary).map_err(|e| {
-                    Error::InvalidInput {
-                        message: format!(
-                            "failed to cast blob column '{}' to large binary: {}",
-                            field.name(),
-                            e
-                        ),
-                    }
-                })?
-            };
-            binary_to_blob_struct(&bytes, declared_fields)
-        }
-        DataType::Struct(_) => struct_to_blob_struct(column, declared_fields),
-        other => Err(Error::InvalidInput {
-            message: format!(
-                "cannot coerce column '{}' with type {} into a blob v2 struct. \
-                 expected Binary, LargeBinary, BinaryView, or a Struct with a 'data' or 'uri' child",
-                field.name(),
-                other,
-            ),
-        }),
-    }
-}
-
-fn binary_to_blob_struct(bytes: &ArrayRef, declared_fields: &Fields) -> Result<ArrayRef> {
-    let children: Vec<ArrayRef> = declared_fields
-        .iter()
-        .map(|field| {
-            if field.name() == "data" {
-                bytes.clone()
-            } else {
-                new_null_array(field.data_type(), bytes.len())
-            }
-        })
-        .collect();
-
-    let blob_struct =
-        StructArray::try_new(declared_fields.clone(), children, bytes.nulls().cloned()).map_err(
-            |e| Error::Runtime {
-                message: format!("failed to build blob struct: {e}"),
-            },
-        )?;
-    Ok(Arc::new(blob_struct))
-}
-
-fn struct_to_blob_struct(column: &ArrayRef, declared_fields: &Fields) -> Result<ArrayRef> {
-    let input = column
-        .as_any()
-        .downcast_ref::<StructArray>()
-        .ok_or_else(|| Error::InvalidInput {
-            message: "expected struct array for blob coercion".into(),
-        })?;
-
-    let children: Result<Vec<ArrayRef>> = declared_fields
-        .iter()
-        .map(|field| {
-            let Some(child) = input.column_by_name(field.name()) else {
-                return Ok(new_null_array(field.data_type(), input.len()));
-            };
-            if child.data_type() == field.data_type() {
-                return Ok(child.clone());
-            }
-            arrow_cast::cast(child, field.data_type()).map_err(|e| Error::InvalidInput {
-                message: format!(
-                    "failed to cast blob child '{}' to {}: {}",
-                    field.name(),
-                    field.data_type(),
-                    e
-                ),
-            })
-        })
-        .collect();
-
-    let blob_struct =
-        StructArray::try_new(declared_fields.clone(), children?, input.nulls().cloned()).map_err(
-            |e| Error::Runtime {
-                message: format!("failed to build blob struct: {e}"),
-            },
-        )?;
-    Ok(Arc::new(blob_struct))
+fn typed_null(data_type: &DataType) -> Result<Arc<dyn PhysicalExpr>> {
+    let scalar = ScalarValue::try_from(data_type).map_err(|e| Error::InvalidInput {
+        message: format!("cannot build null literal for blob child type {data_type}: {e}"),
+    })?;
+    Ok(Arc::new(Literal::new(scalar)))
 }
 
 #[cfg(test)]
@@ -221,8 +133,8 @@ mod tests {
     use super::*;
     use crate::blob::blob;
     use arrow_array::{
-        BinaryArray, BinaryViewArray, Int32Array, Int64Array, LargeBinaryArray, RecordBatch,
-        StringArray, UInt8Array, UInt64Array,
+        Array, ArrayRef, BinaryArray, BinaryViewArray, Int32Array, Int64Array, LargeBinaryArray,
+        RecordBatch, StringArray, StructArray, UInt8Array, UInt64Array,
     };
     use arrow_schema::Schema;
     use datafusion::prelude::SessionContext;
@@ -232,7 +144,6 @@ mod tests {
     use lance_arrow::FieldExt;
     use std::collections::HashMap;
 
-    /// Four-child layout from pyarrow `lance.blob.v2`.
     fn wide_blob_field(name: &str) -> Field {
         Field::new(
             name,
@@ -358,8 +269,6 @@ mod tests {
         );
         let coerced = coerce(batch, &blob_table_schema()).await;
         let image = image_struct(&coerced);
-        assert!(!image.is_null(0));
-        assert!(image.is_null(1), "null input rows become null blob rows");
         let data = image.column_by_name("data").unwrap();
         assert!(!data.is_null(0));
         assert!(data.is_null(1));
@@ -444,6 +353,59 @@ mod tests {
         assert_eq!(image.num_columns(), 4);
         assert!(image.column_by_name("position").unwrap().is_null(0));
         assert!(image.column_by_name("size").unwrap().is_null(0));
+    }
+
+    #[tokio::test]
+    async fn external_reference_struct_preserves_uri_position_and_size() {
+        let prebuilt = StructArray::new(
+            vec![
+                Field::new("data", DataType::LargeBinary, true),
+                Field::new("uri", DataType::Utf8, true),
+                Field::new("position", DataType::UInt64, true),
+                Field::new("size", DataType::UInt64, true),
+            ]
+            .into(),
+            vec![
+                Arc::new(LargeBinaryArray::from(vec![None::<&[u8]>])) as ArrayRef,
+                Arc::new(StringArray::from(vec![Some("s3://bucket/blob.bin")])) as ArrayRef,
+                Arc::new(UInt64Array::from(vec![Some(7)])) as ArrayRef,
+                Arc::new(UInt64Array::from(vec![Some(6)])) as ArrayRef,
+            ],
+            None,
+        );
+        let table_schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            wide_blob_field("image"),
+        ]);
+        let batch = batch_with_image(
+            Field::new("image", prebuilt.data_type().clone(), true),
+            Arc::new(prebuilt),
+        );
+        let coerced = coerce(batch, &table_schema).await;
+        let image = image_struct(&coerced);
+
+        let uri: &StringArray = image
+            .column_by_name("uri")
+            .unwrap()
+            .as_any()
+            .downcast_ref()
+            .unwrap();
+        assert_eq!(uri.value(0), "s3://bucket/blob.bin");
+        let position: &UInt64Array = image
+            .column_by_name("position")
+            .unwrap()
+            .as_any()
+            .downcast_ref()
+            .unwrap();
+        assert_eq!(position.value(0), 7);
+        let size: &UInt64Array = image
+            .column_by_name("size")
+            .unwrap()
+            .as_any()
+            .downcast_ref()
+            .unwrap();
+        assert_eq!(size.value(0), 6);
+        assert!(image.column_by_name("data").unwrap().is_null(0));
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table/datafusion/cast.rs
+++ b/rust/lancedb/src/table/datafusion/cast.rs
@@ -13,8 +13,10 @@ use datafusion_physical_expr::expressions::{CastExpr, Literal};
 use datafusion_physical_plan::expressions::Column;
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+use lance_arrow::FieldExt;
 use lance_arrow::json::{is_arrow_json_field, is_json_field};
 
+use super::blob_coerce::coerce_blob_expr;
 use crate::{Error, Result};
 
 pub fn cast_to_table_schema(
@@ -74,6 +76,17 @@ fn build_field_exprs(
         // causes a schema-mismatch error inside lance-core.
         if is_arrow_json_field(input_field) && is_json_field(table_field) {
             result.push((input_expr, Arc::clone(input_field) as FieldRef));
+            continue;
+        }
+
+        // Blob columns accept raw binary on write; exact matches pass through below.
+        if table_field.is_blob_v2() && input_field.as_ref() != table_field.as_ref() {
+            result.push(coerce_blob_expr(
+                input_expr,
+                input_field,
+                table_field,
+                &config,
+            )?);
             continue;
         }
 

--- a/rust/lancedb/tests/blob_integration.rs
+++ b/rust/lancedb/tests/blob_integration.rs
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! Integration tests for blob v2 columns.
+
+use std::sync::Arc;
+
+use arrow_array::{Array, BinaryArray, Int64Array, LargeBinaryArray, RecordBatch, StructArray};
+use arrow_schema::{DataType, Field, Schema};
+use futures::TryStreamExt;
+use lance_encoding::version::LanceFileVersion;
+use lancedb::{
+    Connection, Result, Table, blob::blob, connect,
+    database::listing::OPT_NEW_TABLE_ENABLE_STABLE_ROW_IDS, query::ExecutableQuery,
+};
+use tempfile::tempdir;
+
+fn blob_table_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        blob("image", true),
+    ]))
+}
+
+fn binary_input_batch(ids: &[i64], payloads: &[Option<&[u8]>]) -> RecordBatch {
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("image", DataType::LargeBinary, true),
+        ])),
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())),
+            Arc::new(LargeBinaryArray::from_iter(payloads.iter().copied())),
+        ],
+    )
+    .unwrap()
+}
+
+async fn create_inline_blob_table(
+    db: &Connection,
+    name: &str,
+    ids: &[i64],
+    payloads: &[Option<&[u8]>],
+) -> Result<Table> {
+    let table = db
+        .create_empty_table(name, blob_table_schema())
+        .execute()
+        .await?;
+    table
+        .add(binary_input_batch(ids, payloads))
+        .execute()
+        .await?;
+    Ok(table)
+}
+
+async fn storage_format_version(table: &Table) -> LanceFileVersion {
+    table
+        .as_native()
+        .unwrap()
+        .manifest()
+        .await
+        .unwrap()
+        .data_storage_format
+        .lance_file_version()
+        .unwrap()
+        .resolve()
+}
+
+async fn uses_stable_row_ids(table: &Table) -> bool {
+    table
+        .as_native()
+        .unwrap()
+        .manifest()
+        .await
+        .unwrap()
+        .uses_stable_row_ids()
+}
+
+async fn query_image_struct(table: &Table) -> StructArray {
+    let batches = table
+        .query()
+        .execute()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let batch = arrow_select::concat::concat_batches(&batches[0].schema(), &batches).unwrap();
+    batch
+        .column_by_name("image")
+        .expect("image column present")
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .expect("blob column reads back as a descriptor struct")
+        .clone()
+}
+
+#[tokio::test]
+async fn declaring_blob_column_bumps_format_and_enables_stable_row_ids() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let table = db
+        .create_empty_table("t", blob_table_schema())
+        .execute()
+        .await?;
+
+    assert!(storage_format_version(&table).await >= LanceFileVersion::V2_2);
+    assert!(uses_stable_row_ids(&table).await);
+    Ok(())
+}
+
+#[tokio::test]
+async fn explicit_stable_row_id_setting_wins_over_blob_default() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let table = db
+        .create_empty_table("t", blob_table_schema())
+        .storage_option(OPT_NEW_TABLE_ENABLE_STABLE_ROW_IDS, "false")
+        .execute()
+        .await?;
+
+    assert!(
+        storage_format_version(&table).await >= LanceFileVersion::V2_2,
+        "format bump still applies; the schema cannot be written below 2.2"
+    );
+    assert!(!uses_stable_row_ids(&table).await);
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_blob_table_keeps_default_format_and_row_id_setting() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    let table = db.create_empty_table("t", schema).execute().await?;
+
+    assert!(storage_format_version(&table).await < LanceFileVersion::V2_2);
+    assert!(!uses_stable_row_ids(&table).await);
+    Ok(())
+}
+
+#[tokio::test]
+async fn creating_with_blob_data_bumps_format() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+
+    // Batch already declares the blob field (pre-built struct).
+    let blob_field = blob("image", true);
+    let DataType::Struct(children) = blob_field.data_type().clone() else {
+        unreachable!("blob field is a struct")
+    };
+    let image = StructArray::new(
+        children,
+        vec![
+            Arc::new(LargeBinaryArray::from_iter_values([b"payload".as_slice()])),
+            Arc::new(arrow_array::StringArray::from(vec![None::<&str>])),
+        ],
+        None,
+    );
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            blob_field,
+        ])),
+        vec![Arc::new(Int64Array::from(vec![1])), Arc::new(image)],
+    )
+    .unwrap();
+    let table = db.create_table("t", batch).execute().await?;
+
+    assert!(storage_format_version(&table).await >= LanceFileVersion::V2_2);
+    assert!(uses_stable_row_ids(&table).await);
+    assert_eq!(table.count_rows(None).await?, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_coerces_large_binary_into_blob_column() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let table =
+        create_inline_blob_table(&db, "t", &[1, 2], &[Some(b"cat".as_slice()), Some(b"dog")])
+            .await?;
+
+    assert_eq!(table.count_rows(None).await?, 2);
+    let image = query_image_struct(&table).await;
+    assert_eq!(image.len(), 2);
+    // Table schema still has the blob marker after append.
+    let schema = table.schema().await?;
+    let field = schema.field_with_name("image").unwrap();
+    assert_eq!(
+        field
+            .metadata()
+            .get("ARROW:extension:name")
+            .map(String::as_str),
+        Some("lance.blob.v2")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_coerces_binary_into_blob_column() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let table = db
+        .create_empty_table("t", blob_table_schema())
+        .execute()
+        .await?;
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("image", DataType::Binary, true),
+        ])),
+        vec![
+            Arc::new(Int64Array::from(vec![1])),
+            Arc::new(BinaryArray::from_iter_values([b"small".as_slice()])),
+        ],
+    )
+    .unwrap();
+    table.add(batch).execute().await?;
+
+    assert_eq!(table.count_rows(None).await?, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_accepts_null_blob_rows() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let table = create_inline_blob_table(
+        &db,
+        "t",
+        &[1, 2, 3],
+        &[Some(b"first".as_slice()), None, Some(b"third")],
+    )
+    .await?;
+
+    assert_eq!(table.count_rows(None).await?, 3);
+    let image = query_image_struct(&table).await;
+    assert_eq!(image.len(), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_rejects_uncoercible_blob_input() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let table = db
+        .create_empty_table("t", blob_table_schema())
+        .execute()
+        .await?;
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("image", DataType::Utf8, true),
+        ])),
+        vec![
+            Arc::new(Int64Array::from(vec![1])),
+            Arc::new(arrow_array::StringArray::from(vec!["not bytes"])),
+        ],
+    )
+    .unwrap();
+    let err = table.add(batch).execute().await.unwrap_err();
+    assert!(err.to_string().contains("image"), "got: {err}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn connection_level_stable_row_id_setting_wins_over_blob_default() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap())
+        .storage_option(OPT_NEW_TABLE_ENABLE_STABLE_ROW_IDS, "false")
+        .execute()
+        .await?;
+    let table = db
+        .create_empty_table("t", blob_table_schema())
+        .execute()
+        .await?;
+
+    assert!(storage_format_version(&table).await >= LanceFileVersion::V2_2);
+    assert!(!uses_stable_row_ids(&table).await);
+    Ok(())
+}
+
+#[tokio::test]
+async fn namespace_create_applies_blob_defaults() -> Result<()> {
+    let tmp = tempdir().unwrap();
+    let mut properties = std::collections::HashMap::new();
+    properties.insert("root".to_string(), tmp.path().to_str().unwrap().to_string());
+    let db = lancedb::connect_namespace("dir", properties)
+        .execute()
+        .await?;
+    let table = db
+        .create_empty_table("t", blob_table_schema())
+        .execute()
+        .await?;
+
+    assert!(storage_format_version(&table).await >= LanceFileVersion::V2_2);
+    assert!(uses_stable_row_ids(&table).await);
+    Ok(())
+}
+
+// Overwrite takes the input schema as-is (same as cast skip). Raw binary
+// overwrite drops the blob marker unless the input declares blob v2.
+#[tokio::test]
+async fn overwrite_replaces_blob_schema_with_input_schema() -> Result<()> {
+    use lancedb::table::AddDataMode;
+
+    let tmp = tempdir().unwrap();
+    let db = connect(tmp.path().to_str().unwrap()).execute().await?;
+    let table = create_inline_blob_table(&db, "t", &[1], &[Some(b"blob".as_slice())]).await?;
+
+    // Raw binary overwrite. Plain LargeBinary replaces the blob declaration.
+    let raw_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("image", DataType::LargeBinary, true),
+    ]));
+    let raw_batch = RecordBatch::try_new(
+        raw_schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![2])),
+            Arc::new(LargeBinaryArray::from_iter_values([b"plain".as_slice()])),
+        ],
+    )
+    .unwrap();
+    table
+        .add(raw_batch)
+        .mode(AddDataMode::Overwrite)
+        .execute()
+        .await?;
+    let schema = table.schema().await?;
+    assert_eq!(schema, raw_schema);
+    assert!(
+        !schema
+            .field_with_name("image")
+            .unwrap()
+            .metadata()
+            .contains_key("ARROW:extension:name"),
+        "raw binary overwrite leaves a plain binary column"
+    );
+
+    // Overwrite with a declared blob struct keeps the blob column.
+    let blob_field = blob("image", true);
+    let DataType::Struct(children) = blob_field.data_type().clone() else {
+        unreachable!("blob field is a struct")
+    };
+    let image = StructArray::new(
+        children,
+        vec![
+            Arc::new(LargeBinaryArray::from_iter_values([b"declared".as_slice()])),
+            Arc::new(arrow_array::StringArray::from(vec![None::<&str>])),
+        ],
+        None,
+    );
+    let declared_batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            blob_field,
+        ])),
+        vec![Arc::new(Int64Array::from(vec![3])), Arc::new(image)],
+    )
+    .unwrap();
+    table
+        .add(declared_batch)
+        .mode(AddDataMode::Overwrite)
+        .execute()
+        .await?;
+    let schema = table.schema().await?;
+    assert_eq!(
+        schema
+            .field_with_name("image")
+            .unwrap()
+            .metadata()
+            .get("ARROW:extension:name")
+            .map(String::as_str),
+        Some("lance.blob.v2")
+    );
+    Ok(())
+}


### PR DESCRIPTION
First Rust PR for #3231. Lance already stores blob v2. This adds the LanceDB write side.

```rust
let schema = Schema::new(vec![
    Field::new("id", DataType::Int64, false),
    lancedb::blob("image", true),
]);

let table = db.create_table("photos", schema).execute().await?;

table.add(batch_with_large_binary_image_column).execute().await?;
```

Read/materialize and Python are follow-up PRs.

### Testing

- cargo test -p lancedb --test blob_integration
- cargo test -p lancedb blob:: datafusion::blob_coerce
- cargo test -p lancedb (591 passed)
- cargo clippy --features remote --tests
