### PR TITLE
ci(python): add win_arm64 wheel build

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -88,12 +88,32 @@ jobs:
           path: target/wheels/lancedb-*.whl
           if-no-files-found: error
   windows:
+    name: "Python windows-${{ matrix.config.platform }}"
     timeout-minutes: 90
-    runs-on: windows-latest
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      matrix:
+        config:
+          - platform: x86_64
+            runner: windows-latest
+            # Published: the publish job downloads artifacts matching `wheels-*`.
+            artifact: wheels-windows-x86_64
+          - platform: arm64
+            runner: windows-11-arm
+            # TODO(win_arm64): the `unpublished-` prefix intentionally keeps this
+            # wheel OUT of the release. The publish job downloads `wheels-*`, so
+            # `unpublished-*` is not picked up. The wheel is still uploaded (so it
+            # can be downloaded for local validation), it just isn't published,
+            # because pyarrow (a core runtime dependency) has no win_arm64 wheel
+            # on PyPI yet, so `pip install lancedb` cannot resolve pyarrow on
+            # win_arm64. Once pyarrow ships win_arm64 wheels, rename this to
+            # `wheels-windows-arm64` to include it in the release.
+            artifact: unpublished-wheels-windows-arm64
     env:
       # link.exe is single-threaded and the long pole on Windows builds. Use
       # rustc's bundled lld-link instead.
       CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld
+      CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER: rust-lld
     steps:
       - uses: actions/checkout@v6
         with:
@@ -110,7 +130,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: startsWith(github.ref, 'refs/tags/python-v')
         with:
-          name: wheels-windows
+          name: ${{ matrix.config.artifact }}
           path: target/wheels/lancedb-*.whl
           if-no-files-found: error
   publish:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -182,7 +182,11 @@ jobs:
       matrix:
         config:
           - name: x86
+            platform: x86_64
             runner: windows-latest
+          - name: arm64
+            platform: arm64
+            runner: windows-11-arm
     runs-on: "${{ matrix.config.runner }}"
     defaults:
       run:
@@ -200,7 +204,21 @@ jobs:
       - uses: ./.github/workflows/build_windows_wheel
         with:
           args: --profile ci
+      # TODO(win_arm64): run tests on the arm64 leg too once the missing test
+      # dependencies publish win_arm64 wheels. Then drop this `if` (and the
+      # `platform` matrix key if no longer needed) so run_tests runs on both legs.
+      #
+      # Tests only run on x86_64. Several test dependencies have no win_arm64
+      # wheel on PyPI, so the suite cannot run on arm64:
+      #   * pyarrow    - core runtime dependency; without it `import lancedb`
+      #                  itself fails, so the whole suite cannot run.
+      #   * pylance    - required by a subset of tests.
+      #   * datafusion - required by a subset of tests.
+      #   * polars     - the `tests` extra pins `polars<=1.3.0`, and win_arm64
+      #                  wheels only exist from 1.18.0.
+      # The arm64 leg therefore only verifies that the wheel *builds*.
       - uses: ./.github/workflows/run_tests
+        if: ${{ matrix.config.platform == 'x86_64' }}
       # Make sure wheels are not included in the Rust cache
       - name: Delete wheels
         run: rm -rf target/wheels


### PR DESCRIPTION
## Summary

Adds a Windows/ARM64 (`aarch64-pc-windows-msvc`) Python wheel build to CI and the
release workflow, folding the new target into the existing `windows` job as a
matrix leg (`x86_64` + `arm64`). The wheel builds as `cp39-abi3`, same as the
existing `win_amd64` build. Verified end-to-end on GitHub's `windows-11-arm`
runner.

## Why tests are skipped on the arm64 leg

Both legs build the wheel, but tests run on `x86_64` only. Several test
dependencies have **no `win_arm64` wheel on PyPI**, so the `[tests]` install
cannot resolve on Windows/ARM64:

| Dependency | Note |
| --- | --- |
| **pyarrow** | core runtime dep — `import lancedb` fails without it, so the whole suite cannot run |
| **pylance** | required by a subset of tests |
| **datafusion** | required by a subset of tests |
| **polars** | the `tests` extra pins `polars<=1.3.0`; arm64 wheels exist only from `1.18.0` |

For the same reason the arm64 wheel is built but **not published** yet: it is
uploaded under an `unpublished-` artifact name so the release `publish` job
(which downloads `wheels-*`) does not ship an uninstallable package.

## Validation (native `aarch64-pc-windows-msvc`)

- **CI (this PR):** the `python.yml` arm64 leg and the release build both succeed
  and produce `lancedb-0.35.0b2-cp39-abi3-win_arm64.whl`. The Linux/Mac/x86 test
  jobs pass.
- **Local run of the CI-built wheel** — the `unpublished-wheels-windows-arm64`
  artifact downloaded from this PR's release build (with a prebuilt `pyarrow`
  win_arm64 wheel + newer `polars`; `pylance`/`datafusion` tests skipped via
  `importorskip`): `pytest -m "not slow and not s3_test"` → **797 passed, 86
  skipped**, no wheel-attributable failures.
- **Rust suite** (`cargo test --features remote --tests -p lancedb`): **709 passed**.

## Future steps

Once `pyarrow` (and ideally `pylance`/`datafusion`) publish `win_arm64` wheels,
two `TODO(win_arm64)` markers point to the follow-ups:

1. **`python.yml`** — drop the `matrix.config.platform == 'x86_64'` guard on
   `run_tests` so the suite also runs on the arm64 leg.
2. **`pypi-publish.yml`** — rename the arm64 artifact from
   `unpublished-wheels-windows-arm64` to `wheels-windows-arm64` so it is included
   in releases.

from Microsoft