### PR TITLE
Avoid background loop for sync connect

### DIFF
--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -282,6 +282,14 @@ async def connect(
     namespace_client_properties: Optional[Dict[str, str]] = None,
     oauth_config: Optional[Any] = None,
 ) -> Connection: ...
+def connect_blocking(
+    uri: str,
+    read_consistency_interval: Optional[float] = None,
+    storage_options: Optional[Dict[str, str]] = None,
+    session: Optional[Session] = None,
+    manifest_enabled: bool = False,
+    namespace_client_properties: Optional[Dict[str, str]] = None,
+) -> Connection: ...
 def connect_namespace(
     namespace_client_impl: str,
     namespace_client_properties: Dict[str, str],

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -44,6 +44,7 @@ from lance_namespace import (
 
 from . import __version__
 from ._lancedb import connect as lancedb_connect  # type: ignore
+from ._lancedb import connect_blocking as lancedb_connect_blocking  # type: ignore
 from .table import (
     AsyncTable,
     LanceTable,
@@ -648,26 +649,21 @@ class LanceDBConnection(DBConnection):
         else:
             read_consistency_interval_secs = None
 
-        async def do_connect():
-            return await lancedb_connect(
-                sanitize_uri(uri),
-                None,
-                None,
-                None,
-                read_consistency_interval_secs,
-                None,
-                storage_options,
-                session,
-                manifest_enabled,
-                namespace_client_properties,
-            )
-
         # TODO: It would be nice if we didn't store self.storage_options but it is
         # currently used by the LanceTable.to_lance method.  This doesn't _really_
         # work because some paths like LanceDBConnection.from_inner will lose the
         # storage_options.  Also, this class really shouldn't be holding any state
         # beyond _conn.
-        self._conn = AsyncConnection(LOOP.run(do_connect()))
+        self._conn = AsyncConnection(
+            lancedb_connect_blocking(
+                sanitize_uri(uri),
+                read_consistency_interval_secs,
+                storage_options,
+                session,
+                manifest_enabled,
+                namespace_client_properties,
+            )
+        )
         self._cached_namespace_client: Optional[LanceNamespace] = None
 
     @property

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -61,6 +61,19 @@ def test_basic(tmp_path):
     assert db.open_table("test").name == db["test"].name
 
 
+def test_sync_connect_does_not_use_background_loop(tmp_path, monkeypatch):
+    from lancedb import db as db_module
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("sync connect should not use the Python background loop")
+
+    monkeypatch.setattr(db_module.LOOP, "run", fail_run)
+
+    db = lancedb.connect(tmp_path)
+
+    assert db.uri == str(tmp_path)
+
+
 def test_ingest_pd(tmp_path):
     db = lancedb.connect(tmp_path)
 

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -596,6 +596,42 @@ pub fn connect(
 }
 
 #[pyfunction]
+#[pyo3(signature = (uri, read_consistency_interval=None, storage_options=None, session=None, manifest_enabled=false, namespace_client_properties=None))]
+#[allow(clippy::too_many_arguments)]
+pub fn connect_blocking(
+    py: Python<'_>,
+    uri: String,
+    read_consistency_interval: Option<f64>,
+    storage_options: Option<HashMap<String, String>>,
+    session: Option<crate::session::Session>,
+    manifest_enabled: bool,
+    namespace_client_properties: Option<HashMap<String, String>>,
+) -> PyResult<Connection> {
+    let mut builder = lancedb::connect(&uri);
+    if let Some(read_consistency_interval) = read_consistency_interval {
+        let read_consistency_interval = Duration::from_secs_f64(read_consistency_interval);
+        builder = builder.read_consistency_interval(read_consistency_interval);
+    }
+    if let Some(storage_options) = storage_options {
+        builder = builder.storage_options(storage_options);
+    }
+    if manifest_enabled {
+        builder = builder.manifest_enabled(true);
+    }
+    if let Some(namespace_client_properties) = namespace_client_properties {
+        builder = builder.namespace_client_properties(namespace_client_properties);
+    }
+    if let Some(session) = session {
+        builder = builder.session(session.inner.clone());
+    }
+
+    let conn = py
+        .detach(move || crate::runtime::block_on(builder.execute()))
+        .infer_error()?;
+    Ok(Connection::new(conn))
+}
+
+#[pyfunction]
 #[pyo3(signature = (
     namespace_client,
     read_consistency_interval=None,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 use arrow::RecordBatchStream;
-use connection::{Connection, connect, connect_namespace, connect_namespace_client};
+use connection::{
+    Connection, connect, connect_blocking, connect_namespace, connect_namespace_client,
+};
 use env_logger::Env;
 use expr::{PyExpr, expr_col, expr_func, expr_lit};
 use index::IndexConfig;
@@ -62,6 +64,7 @@ pub fn _lancedb(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPermutationReader>()?;
     m.add_class::<PyExpr>()?;
     m.add_function(wrap_pyfunction!(connect, m)?)?;
+    m.add_function(wrap_pyfunction!(connect_blocking, m)?)?;
     m.add_function(wrap_pyfunction!(connect_namespace, m)?)?;
     m.add_function(wrap_pyfunction!(connect_namespace_client, m)?)?;
     m.add_function(wrap_pyfunction!(permutation::async_permutation_builder, m)?)?;


### PR DESCRIPTION
## Summary

- add a blocking native Python extension entry point for local sync `lancedb.connect()`
- route sync `LanceDBConnection` construction through that native entry point instead of the Python background asyncio loop
- release the GIL while the Rust runtime blocks on connection setup
- add stub coverage and a regression test that sync connect does not call `LOOP.run()`

## Context

Refs #3611. The issue reports VS Code/debugpy freezing after `lancedb.connect()` against a MinIO-backed `s3://` URI. I could not reproduce the freeze locally with 0.33.0, but this narrows the sync connect path by removing the Python background-loop bridge during initial connection setup.

## Validation

- `cargo fmt --manifest-path python/Cargo.toml --check`
- `git diff --check`
- `PYTHONPATH=python/python .../venv-local-build/bin/python -m pytest python/python/tests/test_db.py::test_sync_connect_does_not_use_background_loop -q`
- `maturin develop --manifest-path python/Cargo.toml`
- local MinIO container with issue-style storage options (`endpoint`, `access_key_id`, `secret_access_key`, `allow_http`, `region`)
- debugpy DAP launch validation with `console=integratedTerminal`: connect/create/count completed and exited with code 0

Note: the same MinIO + debugpy launch scenario also completed on `lancedb==0.33.0` in my local environment, so this PR should be treated as a targeted hardening fix rather than a locally reproduced crash fix.