### PR TITLE
fix(python): handle scalar-indexed merge inserts

### DIFF
--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -2204,6 +2204,61 @@ def test_merge_insert(mem_db: DBConnection):
         )
 
 
+def test_merge_insert_update_all_with_scalar_index(tmp_db: DBConnection):
+    schema = pa.schema(
+        [
+            pa.field("vector", pa.list_(pa.float32(), 4), nullable=True),
+            pa.field("path", pa.string(), nullable=False),
+            pa.field("status", pa.utf8()),
+            pa.field("file_size", pa.int64()),
+        ]
+    )
+    table = tmp_db.create_table("my_table", schema=schema)
+    table.add(
+        pa.Table.from_pylist(
+            [
+                {
+                    "vector": None,
+                    "path": f"/img/{idx}.jpg",
+                    "status": "pending",
+                    "file_size": 1000 + idx,
+                }
+                for idx in range(64)
+            ],
+            schema=schema,
+        )
+    )
+    table.create_scalar_index("path", index_type="BTREE")
+
+    updates_schema = pa.schema(
+        [
+            pa.field("path", pa.string(), nullable=False),
+            pa.field("vector", pa.list_(pa.float32(), 4), nullable=True),
+            pa.field("status", pa.utf8()),
+        ]
+    )
+    updates = pa.Table.from_pylist(
+        [
+            {
+                "path": f"/img/{idx}.jpg",
+                "vector": [0.1] * 4,
+                "status": "indexed",
+            }
+            for idx in range(16)
+        ],
+        schema=updates_schema,
+    )
+
+    merge_insert_res = (
+        table.merge_insert("path").when_matched_update_all().execute(updates)
+    )
+
+    assert merge_insert_res.num_updated_rows == 16
+    assert merge_insert_res.num_inserted_rows == 0
+    assert merge_insert_res.num_deleted_rows == 0
+    assert table.count_rows("status = 'indexed'") == 16
+
+
 def test_merge_insert_by_source_delete_expr(mem_db: DBConnection):
     table = mem_db.create_table(
         "my_table",

--- a/rust/lancedb/src/table/merge.rs
+++ b/rust/lancedb/src/table/merge.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrow_array::RecordBatchReader;
+use arrow_schema::Schema as ArrowSchema;
 use futures::future::Either;
 use futures::{FutureExt, TryFutureExt};
 use lance::dataset::{
@@ -250,6 +251,10 @@ pub(crate) async fn execute_merge_insert(
     }
 
     let dataset = table.dataset.get().await?;
+    let target_schema = ArrowSchema::from(dataset.schema());
+    // The indexed merge path classifies matches from the leading target fields.
+    // Fall back to a full scan when the merge keys are not those fields.
+    let use_index = params.use_index && merge_keys_are_leading_fields(&target_schema, &params.on);
     let mut builder = LanceMergeInsertBuilder::try_new(dataset.clone(), params.on)?;
     match (
         params.when_matched_update_all,
@@ -281,7 +286,7 @@ pub(crate) async fn execute_merge_insert(
     } else {
         builder.when_not_matched_by_source(WhenNotMatchedBySource::Keep);
     }
-    builder.use_index(params.use_index);
+    builder.use_index(use_index);
 
     let future = if let Some(timeout) = params.timeout {
         let future = builder
@@ -309,6 +314,15 @@ pub(crate) async fn execute_merge_insert(
         num_deleted_rows: stats.num_deleted_rows,
         num_attempts: stats.num_attempts,
         num_rows: stats.num_inserted_rows + stats.num_updated_rows,
+    })
+}
+
+fn merge_keys_are_leading_fields(schema: &ArrowSchema, keys: &[String]) -> bool {
+    keys.iter().enumerate().all(|(idx, key)| {
+        schema
+            .fields()
+            .get(idx)
+            .is_some_and(|field| field.name() == key)
     })
 }
 


### PR DESCRIPTION
## Summary

Fix `merge_insert(...).when_matched_update_all()` for tables that have a scalar index on the merge key when the key is not one of the leading target fields.

The indexed merge path can silently report zero updated rows in that shape. This keeps the indexed path for schemas where the merge keys are leading fields, and falls back to a full scan otherwise.

Adds a Python regression covering a BTREE scalar index on `path` with partial update data, matching the reported failure mode.

## Test Plan

- `python -m pytest python/tests/test_table.py::test_merge_insert_update_all_with_scalar_index`
- `python -m pytest python/tests/test_table.py::test_merge_insert python/tests/test_table.py::test_merge_insert_subschema python/tests/test_table.py::test_merge_insert_update_all_with_scalar_index`
- `ruff check python/tests/test_table.py`
- `ruff format --check python/tests/test_table.py`
- `cargo fmt --all -- --check`
- `cargo test -p lancedb table::merge::tests::test_merge_insert_use_index`

## Breaking Changes

None.

Fixes #3515