### PR TITLE
chore: upgrade rust toolchain to 1.97.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.0"

--- a/rust/lancedb/src/embeddings.rs
+++ b/rust/lancedb/src/embeddings.rs
@@ -256,7 +256,7 @@ pub fn compute_output_schema(
         let field_name = ed
             .dest_column
             .clone()
-            .unwrap_or_else(|| format!("{}_embedding", &ed.source_column));
+            .unwrap_or_else(|| format!("{}_embedding", ed.source_column));
 
         sb.push(Field::new(
             field_name,
@@ -283,7 +283,7 @@ pub fn compute_embeddings_for_batch(
         let dst_field_name = fld
             .dest_column
             .clone()
-            .unwrap_or_else(|| format!("{}_embedding", &fld.source_column));
+            .unwrap_or_else(|| format!("{}_embedding", fld.source_column));
 
         let dst_field = Field::new(
             dst_field_name,
@@ -307,7 +307,7 @@ impl<R: RecordBatchReader> WithEmbeddings<R> {
                 let field_name = ed
                     .dest_column
                     .clone()
-                    .unwrap_or_else(|| format!("{}_embedding", &ed.source_column));
+                    .unwrap_or_else(|| format!("{}_embedding", ed.source_column));
                 Ok(Field::new(
                     field_name,
                     func.dest_type()?.into_owned(),

--- a/rust/lancedb/src/remote/client.rs
+++ b/rust/lancedb/src/remote/client.rs
@@ -591,7 +591,7 @@ impl<S: HttpSend> RestfulLanceDbClient<S> {
             .err_to_http(request_id.clone())?;
         debug!(
             "Received response for request_id={}: {:?}",
-            request_id, &response
+            request_id, response
         );
         Ok((request_id, response))
     }
@@ -653,7 +653,7 @@ impl<S: HttpSend> RestfulLanceDbClient<S> {
                 Ok((status, response)) if status.is_success() => {
                     debug!(
                         "Received response for request_id={}: {:?}",
-                        retry_counter.request_id, &response
+                        retry_counter.request_id, response
                     );
                     return Ok((retry_counter.request_id, response));
                 }


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.95.0 to the latest stable (1.97.0).

Rust 1.97's clippy adds `useless_borrows_in_formatting`, which flags a
redundant `&` in `format!`/`debug!` arguments in a few places. This PR
removes those to keep `cargo clippy` clean.

No behavior change; the MSRV (`rust-version = "1.91.0"`) is unchanged.