### PR TITLE
docs: link to a LanceDB-powered VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ LanceDB is a central location where developers can build, train and analyze thei
 - **Columnar Storage**: Built on the Lance columnar format for efficient storage and analytics.
 - **Seamless Integration**: Python, Node.js, Rust, and REST APIs for easy integration. Native Python and Javascript/Typescript support.
 - **Rich Ecosystem**: Integrations with [**LangChain** 🦜️🔗](https://python.langchain.com/docs/integrations/vectorstores/lancedb/), [**LlamaIndex** 🦙](https://gpt-index.readthedocs.io/en/latest/examples/vector_stores/LanceDBIndexDemo.html), Apache-Arrow, Pandas, Polars, DuckDB and more on the way.
+- **VS Code Extension Example**: [Kilo Code](https://github.com/Kilo-Org/kilocode) uses LanceDB for its [codebase indexing vector store](https://github.com/Kilo-Org/kilocode/blob/9ac93a4c904b32801982051c636dff1cdb471136/packages/kilo-indexing/src/indexing/vector-store/lancedb-vector-store.ts).
 
 ## **How to Install**:
 


### PR DESCRIPTION
## Summary

- add Kilo Code as a real-world VS Code extension example in the README ecosystem section
- link to its pinned LanceDB-backed codebase indexing implementation

## Why

This gives extension authors a concrete open-source reference for integrating LanceDB, as requested in #1849.

Closes #1849.

## Validation

- `git diff --check`
- verified the Kilo Code repository and pinned implementation links through the GitHub API

## AI disclosure

OpenAI Codex assisted with repository research, wording, and validation.
