### PR TITLE
chore(rust): make lance-testing a dev-dependency

### DIFF
--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -93,8 +93,8 @@ tokenizers = { version = "0.19.1", optional = true }
 semver = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1"
 lance-testing = { workspace = true }
+anyhow = "1"
 tempfile = "3.5.0"
 random_word = { version = "0.4.3", features = ["en"] }
 tokio = { version = "1.23", features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }


### PR DESCRIPTION
Resolves #3645.

### Description
Currently, `lance-testing` is declared as a direct dependency of the `lancedb` crate, pulling in testing-specific dependencies into release builds of `lancedb`.

Since `lance-testing` is only used within test modules in `connection.rs` and `query.rs`, it can be moved to `[dev-dependencies]` to reduce compilation time and dependency footprint for production builds.

### Changes
- Moved `lance-testing` from `[dependencies]` to `[dev-dependencies]` in `rust/lancedb/Cargo.toml`.