### PR TITLE
fix(python): route sync namespace ops through native connection

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -914,23 +914,7 @@ class LanceDBConnection(DBConnection):
             raise ValueError("mode must be either 'create' or 'overwrite'")
         validate_table_name(name)
 
-        if namespace_path:
-            return self._namespace_conn().create_table(
-                name,
-                data=data,
-                schema=schema,
-                mode=mode,
-                exist_ok=exist_ok,
-                on_bad_vectors=on_bad_vectors,
-                fill_value=fill_value,
-                embedding_functions=embedding_functions,
-                namespace_path=namespace_path,
-                storage_options=storage_options,
-                data_storage_version=data_storage_version,
-                enable_v2_manifest_paths=enable_v2_manifest_paths,
-            )
-
-        tbl = LanceTable.create(
+        return LanceTable.create(
             self,
             name,
             data,
@@ -942,20 +926,8 @@ class LanceDBConnection(DBConnection):
             embedding_functions=embedding_functions,
             namespace_path=namespace_path,
             storage_options=storage_options,
-        )
-        return tbl
-
-    def _namespace_conn(self) -> DBConnection:
-        """Return a LanceNamespaceDBConnection backed by this connection's
-        directory namespace.  Used to delegate child-namespace operations."""
-        from lancedb.namespace import LanceNamespaceDBConnection
-
-        return LanceNamespaceDBConnection(
-            self.namespace_client(),
-            read_consistency_interval=self.read_consistency_interval,
-            storage_options=self.storage_options,
-            namespace_client_impl=None,
-            namespace_client_properties=None,
+            data_storage_version=data_storage_version,
+            enable_v2_manifest_paths=enable_v2_manifest_paths,
         )
 
     @override
@@ -976,8 +948,7 @@ class LanceDBConnection(DBConnection):
         name: str
             The name of the table.
         namespace_path: List[str], optional
-            The namespace to open the table from.  When non-empty, the
-            table is resolved through the directory namespace client.
+            The namespace to open the table from.
         branch: str, optional
             If provided, open a handle scoped to this branch instead of the
             default branch. Reads and writes operate in the branch's context.
@@ -1004,21 +975,13 @@ class LanceDBConnection(DBConnection):
                 stacklevel=2,
             )
 
-        if namespace_path:
-            tbl = self._namespace_conn().open_table(
-                name,
-                namespace_path=namespace_path,
-                storage_options=storage_options,
-                index_cache_size=index_cache_size,
-            )
-        else:
-            tbl = LanceTable.open(
-                self,
-                name,
-                namespace_path=namespace_path,
-                storage_options=storage_options,
-                index_cache_size=index_cache_size,
-            )
+        tbl = LanceTable.open(
+            self,
+            name,
+            namespace_path=namespace_path,
+            storage_options=storage_options,
+            index_cache_size=index_cache_size,
+        )
 
         if branch is not None:
             tbl = tbl.branches.checkout(branch, version)
@@ -1102,9 +1065,6 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        if namespace_path:
-            self._namespace_conn().drop_table(name, namespace_path=namespace_path)
-            return
         LOOP.run(
             self._conn.drop_table(
                 name, namespace_path=namespace_path, ignore_missing=ignore_missing

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -746,10 +746,12 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        return self._namespace_conn().list_namespaces(
-            namespace_path=namespace_path,
-            page_token=page_token,
-            limit=limit,
+        return LOOP.run(
+            self._conn.list_namespaces(
+                namespace_path=namespace_path,
+                page_token=page_token,
+                limit=limit,
+            )
         )
 
     @override
@@ -759,10 +761,12 @@ class LanceDBConnection(DBConnection):
         mode: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -> CreateNamespaceResponse:
-        return self._namespace_conn().create_namespace(
-            namespace_path=namespace_path,
-            mode=mode,
-            properties=properties,
+        return LOOP.run(
+            self._conn.create_namespace(
+                namespace_path,
+                mode=mode,
+                properties=properties,
+            )
         )
 
     @override
@@ -772,19 +776,19 @@ class LanceDBConnection(DBConnection):
         mode: Optional[str] = None,
         behavior: Optional[str] = None,
     ) -> DropNamespaceResponse:
-        return self._namespace_conn().drop_namespace(
-            namespace_path=namespace_path,
-            mode=mode,
-            behavior=behavior,
+        return LOOP.run(
+            self._conn.drop_namespace(
+                namespace_path,
+                mode=mode,
+                behavior=behavior,
+            )
         )
 
     @override
     def describe_namespace(
         self, namespace_path: List[str]
     ) -> DescribeNamespaceResponse:
-        return self._namespace_conn().describe_namespace(
-            namespace_path=namespace_path,
-        )
+        return LOOP.run(self._conn.describe_namespace(namespace_path))
 
     @override
     def list_tables(
@@ -813,12 +817,6 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        if namespace_path:
-            return self._namespace_conn().list_tables(
-                namespace_path=namespace_path,
-                page_token=page_token,
-                limit=limit,
-            )
         return LOOP.run(
             self._conn.list_tables(
                 namespace_path=namespace_path, page_token=page_token, limit=limit

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2119,6 +2119,10 @@ class LanceTable(Table):
         # use that location directly instead of constructing from base URI
         if self._location is not None:
             return self._location
+        # Tables in a child namespace don't live at "{base_uri}/{name}.lance";
+        # ask the native table for its resolved location instead.
+        if self._namespace_path:
+            return self.uri
         return _table_path(self._conn.uri, self.name)
 
     def to_lance(self, **kwargs) -> lance.LanceDataset:

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -955,6 +955,43 @@ def test_local_namespace_operations(tmp_path):
     assert db.list_namespaces().namespaces == []
 
 
+def test_local_namespace_operations_without_pylance(tmp_path, monkeypatch):
+    """Sync namespace operations must not require the optional ``pylance`` package.
+
+    Regression test for OSS-1275: the sync ``list_namespaces``/``create_namespace``/
+    ``drop_namespace``/``describe_namespace``/``list_tables`` paths used to route
+    through the Python ``lance_namespace`` client, whose directory namespace impl
+    imports ``lance.namespace``. That made these operations fail with
+    ``No module named 'lance'`` on installs without the ``pylance`` extra, even
+    though the async equivalents (backed by the native Rust connection) worked.
+    """
+    import importlib.abc
+
+    # Drop any already-imported ``lance`` modules and block re-importing them so we
+    # faithfully simulate an install that lacks the optional ``pylance`` package.
+    for name in list(sys.modules):
+        if name == "lance" or name.startswith("lance."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    class BlockLance(importlib.abc.MetaPathFinder):
+        def find_spec(self, name, path, target=None):
+            if name == "lance" or name.startswith("lance."):
+                raise ModuleNotFoundError(f"No module named '{name}'")
+            return None
+
+    monkeypatch.setattr(sys, "meta_path", [BlockLance(), *sys.meta_path])
+
+    db = lancedb.connect(tmp_path)
+
+    assert db.list_namespaces().namespaces == []
+    db.create_namespace(["child"])
+    assert "child" in db.list_namespaces().namespaces
+    db.describe_namespace(["child"])  # must not raise
+    assert db.list_tables().tables == []
+    db.drop_namespace(["child"])
+    assert db.list_namespaces().namespaces == []
+
+
 def test_create_namespace_invalid_mode_raises(tmp_path):
     """Unrecognized create namespace modes raise a clear error."""
     db = lancedb.connect(tmp_path)

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -955,43 +955,6 @@ def test_local_namespace_operations(tmp_path):
     assert db.list_namespaces().namespaces == []
 
 
-def test_local_namespace_operations_without_pylance(tmp_path, monkeypatch):
-    """Sync namespace operations must not require the optional ``pylance`` package.
-
-    Regression test for OSS-1275: the sync ``list_namespaces``/``create_namespace``/
-    ``drop_namespace``/``describe_namespace``/``list_tables`` paths used to route
-    through the Python ``lance_namespace`` client, whose directory namespace impl
-    imports ``lance.namespace``. That made these operations fail with
-    ``No module named 'lance'`` on installs without the ``pylance`` extra, even
-    though the async equivalents (backed by the native Rust connection) worked.
-    """
-    import importlib.abc
-
-    # Drop any already-imported ``lance`` modules and block re-importing them so we
-    # faithfully simulate an install that lacks the optional ``pylance`` package.
-    for name in list(sys.modules):
-        if name == "lance" or name.startswith("lance."):
-            monkeypatch.delitem(sys.modules, name, raising=False)
-
-    class BlockLance(importlib.abc.MetaPathFinder):
-        def find_spec(self, name, path, target=None):
-            if name == "lance" or name.startswith("lance."):
-                raise ModuleNotFoundError(f"No module named '{name}'")
-            return None
-
-    monkeypatch.setattr(sys, "meta_path", [BlockLance(), *sys.meta_path])
-
-    db = lancedb.connect(tmp_path)
-
-    assert db.list_namespaces().namespaces == []
-    db.create_namespace(["child"])
-    assert "child" in db.list_namespaces().namespaces
-    db.describe_namespace(["child"])  # must not raise
-    assert db.list_tables().tables == []
-    db.drop_namespace(["child"])
-    assert db.list_namespaces().namespaces == []
-
-
 def test_create_namespace_invalid_mode_raises(tmp_path):
     """Unrecognized create namespace modes raise a clear error."""
     db = lancedb.connect(tmp_path)

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -1007,9 +1007,6 @@ def test_branch_name_validation(tmp_path):
 
 
 def test_branches_preserve_namespace(tmp_path):
-    pytest.importorskip(
-        "lance"
-    )  # namespace_path routes through lance's DirectoryNamespace
     db = lancedb.connect(tmp_path)
     table = db.create_table("t", [{"id": 1}], namespace_path=["ns1"])
     assert table.namespace == ["ns1"]
@@ -1021,6 +1018,41 @@ def test_branches_preserve_namespace(tmp_path):
     # opening the branch directly also preserves namespace identity
     opened = db.open_table("t", namespace_path=["ns1"], branch="exp")
     assert opened.namespace == ["ns1"]
+
+
+def test_local_namespace_lifecycle_without_pylance(tmp_path):
+    """Native (non-namespace-client) connections must support the full
+    namespace + table lifecycle without the optional ``pylance`` package.
+
+    Regression test for OSS-1275. The sync namespace and namespaced-table
+    operations used to route through the Python ``lance_namespace`` client,
+    whose directory impl imports ``lance.namespace`` (from ``pylance``), so
+    they failed with ``No module named 'lance'`` on installs without the
+    ``pylance`` extra. This test runs in the "without pylance" CI job, so it
+    fails loudly if any of these paths regress to requiring ``pylance``.
+    """
+    db = lancedb.connect(tmp_path)
+
+    # Namespace metadata operations.
+    assert db.list_namespaces().namespaces == []
+    db.create_namespace(["child"])
+    assert "child" in db.list_namespaces().namespaces
+    db.describe_namespace(["child"])  # must not raise
+
+    # Table operations scoped to a child namespace.
+    table = db.create_table("t", [{"i": 1}, {"i": 2}], namespace_path=["child"])
+    assert table.namespace == ["child"]
+    table.add([{"i": 3}])
+    assert db.list_tables(namespace_path=["child"]).tables == ["t"]
+
+    reopened = db.open_table("t", namespace_path=["child"])
+    assert reopened.count_rows() == 3
+    assert reopened.to_arrow().num_rows == 3
+
+    db.drop_table("t", namespace_path=["child"])
+    assert db.list_tables(namespace_path=["child"]).tables == []
+    db.drop_namespace(["child"])
+    assert db.list_namespaces().namespaces == []
 
 
 def test_open_table_with_branch(tmp_path):


### PR DESCRIPTION
Namespace operations (and tables within a namespace) failed on a sync
connection while the async equivalents worked:

```python
db = lancedb.connect(DB_PATH)
db.list_namespaces()  # ValueError: ... No module named 'lance'
```

## Root cause

The sync `LanceDBConnection` namespace and namespaced-table operations
routed through the Python `lance_namespace` client. Its directory (`"dir"`)
implementation lives in `lance.namespace.DirectoryNamespace` — part of the
optional `pylance` package — so these operations failed with
`No module named 'lance'` on installs without the `pylance` extra. The async
API worked because it goes straight to the native Rust connection, which
already bundles a directory-namespace implementation (`lance-namespace-impls`).

`pylance` only ships the *implementations*; the lightweight `lance-namespace`
package (a core dep) ships just the interface and registry. Requiring
`pylance` here meant pulling in a second copy of the Lance Rust bindings to
do something LanceDB already implements natively.

## Fix

Route all sync namespace + namespaced-table operations through the native
connection (via `LOOP.run(self._conn.<op>(...))`), matching the async API:

- `list_namespaces`, `create_namespace`, `drop_namespace`,
  `describe_namespace`, `list_tables`
- `create_table`, `open_table`, `drop_table` with a `namespace_path`
  (`clone_table`/`drop_all_tables` already used the native path)

`_namespace_conn()` is removed. `_dataset_path` now derives a child-namespace
table's location from the native table's resolved URI, so
`to_lance()`/`to_pandas()` keep working without a namespace client.

The only remaining `pylance`-requiring surface is the **public**
`namespace_client()` method and the `connect_namespace(...)` API for
user-supplied Python namespace implementations — both explicit opt-ins,
unchanged here.

## Tests

The repo already has a "Test without pylance or pandas" CI job. This PR makes
it cover the regression: removed the now-unnecessary `importorskip("lance")`
from `test_branches_preserve_namespace`, and added
`test_local_namespace_lifecycle_without_pylance` exercising the full
namespace + table lifecycle. Verified locally with `pylance` actually
uninstalled (the native tests pass; the `connect_namespace`/`to_lance` tests
correctly skip).

Fixes OSS-1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)