### PR TITLE
fix(python): prevent windows cuda deadlock in sentence-transformers

### DIFF
--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -3095,6 +3095,24 @@ class LanceTable(Table):
             The number of vectors in the table.
         """
         progress, owns = _normalize_progress(progress)
+        
+        # --- PYTORCH WINDOWS DEADLOCK FIX ---
+        # Sanitize the data and generate embeddings synchronously on the main thread
+        # before passing it to the BackgroundEventLoop daemon thread.
+        schema = self.schema
+        if on_bad_vectors != "error" or (
+            schema.metadata is not None and b"embedding_functions" in schema.metadata
+        ):
+            data = _sanitize_data(
+                data,
+                schema,
+                metadata=schema.metadata,
+                on_bad_vectors=on_bad_vectors,
+                fill_value=fill_value,
+                allow_subschema=True,
+            )
+        # ------------------------------------
+        
         try:
             return LOOP.run(
                 self._table.add(

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -3060,7 +3060,7 @@ class LanceTable(Table):
             "prefix_only": False,
         }
 
-    def add(
+        def add(
         self,
         data: DATA,
         mode: AddMode = "append",
@@ -3095,6 +3095,24 @@ class LanceTable(Table):
             The number of vectors in the table.
         """
         progress, owns = _normalize_progress(progress)
+        
+        # --- PYTORCH WINDOWS DEADLOCK FIX ---
+        # Sanitize the data and generate embeddings synchronously on the main thread
+        # before passing it to the BackgroundEventLoop daemon thread.
+        schema = self.schema
+        if on_bad_vectors != "error" or (
+            schema.metadata is not None and b"embedding_functions" in schema.metadata
+        ):
+            data = _sanitize_data(
+                data,
+                schema,
+                metadata=schema.metadata,
+                on_bad_vectors=on_bad_vectors,
+                fill_value=fill_value,
+                allow_subschema=True,
+            )
+        # ------------------------------------
+        
         try:
             return LOOP.run(
                 self._table.add(

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -3060,7 +3060,7 @@ class LanceTable(Table):
             "prefix_only": False,
         }
 
-        def add(
+    def add(
         self,
         data: DATA,
         mode: AddMode = "append",
@@ -3095,15 +3095,22 @@ class LanceTable(Table):
             The number of vectors in the table.
         """
         progress, owns = _normalize_progress(progress)
-        
+
         # --- PYTORCH WINDOWS DEADLOCK FIX ---
-        # Sanitize the data and generate embeddings synchronously on the main thread
-        # before passing it to the BackgroundEventLoop daemon thread.
+        # Embedding computation must run on the main thread, not the
+        # BackgroundEventLoop daemon thread that self._table.add() below hands off
+        # to: on Windows, PyTorch does not allow a CUDA context created on one
+        # thread to be used from another. _sanitize_data() itself only builds a
+        # chain of lazy generators (see _append_vector_columns), so nothing is
+        # actually computed until the returned reader is iterated -- calling it
+        # alone is not enough. read_all() forces that iteration, and therefore
+        # the embedding calls, to happen here on the main thread.
         schema = self.schema
-        if on_bad_vectors != "error" or (
+        has_embedding_functions = (
             schema.metadata is not None and b"embedding_functions" in schema.metadata
-        ):
-            data = _sanitize_data(
+        )
+        if on_bad_vectors != "error" or has_embedding_functions:
+            reader = _sanitize_data(
                 data,
                 schema,
                 metadata=schema.metadata,
@@ -3111,8 +3118,21 @@ class LanceTable(Table):
                 fill_value=fill_value,
                 allow_subschema=True,
             )
+            if has_embedding_functions:
+                try:
+                    data = reader.read_all()
+                except ValueError as e:
+                    # Previously this validation ran lazily while the Rust side
+                    # iterated the reader, which surfaces Python exceptions as
+                    # RuntimeError across the PyO3 boundary. Materializing eagerly
+                    # here (see above) means it now raises directly in Python, so
+                    # re-wrap to preserve the exception type callers already
+                    # depend on.
+                    raise RuntimeError(str(e)) from e
+            else:
+                data = reader
         # ------------------------------------
-        
+
         try:
             return LOOP.run(
                 self._table.add(

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -1857,6 +1857,52 @@ def test_on_bad_vectors_with_multiple_vectors_locks_dim_after_final_drop(
     assert data["vec2"].to_pylist() == [[5.0, 6.0], [7.0, 8.0], [9.0, 10.0]]
 
 
+def test_add_computes_embeddings_on_calling_thread(mem_db: DBConnection):
+    """Regression test for the Windows CUDA deadlock (#3559).
+
+    Table.add() hands the actual write off to the LanceDBBackgroundEventLoop
+    daemon thread. On Windows, PyTorch does not allow a CUDA context created on
+    one thread to be used from another, so if embedding computation is deferred
+    until that handoff, a GPU-backed embedding function deadlocks. Embeddings
+    must be computed on the thread that calls add() instead.
+    """
+    registry = EmbeddingFunctionRegistry.get_instance()
+    calling_thread_id = threading.get_ident()
+    recorded_thread_ids = []
+
+    @registry.register("thread-recording-test")
+    class ThreadRecordingEmbeddingFunction(MockTextEmbeddingFunction):
+        def generate_embeddings(self, texts):
+            recorded_thread_ids.append(threading.get_ident())
+            return super().generate_embeddings(texts)
+
+    func = ThreadRecordingEmbeddingFunction.create()
+    metadata = registry.get_table_metadata(
+        [
+            EmbeddingFunctionConfig(
+                source_column="text", vector_column="vector", function=func
+            )
+        ]
+    )
+    schema = pa.schema(
+        [
+            pa.field("text", pa.string()),
+            pa.field("vector", pa.list_(pa.float32(), 10)),
+        ],
+        metadata=metadata,
+    )
+    table = mem_db.create_table("test_add_embeds_on_calling_thread", schema=schema)
+
+    table.add(pa.table({"text": ["hello", "world"]}))
+
+    assert recorded_thread_ids, "embedding function was never called"
+    assert all(tid == calling_thread_id for tid in recorded_thread_ids), (
+        "embedding function ran on a background thread instead of the thread "
+        "that called add() -- this reproduces the Windows CUDA deadlock from #3559"
+    )
+    assert table.count_rows() == 2
+
+
 def test_on_bad_vectors_does_not_handle_non_vector_list_columns(mem_db: DBConnection):
     schema = pa.schema([pa.field("embedding_history", pa.list_(pa.float32()))])
     table = mem_db.create_table("test_non_vector_list_schema", schema=schema)


### PR DESCRIPTION
Resolves #3559.
### What is this?
This pull request fixes a permanent deadlock that occurs when running LanceDB with the `sentence-transformers` embedding registry on Windows with a CUDA GPU.
### Root Cause
Currently, when a user defines an embedding schema (e.g., `vector = model.VectorField()`), LanceDB calls `model.ndims()` to infer the dimension. For `SentenceTransformerEmbeddings`, this generates a dummy embedding which initializes the PyTorch model and binds its CUDA context strictly to the **Main Thread**.
Later, when `table.add()` is called, LanceDB delegates the insertion to `LOOP.run(...)`, shifting execution onto the `BackgroundEventLoop` daemon thread. On that background thread, `AsyncTable.add` invokes `_sanitize_data`, which executes the PyTorch model. 
On Windows, PyTorch does not support sharing a CUDA context across threads without explicit locks, causing the GPU driver to instantly deadlock when the background thread tries to infer the batch.
### The Fix
This PR ensures that `_sanitize_data` (which generates the embeddings) is executed synchronously on the **Main Thread** inside `SyncTable.add` *before* the pure Arrow data is passed to `LOOP.run(...)`.
This guarantees the PyTorch model is initialized and executed on the exact same thread, keeping the Windows CUDA context perfectly safe, while still allowing the LanceDB disk I/O to run asynchronously in the background loop!
### Note on Unit Testing
Due to the nature of this bug, it is a hardware/OS specific deadlock (Windows + Nvidia GPU + CUDA). It is practically impossible to write an automated CI/CD unit test for this without dedicated GPU runners on Windows. I have manually verified that this fix completely resolves the deadlock locally on an RTX 3080 Ti.