### PR TITLE
fix: purge stale session metadata cache on drop_table (#3626)

### DIFF
--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -739,6 +739,27 @@ impl ListingDatabase {
                     },
                     _ => Error::from(err),
                 })?;
+
+            // Removing the files leaves the shared session's metadata cache
+            // (keyed by the dataset URI prefix, see `Session::metadata_cache`
+            // and `GlobalMetadataCache::for_dataset`) holding metadata for the
+            // now-deleted dataset. If a table is later re-created under the same
+            // URI, a mutation can resolve a stale row-id sequence and panic
+            // inside lance ("row id missing from index"). Invalidate the dropped
+            // dataset's cached metadata so the session stays consistent.
+            // See https://github.com/lancedb/lancedb/issues/3626.
+            if let Ok(table_uri) = self.table_uri(&name) {
+                // Strip any query string; lance keys the cache off the dataset
+                // path, and the `.lance` suffix makes this a safe prefix.
+                let uri_prefix = match table_uri.split_once('?') {
+                    Some((base, _)) => base,
+                    None => table_uri.as_str(),
+                };
+                self.session
+                    .file_metadata_cache()
+                    .invalidate_prefix(uri_prefix)
+                    .await;
+            }
         }
         Ok(())
     }
@@ -1307,6 +1328,60 @@ mod tests {
             .unwrap();
 
         (tempdir, db)
+    }
+
+    // Count entries in the shared session metadata cache that belong to the
+    // dataset at `table_uri` (entries are prefixed with `{uri}/`).
+    async fn metadata_cache_entries(db: &ListingDatabase, table_uri: &str) -> usize {
+        match db.session.metadata_cache_keys().await {
+            Some(keys) => keys.filter(|k| k.starts_with(table_uri)).count(),
+            None => 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_purges_session_metadata_cache() {
+        // GH#3626: drop_table removed the files but left the shared session's
+        // metadata cache holding entries for the dropped dataset's URI. A table
+        // re-created under the same URI could then resolve stale metadata and
+        // panic inside lance. Verify the cache is purged on drop.
+        let (_tempdir, db) = setup_database().await;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+
+        let table = db
+            .create_table(CreateTableRequest {
+                name: "cache_drop".to_string(),
+                namespace_path: vec![],
+                data: Box::new(batch) as Box<dyn Scannable>,
+                mode: CreateTableMode::Create,
+                write_options: Default::default(),
+                location: None,
+                namespace_client: None,
+            })
+            .await
+            .unwrap();
+        // Force a metadata read so the dataset is cached under its URI.
+        table.schema().await.unwrap();
+
+        let table_uri = db.table_uri("cache_drop").unwrap();
+        assert!(
+            metadata_cache_entries(&db, &table_uri).await > 0,
+            "expected the session metadata cache to be populated after use"
+        );
+
+        db.drop_table("cache_drop", &[]).await.unwrap();
+
+        assert_eq!(
+            metadata_cache_entries(&db, &table_uri).await,
+            0,
+            "drop_table should purge the dropped dataset's session cache entries"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #3626.

## Problem
`Connection::drop_table` (the local `ListingDatabase`) removes a table's files but never purges the shared `Session` caches. The metadata cache is namespaced only by the dataset **URI** prefix (`Session::metadata_cache` → `GlobalMetadataCache::for_dataset(uri)`), and the most damaging entry — the row-id sequence — is keyed version-less. So when a table is dropped and a new table is **re-created under the same URI**, a later mutation (DELETE/UPDATE with stable row ids) can resolve stale cached metadata from the dropped dataset and panic inside lance:

```
lance/src/dataset/utils.rs: row id missing from index
```

## Fix
`ListingDatabase::drop_tables` now invalidates the dropped dataset's cached metadata after removing its files:

```rust
if let Ok(table_uri) = self.table_uri(&name) {
    let uri_prefix = /* table_uri without any ?query suffix */;
    self.session
        .file_metadata_cache()
        .invalidate_prefix(uri_prefix)
        .await;
}
```

- Uses lance's documented public API: `Session::file_metadata_cache()` + `LanceCache::invalidate_prefix`.
- Reuses the same `table_uri(name)` that `create_table`/`open_table` pass to `DatasetBuilder::from_uri`, so the invalidation prefix matches the cache prefix exactly. The `.lance` suffix makes it a safe prefix boundary (won't touch sibling tables); any `?query` suffix is stripped since lance keys off the dataset path.

## Test
`test_drop_table_purges_session_metadata_cache` creates a table, reads it to populate the shared session metadata cache, asserts entries exist under the table's URI, drops it, and asserts the cache has **zero** entries under that URI afterwards. Fails on `main` (entries survive), passes with this change.

## Notes
- The index cache (`Session::index_cache`) is namespaced the same way but isn't exposed publicly for invalidation; the reported panic comes from the metadata cache (row-id sequence), which this addresses. Happy to extend to the index cache if lance exposes an accessor.
