### PR TITLE
fix: overflow using sys.maxsize for k in query with namespace connection

### DIFF
--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -70,13 +70,6 @@ from lancedb.embeddings import EmbeddingFunctionConfig
 from ._lancedb import Session
 
 
-# The namespace ``query_table`` request models ``k`` as a 32-bit integer (the
-# OpenAPI contract; the Rust binding deserializes it into an ``i32``). An
-# "unlimited" read therefore must not use ``sys.maxsize`` (i64::MAX) as the
-# sentinel — it overflows when the request is marshaled into the binding with
-# ``OverflowError: out of range integral type conversion attempted``. i32::MAX
-# is effectively unbounded for any realistic table (no single query returns
-# more than ~2.1B rows).
 _MAX_QUERY_K = 2**31 - 1
 
 
@@ -157,9 +150,7 @@ def _query_to_namespace_request(
     if query.limit is not None:
         k = query.limit
     elif query.vector is None and query.full_text_query is None:
-        # No explicit limit: read everything. Capped at i32::MAX so the
-        # request fits the namespace ``query_table`` ``k`` field — see
-        # ``_MAX_QUERY_K``.
+        # limit k to max i32 value to avoid client overflows
         k = _MAX_QUERY_K
     else:
         k = 10

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -70,6 +70,16 @@ from lancedb.embeddings import EmbeddingFunctionConfig
 from ._lancedb import Session
 
 
+# The namespace ``query_table`` request models ``k`` as a 32-bit integer (the
+# OpenAPI contract; the Rust binding deserializes it into an ``i32``). An
+# "unlimited" read therefore must not use ``sys.maxsize`` (i64::MAX) as the
+# sentinel — it overflows when the request is marshaled into the binding with
+# ``OverflowError: out of range integral type conversion attempted``. i32::MAX
+# is effectively unbounded for any realistic table (no single query returns
+# more than ~2.1B rows).
+_MAX_QUERY_K = 2**31 - 1
+
+
 def _query_to_namespace_request(
     table_id: List[str],
     query: "Query",
@@ -147,7 +157,10 @@ def _query_to_namespace_request(
     if query.limit is not None:
         k = query.limit
     elif query.vector is None and query.full_text_query is None:
-        k = sys.maxsize
+        # No explicit limit: read everything. Capped at i32::MAX so the
+        # request fits the namespace ``query_table`` ``k`` field — see
+        # ``_MAX_QUERY_K``.
+        k = _MAX_QUERY_K
     else:
         k = 10
 

--- a/python/python/tests/test_namespace.py
+++ b/python/python/tests/test_namespace.py
@@ -5,11 +5,11 @@
 
 import tempfile
 import shutil
-import sys
 import pytest
 import pyarrow as pa
 import lancedb
 from lance_namespace.errors import NamespaceNotEmptyError, TableNotFoundError
+from lancedb.namespace import _MAX_QUERY_K
 from lancedb.table import AsyncTable, LanceTable
 
 
@@ -804,10 +804,13 @@ class TestPushdownOperations:
             ["geneva", "hist"],
             ["geneva", "hist"],
         ]
+        # Unlimited reads cap k at i32::MAX (the namespace query_table `k`
+        # field is i32); sys.maxsize would overflow the Rust binding.
         assert [request.k for request in namespace_client.requests] == [
-            sys.maxsize,
-            sys.maxsize,
+            _MAX_QUERY_K,
+            _MAX_QUERY_K,
         ]
+        assert all(r.k <= 2**31 - 1 for r in namespace_client.requests)
 
 
 @pytest.mark.asyncio
@@ -862,10 +865,13 @@ class TestAsyncPushdownOperations:
             ["geneva", "hist"],
             ["geneva", "hist"],
         ]
+        # Unlimited reads cap k at i32::MAX (the namespace query_table `k`
+        # field is i32); sys.maxsize would overflow the Rust binding.
         assert [request.k for request in namespace_client.requests] == [
-            sys.maxsize,
-            sys.maxsize,
+            _MAX_QUERY_K,
+            _MAX_QUERY_K,
         ]
+        assert all(r.k <= 2**31 - 1 for r in namespace_client.requests)
 
 
 def test_local_table_to_arrow_and_to_pandas_are_unchanged(tmp_path):


### PR DESCRIPTION
Previously k was set to sys.maxsize, which could result in i64, overflowing clients generated using i32 from OpenAPI spec.

```
return self._inner.query_table(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OverflowError: out of range integral type conversion attempted
```

This change limits k to max value for i32