### PR TITLE
fix(ci): allow shell pre-commit hooks in bumpversion configs

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -23,6 +23,8 @@ allow_dirty = true
 commit = true
 message = "Bump version: {current_version} → {new_version}"
 commit_args = ""
+# bump-my-version >=1.4.0 rejects pre_commit_hooks containing shell syntax unless opted in.
+allow_shell_hooks = true
 
 # Java maven files
 pre_commit_hooks = [

--- a/python/.bumpversion.toml
+++ b/python/.bumpversion.toml
@@ -23,6 +23,8 @@ allow_dirty = true
 commit = true
 message = "Bump version: {current_version} → {new_version}"
 commit_args = ""
+# bump-my-version >=1.4.0 rejects pre_commit_hooks containing shell syntax unless opted in.
+allow_shell_hooks = true
 
 # Update Cargo.lock after version bump
 pre_commit_hooks = [


### PR DESCRIPTION
The "Create release commit" workflow (`make-release-commit.yml`) has failed on its last two runs; no release tags have been created since June 4. Since this workflow creates the tag that the cargo/npm/pypi/java publish workflows trigger off of, all recent releases are effectively blocked.

The workflow installs `bump-my-version` unpinned. Version `1.4.0` added a check that refuses to run `pre_commit_hooks` containing shell syntax (pipes, `&&`, `if`, variable expansion) unless `allow_shell_hooks = true` is set. Both bumpversion configs use such hooks:

- `python/.bumpversion.toml` — updates `Cargo.lock` after the bump (fails first)
- `.bumpversion.toml` — runs `mvn versions:set` for the Java packages

The job dies at the version-bump step with:

> Hook '…' contains shell syntax (pipes, redirects, or variable expansion). Set `allow_shell_hooks = true` in your configuration to enable shell execution…

This sets `allow_shell_hooks = true` in both configs to restore the previous behavior.