### PR TITLE
ci: pin ad-m/github-push-action to a full commit SHA in the release job

### DIFF
--- a/.github/workflows/make-release-commit.yml
+++ b/.github/workflows/make-release-commit.yml
@@ -87,7 +87,7 @@ jobs:
           bash ci/update_lockfiles.sh --amend
       - name: Push new version tag
         if: ${{ !inputs.dry_run }}
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           # Need to use PAT here too to trigger next workflow. See comment above.
           github_token: ${{ secrets.LANCEDB_RELEASE_TOKEN }}


### PR DESCRIPTION
Hi, and thank you for LanceDB.

Small CI supply-chain hardening. In `make-release-commit.yml`, the release job checks out with `LANCEDB_RELEASE_TOKEN` (a push-capable PAT) and its final step pushes the version tag using a third-party action pinned to a **mutable branch**:

```yaml
- name: Push new version tag
  uses: ad-m/github-push-action@master
  with:
    github_token: ${{ secrets.LANCEDB_RELEASE_TOKEN }}
```

`@master` can move after review; whatever it points at then runs with that release token in scope. This PR pins it to the commit behind the current release (`v1.3.0` → `881a6320…`), keeping the version visible as a comment. Behavior today is unchanged.

For transparency: I used AI assistance to spot and draft this; I verified the workflow and resolved the SHA myself.
