### PR TITLE
feat(embeddings): add TwelveLabs Marengo multimodal embedding function

### DIFF
--- a/docs/src/embeddings/available_embedding_models/multimodal_embedding_functions/twelvelabs_embedding.md
+++ b/docs/src/embeddings/available_embedding_models/multimodal_embedding_functions/twelvelabs_embedding.md
@@ -1,0 +1,61 @@
+# TwelveLabs Embeddings : Multimodal
+
+[TwelveLabs](https://twelvelabs.io) Marengo is a multimodal model that maps
+text, images, audio and video into a single shared embedding space. That means
+you can store image (or other media) embeddings as the source column and query
+them with plain text, or vice-versa.
+
+Set the `TWELVELABS_API_KEY` environment variable with your API key. You can
+grab a free key at [https://twelvelabs.io](https://twelvelabs.io) — there's a
+generous free tier.
+
+Supported models:
+
+- `marengo3.0` - 512 dimensions (default)
+- `Marengo-retrieval-2.7` - 1024 dimensions
+
+Supported parameters (to be passed in the `create` method):
+
+| Parameter | Type | Default Value | Description |
+|---|---|---|---|
+| `name` | `str` | `"marengo3.0"` | The Marengo model to use |
+
+Source and query inputs may be text (`str`), an image URL (`str`), a local
+image path (`pathlib.Path`), raw image `bytes`, or a `PIL.Image.Image`.
+
+Usage Example:
+
+```python
+import os
+
+import lancedb
+from lancedb.pydantic import LanceModel, Vector
+from lancedb.embeddings import get_registry
+
+os.environ["TWELVELABS_API_KEY"] = "YOUR_TWELVELABS_API_KEY"
+
+db = lancedb.connect(".lancedb")
+func = get_registry().get("twelvelabs").create(name="marengo3.0")
+
+
+class Images(LanceModel):
+    label: str
+    image_uri: str = func.SourceField()  # image uri as the source
+    vector: Vector(func.ndims()) = func.VectorField()  # vector column
+
+
+table = db.create_table("images", schema=Images, mode="overwrite")
+table.add(
+    [
+        {"label": "cat", "image_uri": "http://farm1.staticflickr.com/53/167798175_7c7845bbbd_z.jpg"},
+        {"label": "dog", "image_uri": "http://farm9.staticflickr.com/8387/8602747737_2e5c2a45d4_z.jpg"},
+    ]
+)
+```
+
+Because Marengo is multimodal, we can search the image column with a text query:
+
+```python
+result = table.search("man's best friend").limit(1).to_pydantic(Images)[0]
+print(result.label)  # prints "dog"
+```

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -88,7 +88,8 @@ embeddings = [
     "botocore>=1.31.57",
     'ibm-watsonx-ai>=1.1.2; python_version >= "3.10"',
     "ollama>=0.3.0",
-    "sentencepiece>=0.1.99"
+    "sentencepiece>=0.1.99",
+    "twelvelabs>=1.2.8"
 ]
 azure = ["adlfs>=2024.2.0"]
 

--- a/python/python/lancedb/embeddings/__init__.py
+++ b/python/python/lancedb/embeddings/__init__.py
@@ -21,3 +21,4 @@ from .watsonx import WatsonxEmbeddings
 from .voyageai import VoyageAIEmbeddingFunction
 from .colpali import ColPaliEmbeddings
 from .siglip import SigLipEmbeddings
+from .twelvelabs import TwelveLabsEmbeddingFunction

--- a/python/python/lancedb/embeddings/twelvelabs.py
+++ b/python/python/lancedb/embeddings/twelvelabs.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The LanceDB Authors
+import io
+import os
+from pathlib import Path
+from typing import ClassVar, List, TYPE_CHECKING, Union
+from urllib.parse import urlparse
+
+import numpy as np
+import pyarrow as pa
+
+from ..util import attempt_import_or_raise
+from .base import EmbeddingFunction
+from .registry import register
+from .utils import IMAGES, TEXT, api_key_not_found_help
+
+if TYPE_CHECKING:
+    import PIL
+
+# Marengo embedding models and their output dimensions.
+TWELVELABS_MODEL_DIMS = {
+    "marengo3.0": 512,
+    "Marengo-retrieval-2.7": 1024,
+}
+
+
+def _is_url(text: str) -> bool:
+    try:
+        parsed = urlparse(text)
+        return bool(parsed.scheme) and bool(parsed.netloc)
+    except Exception:
+        return False
+
+
+@register("twelvelabs")
+class TwelveLabsEmbeddingFunction(EmbeddingFunction):
+    """
+    An embedding function that uses the TwelveLabs Marengo multimodal model.
+
+    Marengo produces embeddings that live in a single space shared across text,
+    image, audio, and video, so a text query can be matched directly against
+    image or audio source columns. See https://docs.twelvelabs.io/ for details.
+
+    The TwelveLabs API key is read from the ``TWELVELABS_API_KEY`` environment
+    variable. You can grab a free key at https://twelvelabs.io.
+
+    Parameters
+    ----------
+    name: str, default "marengo3.0"
+        The name of the Marengo model to use. Supported models:
+
+            * marengo3.0 (512 dims)
+            * Marengo-retrieval-2.7 (1024 dims)
+
+    Examples
+    --------
+    import lancedb
+    from lancedb.pydantic import LanceModel, Vector
+    from lancedb.embeddings import get_registry
+
+    tl = get_registry().get("twelvelabs").create(name="marengo3.0")
+
+    class Media(LanceModel):
+        url: str = tl.SourceField()
+        vector: Vector(tl.ndims()) = tl.VectorField()
+
+    db = lancedb.connect("~/.lancedb")
+    tbl = db.create_table("media", schema=Media, mode="overwrite")
+    tbl.add([{"url": "https://example.com/cat.jpg"}])
+
+    # Search images using a text query (shared embedding space)
+    tbl.search("a cat sitting on a couch").limit(1).to_pandas()
+    """
+
+    name: str = "marengo3.0"
+    client: ClassVar = None
+
+    def ndims(self) -> int:
+        if self.name not in TWELVELABS_MODEL_DIMS:
+            raise ValueError(
+                f"Model {self.name} not supported. "
+                f"Supported models: {list(TWELVELABS_MODEL_DIMS)}"
+            )
+        return TWELVELABS_MODEL_DIMS[self.name]
+
+    @staticmethod
+    def sensitive_keys() -> List[str]:
+        return ["api_key"]
+
+    def compute_query_embeddings(
+        self, query: Union[str, "PIL.Image.Image", bytes, Path], *args, **kwargs
+    ) -> List[np.ndarray]:
+        """Compute the embedding for a single text or image query."""
+        return [self._embed_one(query)]
+
+    def compute_source_embeddings(
+        self, inputs: Union[TEXT, IMAGES], *args, **kwargs
+    ) -> List[np.ndarray]:
+        """Compute embeddings for a column of text and/or image inputs."""
+        return [self._embed_one(i) for i in self._sanitize(inputs)]
+
+    def _sanitize(self, inputs: Union[TEXT, IMAGES]) -> List:
+        PIL_Image = attempt_import_or_raise("PIL.Image", "pillow")
+        if isinstance(inputs, (str, bytes, Path, PIL_Image.Image)):
+            return [inputs]
+        if isinstance(inputs, pa.Array):
+            return inputs.to_pylist()
+        if isinstance(inputs, pa.ChunkedArray):
+            return inputs.combine_chunks().to_pylist()
+        if isinstance(inputs, (list, np.ndarray)):
+            return list(inputs)
+        raise ValueError(f"Input type {type(inputs)} not allowed.")
+
+    def _embed_one(
+        self, item: Union[str, bytes, Path, "PIL.Image.Image"]
+    ) -> np.ndarray:
+        client = self._get_client()
+        PIL_Image = attempt_import_or_raise("PIL.Image", "pillow")
+
+        if isinstance(item, str) and not _is_url(item):
+            resp = client.embed.create(model_name=self.name, text=item)
+            result = resp.text_embedding
+        elif isinstance(item, str):
+            resp = client.embed.create(model_name=self.name, image_url=item)
+            result = resp.image_embedding
+        else:
+            # Local image: Path, raw bytes, or a PIL image.
+            if isinstance(item, Path):
+                image_file = item.read_bytes()
+            elif isinstance(item, bytes):
+                image_file = item
+            elif isinstance(item, PIL_Image.Image):
+                buf = io.BytesIO()
+                item.save(buf, format="JPEG")
+                image_file = buf.getvalue()
+            else:
+                raise ValueError("Each input should be str, bytes, Path or PIL.Image.")
+            resp = client.embed.create(model_name=self.name, image_file=image_file)
+            result = resp.image_embedding
+
+        if result is None or not result.segments:
+            raise ValueError(
+                f"TwelveLabs returned no embedding for input "
+                f"(error: {getattr(result, 'error_message', None)})"
+            )
+        return np.array(result.segments[0].float_)
+
+    @classmethod
+    def _get_client(cls):
+        if cls.client is None:
+            twelvelabs = attempt_import_or_raise("twelvelabs")
+            if os.environ.get("TWELVELABS_API_KEY") is None:
+                api_key_not_found_help("twelvelabs")
+            cls.client = twelvelabs.TwelveLabs(api_key=os.environ["TWELVELABS_API_KEY"])
+        return cls.client

--- a/python/python/tests/test_twelvelabs_embeddings.py
+++ b/python/python/tests/test_twelvelabs_embeddings.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+"""Tests for the TwelveLabs Marengo embedding function.
+
+The unit tests mock the SDK and require no network access. The integration
+test is gated on TWELVELABS_API_KEY and marked ``slow``.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import lancedb
+import pytest
+
+from lancedb.embeddings import get_registry
+from lancedb.pydantic import LanceModel, Vector
+
+
+@pytest.fixture(autouse=True)
+def reset_twelvelabs_client():
+    """Reset the cached client before and after each test."""
+    from lancedb.embeddings.twelvelabs import TwelveLabsEmbeddingFunction
+
+    TwelveLabsEmbeddingFunction.client = None
+    yield
+    TwelveLabsEmbeddingFunction.client = None
+
+
+def _mock_client():
+    """Return a mock TwelveLabs client whose embed.create yields a 512-dim vector."""
+    segment = MagicMock()
+    segment.float_ = [0.1] * 512
+    resp = MagicMock()
+    resp.text_embedding.segments = [segment]
+    resp.image_embedding.segments = [segment]
+    client = MagicMock()
+    client.embed.create.return_value = resp
+    return client
+
+
+class TestTwelveLabsRegistration:
+    def test_registered(self):
+        assert get_registry().get("twelvelabs") is not None
+
+    @pytest.mark.parametrize(
+        "model_name,expected_dims",
+        [("marengo3.0", 512), ("Marengo-retrieval-2.7", 1024)],
+    )
+    def test_model_dimensions(self, model_name, expected_dims):
+        func = get_registry().get("twelvelabs").create(name=model_name)
+        assert func.ndims() == expected_dims
+
+    def test_default_model(self):
+        func = get_registry().get("twelvelabs").create()
+        assert func.name == "marengo3.0"
+        assert func.ndims() == 512
+
+    def test_unsupported_model_raises(self):
+        func = get_registry().get("twelvelabs").create(name="not-a-model")
+        with pytest.raises(ValueError, match="not supported"):
+            func.ndims()
+
+    def test_api_key_is_sensitive(self):
+        func = get_registry().get("twelvelabs").create()
+        assert "api_key" in func.sensitive_keys()
+
+    def test_missing_api_key_raises(self):
+        func = get_registry().get("twelvelabs").create(name="marengo3.0")
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="TWELVELABS_API_KEY"):
+                func.compute_query_embeddings("hello")
+
+    def test_text_embedding_uses_text_field(self):
+        client = _mock_client()
+        func = get_registry().get("twelvelabs").create(name="marengo3.0")
+        with patch.object(type(func), "_get_client", return_value=client):
+            out = func.compute_source_embeddings(["hello world"])
+        assert len(out) == 1 and len(out[0]) == 512
+        client.embed.create.assert_called_once_with(
+            model_name="marengo3.0", text="hello world"
+        )
+
+    def test_url_input_uses_image_url_field(self):
+        client = _mock_client()
+        func = get_registry().get("twelvelabs").create(name="marengo3.0")
+        with patch.object(type(func), "_get_client", return_value=client):
+            func.compute_query_embeddings("https://example.com/cat.jpg")
+        client.embed.create.assert_called_once_with(
+            model_name="marengo3.0", image_url="https://example.com/cat.jpg"
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    os.environ.get("TWELVELABS_API_KEY") is None,
+    reason="TWELVELABS_API_KEY not set",
+)
+def test_twelvelabs_embedding_function(tmp_path):
+    """Integration test against the real TwelveLabs Marengo API."""
+    func = get_registry().get("twelvelabs").create(name="marengo3.0", max_retries=0)
+
+    class TextModel(LanceModel):
+        text: str = func.SourceField()
+        vector: Vector(func.ndims()) = func.VectorField()
+
+    db = lancedb.connect(tmp_path)
+    tbl = db.create_table("test", schema=TextModel, mode="overwrite")
+    tbl.add([{"text": "a red sports car"}, {"text": "a fluffy cat"}])
+
+    assert len(tbl.to_pandas()["vector"][0]) == func.ndims() == 512
+    result = tbl.search("automobile").limit(1).to_pandas()
+    assert result["text"][0] == "a red sports car"


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds a new opt-in embedding function for [TwelveLabs Marengo](https://docs.twelvelabs.io/), registered as `"twelvelabs"` in the embedding-function registry alongside the existing providers (VoyageAI multimodal, SigLIP, OpenCLIP, ImageBind, etc.).

### What it adds
- `TwelveLabsEmbeddingFunction` (`lancedb.embeddings.twelvelabs`) — Marengo is a multimodal model that maps text, images, audio and video into a single shared embedding space, so you can store media embeddings as a source column and query them with plain text (or vice-versa).
- Supports `marengo3.0` (512-dim, default) and `Marengo-retrieval-2.7` (1024-dim).
- Accepts text (`str`), image URLs (`str`), local image paths (`pathlib.Path`), raw `bytes`, and `PIL.Image.Image` inputs.
- API key is read from `TWELVELABS_API_KEY` and reported via `sensitive_keys()`.
- Docs page under the multimodal embedding functions section, and the `twelvelabs>=1.2.8` SDK added to the optional `embeddings` extra.

### Why it helps this project
LanceDB is a natural store for multimodal/video search, and Marengo gives users a single shared embedding space across text/image/audio/video — letting them do cross-modal retrieval (text query → image/video results) directly in a LanceDB table, with no separate inference plumbing.

### Opt-in / non-breaking
Purely additive: a new registry entry and an optional dependency. No existing defaults or behavior change; the SDK is only imported when the function is actually used (`attempt_import_or_raise`).

### How it was tested
- 9 no-network unit tests (mocked SDK) covering registration, dimensions, default model, unsupported-model error, sensitive-key reporting, missing-API-key error, and that text vs. URL inputs route to the correct SDK fields.
- 1 integration test gated on `TWELVELABS_API_KEY` (skipped without it, marked `slow`) that creates a table, embeds rows via the real Marengo API, and runs a cross-modal text search.
- Verified against the live API: a `marengo3.0` text call returns a 512-dim vector. All 10 tests pass locally; `ruff check` and `ruff format --check` are clean on the changed files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
