### PR TITLE
chore: ignore pyo3 advisories RUSTSEC-2026-0176/0177 in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -113,6 +113,12 @@ ignore = [
     # rand from a custom logger; upgrade once all pinned chains accept 0.8.6+.
     # https://rustsec.org/advisories/RUSTSEC-2026-0097
     { id = "RUSTSEC-2026-0097", reason = "transitive rand 0.8.5; LanceDB does not call ThreadRng from custom logging" },
+
+    # pyo3 advisories in the Python bindings; tracked pending a patched pyo3 release.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0176
+    # https://rustsec.org/advisories/RUSTSEC-2026-0177
+    { id = "RUSTSEC-2026-0176", reason = "pyo3 in Python bindings; awaiting patched pyo3 release" },
+    { id = "RUSTSEC-2026-0177", reason = "pyo3 in Python bindings; awaiting patched pyo3 release" },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `RUSTSEC-2026-0176` and `RUSTSEC-2026-0177` to the cargo-deny advisory ignore list. Both are pyo3 advisories surfaced through the Python bindings:

- RUSTSEC-2026-0176: out-of-bounds read in `nth` / `nth_back` for `PyList` / `PyTuple` iterators
- RUSTSEC-2026-0177: missing `Sync` bound on `PyCFunction::new_closure` closures

## Why

The `deny` CI check is currently failing on `main` and on every open PR because of these two newly published advisories, and there is no patched pyo3 release to bump to yet. This follows the existing pattern in `deny.toml`, where upstream advisories are ignored with a reason until a fix lands; each entry notes it is pending a patched pyo3 release so it can be dropped on the next pyo3 bump.

## Notes
- The build-no-lock CI failure is being resolved in this PR: https://github.com/lance-format/lance/pull/7270