### PR TITLE
fix: avoid manifest writes for read-only directory namespace opens

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -34,15 +34,16 @@ runs:
         maturin-version: "1.12.4"
         command: build
         working-directory: python
-        docker-options: "-e PIP_EXTRA_INDEX_URL='https://pypi.fury.io/lance-format/ https://pypi.fury.io/lancedb/'"
+        docker-options: "-e PIP_EXTRA_INDEX_URL='https://pypi.fury.io/lance-format/ https://pypi.fury.io/lancedb/' -e PROTOC=/usr/local/bin/protoc"
         target: x86_64-unknown-linux-gnu
         manylinux: ${{ inputs.manylinux }}
         args: ${{ inputs.args }}
         before-script-linux: |
           set -e
-          curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$(uname -m).zip > /tmp/protoc.zip \
-            && unzip /tmp/protoc.zip -d /usr/local \
-            && rm /tmp/protoc.zip
+          curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-x86_64.zip -o /tmp/protoc.zip
+          unzip /tmp/protoc.zip -d /usr/local
+          rm /tmp/protoc.zip
+          /usr/local/bin/protoc --version
     - name: Build Arm Manylinux Wheel
       if: ${{ inputs.arm-build == 'true' }}
       uses: PyO3/maturin-action@v1
@@ -50,13 +51,14 @@ runs:
         maturin-version: "1.12.4"
         command: build
         working-directory: python
-        docker-options: "-e PIP_EXTRA_INDEX_URL='https://pypi.fury.io/lance-format/ https://pypi.fury.io/lancedb/'"
+        docker-options: "-e PIP_EXTRA_INDEX_URL='https://pypi.fury.io/lance-format/ https://pypi.fury.io/lancedb/' -e PROTOC=/usr/local/bin/protoc"
         target: aarch64-unknown-linux-gnu
         manylinux: ${{ inputs.manylinux }}
         args: ${{ inputs.args }}
         before-script-linux: |
           set -e
-          yum install -y clang \
-            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
-            && unzip /tmp/protoc.zip -d /usr/local \
-            && rm /tmp/protoc.zip
+          yum install -y clang
+          curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip -o /tmp/protoc.zip
+          unzip /tmp/protoc.zip -d /usr/local
+          rm /tmp/protoc.zip
+          /usr/local/bin/protoc --version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,8 +3423,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "rand 0.9.4",
@@ -4726,8 +4726,8 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lance"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -4801,8 +4801,8 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow-scalar"
 version = "58.0.0"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4838,7 +4838,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow-stats"
 version = "58.0.0"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4847,8 +4847,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrayref",
  "crunchy",
@@ -4858,8 +4858,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4897,8 +4897,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4928,8 +4928,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4946,8 +4946,8 @@ dependencies = [
 
 [[package]]
 name = "lance-derive"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4956,8 +4956,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4992,8 +4992,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -5023,8 +5023,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -5089,8 +5089,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -5131,8 +5131,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5148,8 +5148,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5161,8 +5161,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5185,7 +5185,7 @@ dependencies = [
  "lance-table",
  "log",
  "object_store",
- "quick-xml 0.38.4",
+ "quick-xml 0.40.1",
  "rand 0.9.4",
  "reqwest 0.12.28",
  "roaring",
@@ -5216,8 +5216,8 @@ dependencies = [
 
 [[package]]
 name = "lance-select"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5232,8 +5232,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -5272,8 +5272,8 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5286,8 +5286,8 @@ dependencies = [
 
 [[package]]
 name = "lance-tokenizer"
-version = "9.0.0-beta.18"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.18#d581bb9d068c4c3bba22c8a9972b2103d028dbcd"
+version = "9.0.0-beta.19"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-beta.19#8f0e6d3a7c53438275b134c0ac1afbc80600616e"
 dependencies = [
  "icu_segmenter",
  "jieba-rs",
@@ -7609,21 +7609,21 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ categories = ["database-implementations"]
 rust-version = "1.91.0"
 
 [workspace.dependencies]
-lance = { "version" = "=9.0.0-beta.18", default-features = false, "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-core = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-datagen = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-file = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-io = { "version" = "=9.0.0-beta.18", default-features = false, "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-index = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-linalg = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace-impls = { "version" = "=9.0.0-beta.18", default-features = false, "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-table = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-testing = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-datafusion = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-encoding = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
-lance-arrow = { "version" = "=9.0.0-beta.18", "tag" = "v9.0.0-beta.18", "git" = "https://github.com/lance-format/lance.git" }
+lance = { "version" = "=9.0.0-beta.19", default-features = false, "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-core = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-datagen = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-file = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-io = { "version" = "=9.0.0-beta.19", default-features = false, "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-index = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-linalg = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace-impls = { "version" = "=9.0.0-beta.19", default-features = false, "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-table = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-testing = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-datafusion = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-encoding = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
+lance-arrow = { "version" = "=9.0.0-beta.19", "tag" = "v9.0.0-beta.19", "git" = "https://github.com/lance-format/lance.git" }
 ahash = "0.8"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arrow.version>15.0.0</arrow.version>
-        <lance-core.version>9.0.0-beta.18</lance-core.version>
+        <lance-core.version>9.0.0-beta.19</lance-core.version>
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.30.0</spotless.version>
         <spotless.java.googlejavaformat.version>1.7</spotless.java.googlejavaformat.version>

--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -149,8 +149,14 @@ def connect(
 
     For object storage, use a URI prefix:
 
-    >>> db = lancedb.connect("s3://my-bucket/lancedb",
-    ...                      storage_options={"aws_access_key_id": "***"})
+    >>> db = lancedb.connect(  # doctest: +SKIP
+    ...     "s3://my-bucket/lancedb",
+    ...     storage_options={
+    ...         "aws_access_key_id": "***",
+    ...         "aws_secret_access_key": "***",
+    ...         "aws_region": "us-east-1",
+    ...     },
+    ... )
 
     For tests and temporary data, use an in-memory database:
 

--- a/python/python/tests/test_s3_bucket_dots.py
+++ b/python/python/tests/test_s3_bucket_dots.py
@@ -7,7 +7,8 @@ Tests for S3 bucket names containing dots.
 Related issue: https://github.com/lancedb/lancedb/issues/1898
 
 These tests validate the early error checking for S3 bucket names with dots.
-No actual S3 connection is made - validation happens before connection.
+When validation succeeds, eager namespace initialization may still fail later
+because these tests intentionally do not provide real S3 credentials.
 """
 
 import pytest
@@ -20,6 +21,13 @@ BUCKET_WITH_DOTS_AND_AWS_REGION = ("s3://my.bucket.name", {"aws_region": "us-eas
 BUCKET_WITHOUT_DOTS = "s3://my-bucket/path"
 
 
+def assert_not_rejected_for_bucket_dots(connect):
+    try:
+        connect()
+    except ValueError as err:
+        assert "contains dots" not in str(err)
+
+
 class TestS3BucketWithDotsSync:
     """Tests for connect()."""
 
@@ -27,19 +35,22 @@ class TestS3BucketWithDotsSync:
         with pytest.raises(ValueError, match="contains dots"):
             lancedb.connect(BUCKET_WITH_DOTS)
 
-    def test_bucket_with_dots_and_region_passes(self):
+    def test_bucket_with_dots_and_region_is_not_rejected(self):
         uri, opts = BUCKET_WITH_DOTS_AND_REGION
-        db = lancedb.connect(uri, storage_options=opts)
-        assert db is not None
+        assert_not_rejected_for_bucket_dots(
+            lambda: lancedb.connect(uri, storage_options=opts)
+        )
 
-    def test_bucket_with_dots_and_aws_region_passes(self):
+    def test_bucket_with_dots_and_aws_region_is_not_rejected(self):
         uri, opts = BUCKET_WITH_DOTS_AND_AWS_REGION
-        db = lancedb.connect(uri, storage_options=opts)
-        assert db is not None
+        assert_not_rejected_for_bucket_dots(
+            lambda: lancedb.connect(uri, storage_options=opts)
+        )
 
-    def test_bucket_without_dots_passes(self):
-        db = lancedb.connect(BUCKET_WITHOUT_DOTS)
-        assert db is not None
+    def test_bucket_without_dots_is_not_rejected(self):
+        assert_not_rejected_for_bucket_dots(
+            lambda: lancedb.connect(BUCKET_WITHOUT_DOTS)
+        )
 
 
 class TestS3BucketWithDotsAsync:
@@ -51,18 +62,24 @@ class TestS3BucketWithDotsAsync:
             await lancedb.connect_async(BUCKET_WITH_DOTS)
 
     @pytest.mark.asyncio
-    async def test_bucket_with_dots_and_region_passes(self):
+    async def test_bucket_with_dots_and_region_is_not_rejected(self):
         uri, opts = BUCKET_WITH_DOTS_AND_REGION
-        db = await lancedb.connect_async(uri, storage_options=opts)
-        assert db is not None
+        try:
+            await lancedb.connect_async(uri, storage_options=opts)
+        except ValueError as err:
+            assert "contains dots" not in str(err)
 
     @pytest.mark.asyncio
-    async def test_bucket_with_dots_and_aws_region_passes(self):
+    async def test_bucket_with_dots_and_aws_region_is_not_rejected(self):
         uri, opts = BUCKET_WITH_DOTS_AND_AWS_REGION
-        db = await lancedb.connect_async(uri, storage_options=opts)
-        assert db is not None
+        try:
+            await lancedb.connect_async(uri, storage_options=opts)
+        except ValueError as err:
+            assert "contains dots" not in str(err)
 
     @pytest.mark.asyncio
-    async def test_bucket_without_dots_passes(self):
-        db = await lancedb.connect_async(BUCKET_WITHOUT_DOTS)
-        assert db is not None
+    async def test_bucket_without_dots_is_not_rejected(self):
+        try:
+            await lancedb.connect_async(BUCKET_WITHOUT_DOTS)
+        except ValueError as err:
+            assert "contains dots" not in str(err)

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -342,6 +342,17 @@ impl ListingDatabase {
         ))
     }
 
+    fn namespace_database_uri(table_base_uri: &str, query_string: Option<&str>) -> String {
+        if url::Url::parse(table_base_uri)
+            .map(|url| url.scheme().contains('+'))
+            .unwrap_or(false)
+            && let Some(query_string) = query_string
+        {
+            return format!("{}?{}", table_base_uri, query_string);
+        }
+        table_base_uri.to_string()
+    }
+
     async fn prepare_namespace_root(
         uri: &str,
         storage_options: &HashMap<String, String>,
@@ -569,8 +580,10 @@ impl ListingDatabase {
                     None => None,
                 };
 
+                let namespace_database_uri =
+                    Self::namespace_database_uri(&table_base_uri, query_string.as_deref());
                 let namespace_database = Self::connect_namespace_database(
-                    &table_base_uri,
+                    &namespace_database_uri,
                     options.storage_options.clone(),
                     request.namespace_client_properties.clone(),
                     request.read_consistency_interval,
@@ -2335,6 +2348,22 @@ mod tests {
         let captured =
             capture_query_like_connect(&format!("s3://bucket/prefix/?{}=mem&foo=bar", ENGINE));
         assert_eq!(captured.as_deref(), Some("foo=bar"));
+    }
+
+    #[test]
+    fn test_namespace_database_uri_preserves_commit_engine_query() {
+        assert_eq!(
+            ListingDatabase::namespace_database_uri(
+                "s3+ddb://bucket/prefix",
+                Some("ddbTableName=commit_table")
+            ),
+            "s3+ddb://bucket/prefix?ddbTableName=commit_table"
+        );
+
+        assert_eq!(
+            ListingDatabase::namespace_database_uri("s3://bucket/prefix", Some("foo=bar")),
+            "s3://bucket/prefix"
+        );
     }
 
     /// Regression: connecting via a URL-style URI (which goes through

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -342,15 +342,17 @@ impl ListingDatabase {
         ))
     }
 
-    fn namespace_database_uri(table_base_uri: &str, query_string: Option<&str>) -> String {
-        if url::Url::parse(table_base_uri)
-            .map(|url| url.scheme().contains('+'))
-            .unwrap_or(false)
-            && let Some(query_string) = query_string
-        {
-            return format!("{}?{}", table_base_uri, query_string);
-        }
-        table_base_uri.to_string()
+    fn storage_base_uri(uri: &str) -> String {
+        let Ok(mut url) = url::Url::parse(uri) else {
+            return uri.to_string();
+        };
+        url.set_query(None);
+        let Some((storage_scheme, _commit_scheme)) = url.scheme().split_once('+') else {
+            return url.to_string();
+        };
+        let storage_scheme = storage_scheme.to_string();
+        let _ = url.set_scheme(&storage_scheme);
+        url.to_string()
     }
 
     async fn prepare_namespace_root(
@@ -531,6 +533,8 @@ impl ListingDatabase {
                 // will add a trailing '?' to the url
                 url.set_query(None);
 
+                let storage_base_uri = Self::storage_base_uri(url.as_str());
+
                 let table_base_uri = if let Some(store) = engine {
                     static WARN_ONCE: std::sync::Once = std::sync::Once::new();
                     WARN_ONCE.call_once(|| {
@@ -542,8 +546,6 @@ impl ListingDatabase {
                 } else {
                     url.to_string()
                 };
-
-                let plain_uri = url.to_string();
 
                 let session = request
                     .session
@@ -561,13 +563,13 @@ impl ListingDatabase {
                 };
                 let (object_store, base_path) = ObjectStore::from_uri_and_params(
                     session.store_registry(),
-                    &plain_uri,
+                    &storage_base_uri,
                     &os_params,
                 )
                 .await?;
                 if object_store.is_local() {
-                    Self::try_create_dir(&plain_uri).context(CreateDirSnafu {
-                        path: plain_uri.clone(),
+                    Self::try_create_dir(&storage_base_uri).context(CreateDirSnafu {
+                        path: storage_base_uri.clone(),
                     })?;
                 }
 
@@ -580,10 +582,8 @@ impl ListingDatabase {
                     None => None,
                 };
 
-                let namespace_database_uri =
-                    Self::namespace_database_uri(&table_base_uri, query_string.as_deref());
                 let namespace_database = Self::connect_namespace_database(
-                    &namespace_database_uri,
+                    &storage_base_uri,
                     options.storage_options.clone(),
                     request.namespace_client_properties.clone(),
                     request.read_consistency_interval,
@@ -2351,18 +2351,20 @@ mod tests {
     }
 
     #[test]
-    fn test_namespace_database_uri_preserves_commit_engine_query() {
+    fn test_storage_base_uri_strips_commit_engine_scheme() {
         assert_eq!(
-            ListingDatabase::namespace_database_uri(
-                "s3+ddb://bucket/prefix",
-                Some("ddbTableName=commit_table")
-            ),
-            "s3+ddb://bucket/prefix?ddbTableName=commit_table"
+            ListingDatabase::storage_base_uri("s3+ddb://bucket/prefix?ddbTableName=commit_table"),
+            "s3://bucket/prefix"
         );
 
         assert_eq!(
-            ListingDatabase::namespace_database_uri("s3://bucket/prefix", Some("foo=bar")),
+            ListingDatabase::storage_base_uri("s3://bucket/prefix?foo=bar"),
             "s3://bucket/prefix"
+        );
+
+        assert_eq!(
+            ListingDatabase::storage_base_uri("/tmp/lancedb"),
+            "/tmp/lancedb"
         );
     }
 

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -1310,6 +1310,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_listing_database_root_ops_do_not_create_manifest() {
+        let tempdir = tempdir().unwrap();
+        let uri = tempdir.path().to_str().unwrap();
+
+        let request = ConnectRequest {
+            uri: uri.to_string(),
+            #[cfg(feature = "remote")]
+            client_config: Default::default(),
+            options: Default::default(),
+            namespace_client_properties: Default::default(),
+            manifest_enabled: false,
+            read_consistency_interval: None,
+            session: None,
+        };
+
+        let db = ListingDatabase::connect_with_options(&request)
+            .await
+            .unwrap();
+
+        assert!(!tempdir.path().join("__manifest").exists());
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        db.create_table(CreateTableRequest {
+            name: "root_table".to_string(),
+            namespace_path: vec![],
+            data: Box::new(RecordBatch::new_empty(schema)) as Box<dyn Scannable>,
+            mode: CreateTableMode::Create,
+            write_options: Default::default(),
+            location: None,
+            namespace_client: None,
+        })
+        .await
+        .unwrap();
+
+        db.open_table(OpenTableRequest {
+            name: "root_table".to_string(),
+            namespace_path: vec![],
+            index_cache_size: None,
+            lance_read_params: None,
+            location: None,
+            namespace_client: None,
+            managed_versioning: None,
+        })
+        .await
+        .unwrap();
+
+        #[allow(deprecated)]
+        let table_names = db.table_names(TableNamesRequest::default()).await.unwrap();
+
+        assert_eq!(table_names, vec!["root_table".to_string()]);
+        assert!(!tempdir.path().join("__manifest").exists());
+    }
+
+    #[tokio::test]
     async fn test_clone_table_basic() {
         let (_tempdir, db) = setup_database().await;
 

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -259,7 +259,7 @@ pub struct ListingDatabase {
     session: Arc<lance::session::Session>,
 
     // Namespace-backed database for child namespace operations
-    namespace_database: Arc<ListingNamespaceDatabase>,
+    namespace_database: Arc<LanceNamespaceDatabase>,
 }
 
 impl std::fmt::Display for ListingDatabase {
@@ -283,65 +283,6 @@ impl std::fmt::Display for ListingDatabase {
 const LANCE_EXTENSION: &str = "lance";
 const ENGINE: &str = "engine";
 const MIRRORED_STORE: &str = "mirroredStore";
-
-#[derive(Debug)]
-struct ListingNamespaceDatabase {
-    uri: String,
-    storage_options: HashMap<String, String>,
-    namespace_client_properties: HashMap<String, String>,
-    read_consistency_interval: Option<std::time::Duration>,
-    session: Arc<lance::session::Session>,
-    database: tokio::sync::Mutex<Option<Arc<LanceNamespaceDatabase>>>,
-}
-
-impl ListingNamespaceDatabase {
-    fn new(
-        uri: String,
-        storage_options: HashMap<String, String>,
-        namespace_client_properties: HashMap<String, String>,
-        read_consistency_interval: Option<std::time::Duration>,
-        session: Arc<lance::session::Session>,
-    ) -> Self {
-        Self {
-            uri,
-            storage_options,
-            namespace_client_properties,
-            read_consistency_interval,
-            session,
-            database: tokio::sync::Mutex::new(None),
-        }
-    }
-
-    fn namespace_client_properties(&self) -> HashMap<String, String> {
-        ListingDatabase::build_namespace_client_properties(
-            &self.uri,
-            &self.storage_options,
-            self.namespace_client_properties.clone(),
-        )
-    }
-
-    async fn get(&self) -> Result<Arc<LanceNamespaceDatabase>> {
-        let mut database = self.database.lock().await;
-        if let Some(database) = database.as_ref() {
-            return Ok(database.clone());
-        }
-
-        let initialized = ListingDatabase::connect_namespace_database(
-            &self.uri,
-            self.storage_options.clone(),
-            self.namespace_client_properties.clone(),
-            self.read_consistency_interval,
-            self.session.clone(),
-        )
-        .await?;
-        *database = Some(initialized.clone());
-        Ok(initialized)
-    }
-
-    fn namespace_client_config(&self) -> (String, HashMap<String, String>) {
-        ("dir".to_string(), self.namespace_client_properties())
-    }
-}
 
 /// A connection to LanceDB
 impl ListingDatabase {
@@ -628,13 +569,14 @@ impl ListingDatabase {
                     None => None,
                 };
 
-                let namespace_database = Arc::new(ListingNamespaceDatabase::new(
-                    table_base_uri.clone(),
+                let namespace_database = Self::connect_namespace_database(
+                    &table_base_uri,
                     options.storage_options.clone(),
                     request.namespace_client_properties.clone(),
                     request.read_consistency_interval,
                     session.clone(),
-                ));
+                )
+                .await?;
 
                 Ok(Self {
                     uri: table_base_uri,
@@ -681,13 +623,14 @@ impl ListingDatabase {
             Self::try_create_dir(path).context(CreateDirSnafu { path })?;
         }
 
-        let namespace_database = Arc::new(ListingNamespaceDatabase::new(
-            path.to_string(),
+        let namespace_database = Self::connect_namespace_database(
+            path,
             HashMap::new(),
             namespace_client_properties,
             read_consistency_interval,
             session.clone(),
-        ));
+        )
+        .await?;
 
         Ok(Self {
             uri: path.to_string(),
@@ -758,8 +701,8 @@ impl ListingDatabase {
         Ok(uri)
     }
 
-    async fn namespace_database(&self) -> Result<Arc<LanceNamespaceDatabase>> {
-        self.namespace_database.get().await
+    fn namespace_database(&self) -> Arc<LanceNamespaceDatabase> {
+        self.namespace_database.clone()
     }
 
     async fn drop_tables(&self, names: Vec<String>) -> Result<()> {
@@ -961,10 +904,7 @@ impl Database for ListingDatabase {
         &self,
         request: ListNamespacesRequest,
     ) -> Result<ListNamespacesResponse> {
-        self.namespace_database()
-            .await?
-            .list_namespaces(request)
-            .await
+        self.namespace_database().list_namespaces(request).await
     }
 
     fn uri(&self) -> &str {
@@ -987,33 +927,24 @@ impl Database for ListingDatabase {
         &self,
         request: CreateNamespaceRequest,
     ) -> Result<CreateNamespaceResponse> {
-        self.namespace_database()
-            .await?
-            .create_namespace(request)
-            .await
+        self.namespace_database().create_namespace(request).await
     }
 
     async fn drop_namespace(&self, request: DropNamespaceRequest) -> Result<DropNamespaceResponse> {
-        self.namespace_database()
-            .await?
-            .drop_namespace(request)
-            .await
+        self.namespace_database().drop_namespace(request).await
     }
 
     async fn describe_namespace(
         &self,
         request: DescribeNamespaceRequest,
     ) -> Result<DescribeNamespaceResponse> {
-        self.namespace_database()
-            .await?
-            .describe_namespace(request)
-            .await
+        self.namespace_database().describe_namespace(request).await
     }
 
     #[allow(deprecated)]
     async fn table_names(&self, request: TableNamesRequest) -> Result<Vec<String>> {
         if !request.namespace_path.is_empty() {
-            return self.namespace_database().await?.table_names(request).await;
+            return self.namespace_database().table_names(request).await;
         }
         let mut f = self
             .object_store
@@ -1046,7 +977,7 @@ impl Database for ListingDatabase {
 
     async fn list_tables(&self, request: ListTablesRequest) -> Result<ListTablesResponse> {
         if request.id.as_ref().map(|v| !v.is_empty()).unwrap_or(false) {
-            return self.namespace_database().await?.list_tables(request).await;
+            return self.namespace_database().list_tables(request).await;
         }
         let mut f = self
             .object_store
@@ -1095,7 +1026,7 @@ impl Database for ListingDatabase {
 
     async fn create_table(&self, request: CreateTableRequest) -> Result<Arc<dyn BaseTable>> {
         if !request.namespace_path.is_empty() {
-            return self.namespace_database().await?.create_table(request).await;
+            return self.namespace_database().create_table(request).await;
         }
         // Use provided location if available, otherwise derive from table name
         let table_uri = request
@@ -1213,7 +1144,7 @@ impl Database for ListingDatabase {
 
     async fn open_table(&self, mut request: OpenTableRequest) -> Result<Arc<dyn BaseTable>> {
         if !request.namespace_path.is_empty() {
-            return self.namespace_database().await?.open_table(request).await;
+            return self.namespace_database().open_table(request).await;
         }
         // Use provided location if available, otherwise derive from table name
         let table_uri = request
@@ -1311,7 +1242,6 @@ impl Database for ListingDatabase {
         if !namespace_path.is_empty() {
             return self
                 .namespace_database()
-                .await?
                 .drop_table(name, namespace_path)
                 .await;
         }
@@ -1324,7 +1254,6 @@ impl Database for ListingDatabase {
         if !namespace_path.is_empty() {
             return self
                 .namespace_database()
-                .await?
                 .drop_all_tables(namespace_path)
                 .await;
         }
@@ -1337,11 +1266,11 @@ impl Database for ListingDatabase {
     }
 
     async fn namespace_client(&self) -> Result<Arc<dyn lance_namespace::LanceNamespace>> {
-        self.namespace_database().await?.namespace_client().await
+        self.namespace_database.namespace_client().await
     }
 
     async fn namespace_client_config(&self) -> Result<(String, HashMap<String, String>)> {
-        Ok(self.namespace_database.namespace_client_config())
+        self.namespace_database.namespace_client_config().await
     }
 }
 
@@ -1401,7 +1330,6 @@ mod tests {
             .unwrap();
 
         assert!(!tempdir.path().join("__manifest").exists());
-        assert!(db.namespace_database.database.lock().await.is_none());
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         db.create_table(CreateTableRequest {
@@ -1433,12 +1361,6 @@ mod tests {
 
         assert_eq!(table_names, vec!["root_table".to_string()]);
         assert!(!tempdir.path().join("__manifest").exists());
-        assert!(db.namespace_database.database.lock().await.is_none());
-
-        let (ns_impl, properties) = db.namespace_client_config().await.unwrap();
-        assert_eq!(ns_impl, "dir");
-        assert_eq!(properties.get("root"), Some(&uri.to_string()));
-        assert!(db.namespace_database.database.lock().await.is_none());
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -259,7 +259,7 @@ pub struct ListingDatabase {
     session: Arc<lance::session::Session>,
 
     // Namespace-backed database for child namespace operations
-    namespace_database: Arc<LanceNamespaceDatabase>,
+    namespace_database: Arc<ListingNamespaceDatabase>,
 }
 
 impl std::fmt::Display for ListingDatabase {
@@ -283,6 +283,65 @@ impl std::fmt::Display for ListingDatabase {
 const LANCE_EXTENSION: &str = "lance";
 const ENGINE: &str = "engine";
 const MIRRORED_STORE: &str = "mirroredStore";
+
+#[derive(Debug)]
+struct ListingNamespaceDatabase {
+    uri: String,
+    storage_options: HashMap<String, String>,
+    namespace_client_properties: HashMap<String, String>,
+    read_consistency_interval: Option<std::time::Duration>,
+    session: Arc<lance::session::Session>,
+    database: tokio::sync::Mutex<Option<Arc<LanceNamespaceDatabase>>>,
+}
+
+impl ListingNamespaceDatabase {
+    fn new(
+        uri: String,
+        storage_options: HashMap<String, String>,
+        namespace_client_properties: HashMap<String, String>,
+        read_consistency_interval: Option<std::time::Duration>,
+        session: Arc<lance::session::Session>,
+    ) -> Self {
+        Self {
+            uri,
+            storage_options,
+            namespace_client_properties,
+            read_consistency_interval,
+            session,
+            database: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    fn namespace_client_properties(&self) -> HashMap<String, String> {
+        ListingDatabase::build_namespace_client_properties(
+            &self.uri,
+            &self.storage_options,
+            self.namespace_client_properties.clone(),
+        )
+    }
+
+    async fn get(&self) -> Result<Arc<LanceNamespaceDatabase>> {
+        let mut database = self.database.lock().await;
+        if let Some(database) = database.as_ref() {
+            return Ok(database.clone());
+        }
+
+        let initialized = ListingDatabase::connect_namespace_database(
+            &self.uri,
+            self.storage_options.clone(),
+            self.namespace_client_properties.clone(),
+            self.read_consistency_interval,
+            self.session.clone(),
+        )
+        .await?;
+        *database = Some(initialized.clone());
+        Ok(initialized)
+    }
+
+    fn namespace_client_config(&self) -> (String, HashMap<String, String>) {
+        ("dir".to_string(), self.namespace_client_properties())
+    }
+}
 
 /// A connection to LanceDB
 impl ListingDatabase {
@@ -569,14 +628,13 @@ impl ListingDatabase {
                     None => None,
                 };
 
-                let namespace_database = Self::connect_namespace_database(
-                    &table_base_uri,
+                let namespace_database = Arc::new(ListingNamespaceDatabase::new(
+                    table_base_uri.clone(),
                     options.storage_options.clone(),
                     request.namespace_client_properties.clone(),
                     request.read_consistency_interval,
                     session.clone(),
-                )
-                .await?;
+                ));
 
                 Ok(Self {
                     uri: table_base_uri,
@@ -623,14 +681,13 @@ impl ListingDatabase {
             Self::try_create_dir(path).context(CreateDirSnafu { path })?;
         }
 
-        let namespace_database = Self::connect_namespace_database(
-            path,
+        let namespace_database = Arc::new(ListingNamespaceDatabase::new(
+            path.to_string(),
             HashMap::new(),
             namespace_client_properties,
             read_consistency_interval,
             session.clone(),
-        )
-        .await?;
+        ));
 
         Ok(Self {
             uri: path.to_string(),
@@ -701,8 +758,8 @@ impl ListingDatabase {
         Ok(uri)
     }
 
-    fn namespace_database(&self) -> Arc<LanceNamespaceDatabase> {
-        self.namespace_database.clone()
+    async fn namespace_database(&self) -> Result<Arc<LanceNamespaceDatabase>> {
+        self.namespace_database.get().await
     }
 
     async fn drop_tables(&self, names: Vec<String>) -> Result<()> {
@@ -904,7 +961,10 @@ impl Database for ListingDatabase {
         &self,
         request: ListNamespacesRequest,
     ) -> Result<ListNamespacesResponse> {
-        self.namespace_database().list_namespaces(request).await
+        self.namespace_database()
+            .await?
+            .list_namespaces(request)
+            .await
     }
 
     fn uri(&self) -> &str {
@@ -927,24 +987,33 @@ impl Database for ListingDatabase {
         &self,
         request: CreateNamespaceRequest,
     ) -> Result<CreateNamespaceResponse> {
-        self.namespace_database().create_namespace(request).await
+        self.namespace_database()
+            .await?
+            .create_namespace(request)
+            .await
     }
 
     async fn drop_namespace(&self, request: DropNamespaceRequest) -> Result<DropNamespaceResponse> {
-        self.namespace_database().drop_namespace(request).await
+        self.namespace_database()
+            .await?
+            .drop_namespace(request)
+            .await
     }
 
     async fn describe_namespace(
         &self,
         request: DescribeNamespaceRequest,
     ) -> Result<DescribeNamespaceResponse> {
-        self.namespace_database().describe_namespace(request).await
+        self.namespace_database()
+            .await?
+            .describe_namespace(request)
+            .await
     }
 
     #[allow(deprecated)]
     async fn table_names(&self, request: TableNamesRequest) -> Result<Vec<String>> {
         if !request.namespace_path.is_empty() {
-            return self.namespace_database().table_names(request).await;
+            return self.namespace_database().await?.table_names(request).await;
         }
         let mut f = self
             .object_store
@@ -977,7 +1046,7 @@ impl Database for ListingDatabase {
 
     async fn list_tables(&self, request: ListTablesRequest) -> Result<ListTablesResponse> {
         if request.id.as_ref().map(|v| !v.is_empty()).unwrap_or(false) {
-            return self.namespace_database().list_tables(request).await;
+            return self.namespace_database().await?.list_tables(request).await;
         }
         let mut f = self
             .object_store
@@ -1026,7 +1095,7 @@ impl Database for ListingDatabase {
 
     async fn create_table(&self, request: CreateTableRequest) -> Result<Arc<dyn BaseTable>> {
         if !request.namespace_path.is_empty() {
-            return self.namespace_database().create_table(request).await;
+            return self.namespace_database().await?.create_table(request).await;
         }
         // Use provided location if available, otherwise derive from table name
         let table_uri = request
@@ -1144,7 +1213,7 @@ impl Database for ListingDatabase {
 
     async fn open_table(&self, mut request: OpenTableRequest) -> Result<Arc<dyn BaseTable>> {
         if !request.namespace_path.is_empty() {
-            return self.namespace_database().open_table(request).await;
+            return self.namespace_database().await?.open_table(request).await;
         }
         // Use provided location if available, otherwise derive from table name
         let table_uri = request
@@ -1242,6 +1311,7 @@ impl Database for ListingDatabase {
         if !namespace_path.is_empty() {
             return self
                 .namespace_database()
+                .await?
                 .drop_table(name, namespace_path)
                 .await;
         }
@@ -1254,6 +1324,7 @@ impl Database for ListingDatabase {
         if !namespace_path.is_empty() {
             return self
                 .namespace_database()
+                .await?
                 .drop_all_tables(namespace_path)
                 .await;
         }
@@ -1266,11 +1337,11 @@ impl Database for ListingDatabase {
     }
 
     async fn namespace_client(&self) -> Result<Arc<dyn lance_namespace::LanceNamespace>> {
-        self.namespace_database.namespace_client().await
+        self.namespace_database().await?.namespace_client().await
     }
 
     async fn namespace_client_config(&self) -> Result<(String, HashMap<String, String>)> {
-        self.namespace_database.namespace_client_config().await
+        Ok(self.namespace_database.namespace_client_config())
     }
 }
 
@@ -1330,6 +1401,7 @@ mod tests {
             .unwrap();
 
         assert!(!tempdir.path().join("__manifest").exists());
+        assert!(db.namespace_database.database.lock().await.is_none());
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         db.create_table(CreateTableRequest {
@@ -1361,6 +1433,12 @@ mod tests {
 
         assert_eq!(table_names, vec!["root_table".to_string()]);
         assert!(!tempdir.path().join("__manifest").exists());
+        assert!(db.namespace_database.database.lock().await.is_none());
+
+        let (ns_impl, properties) = db.namespace_client_config().await.unwrap();
+        assert_eq!(ns_impl, "dir");
+        assert_eq!(properties.get("root"), Some(&uri.to_string()));
+        assert!(db.namespace_database.database.lock().await.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Bumps Lance to v9.0.0-beta.19, which includes lance-format/lance#7687 for side-effect-free DirectoryNamespace read paths.

This fixes root-level read-only table opens that previously could trigger `__manifest` creation through directory namespace construction, including Hugging Face bucket reads with read-only tokens. A LanceDB regression test now covers root listing operations without creating `__manifest`.

Fixes #3633.
