### PR TITLE
test: pin mock clock in eventual consistency test

### DIFF
--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -518,6 +518,10 @@ mod tests {
 
         let wrapper = DatasetConsistencyWrapper::new_latest(ds, Some(Duration::from_millis(200)));
 
+        // Freeze `cached_at` on the mock clock so a slow external write below can't
+        // expire the TTL before the explicit advance_by() does (flake on loaded CI).
+        clock::pin();
+
         // Populate the cache
         let v1 = wrapper.get().await.unwrap().version().version;
         assert_eq!(v1, 1);

--- a/rust/lancedb/src/utils/background_cache.rs
+++ b/rust/lancedb/src/utils/background_cache.rs
@@ -329,6 +329,15 @@ pub mod clock {
         });
     }
 
+    /// Start mock time at the current instant if not already pinned.
+    pub fn pin() {
+        MOCK_NOW.with(|mock| {
+            if mock.get().is_none() {
+                mock.set(Some(Instant::now()));
+            }
+        });
+    }
+
     #[allow(dead_code)]
     pub fn clear_mock() {
         MOCK_NOW.with(|mock| mock.set(None));


### PR DESCRIPTION
This PR fixes a flaky test I hit on Windows test in #3528.

Looks like `test_eventual_consistency_background_refresh` was failing with `v_cached` expected 1, got 2. There was a pr which swapped `tokio::time::sleep(300ms)` for `clock::advance_by(300ms)`, which is pretty much fine but the test necer pinned the clock so the first `get()` locks the `cached_at` on wall time. Therefore, if our CI is taking long enough the ttl expires before the value assertion in the test. 

So now we can add a `pin()` and call it first `get()`. After that we can advance the clock manually with no problems.

Also, it's worth noting that I tried pinning in `BackgroundCache::new()` first. That broke another test `test_reload_resets_consistency_timer`, which uses real `tokio::time::sleep` and needs wall clock after `clear_mock()`. So the pin stays in this test only. And this should unblock us.

Failing instances:
- https://github.com/lancedb/lancedb/actions/runs/27567527236/job/81495265474?pr=3528
- https://github.com/lancedb/lancedb/actions/runs/27560366489/job/81470414928