### PR TITLE
chore: update lance dependency to v9.1.0-beta.4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,7 +98,7 @@ jobs:
           cargo build --profile ci --benches --all-features --tests
 
   linux:
-    timeout-minutes: 30
+    timeout-minutes: 60
     # To build all features, we need more disk space than is available
     # on the free OSS github runner. This is mostly due to the the
     # sentence-transformers feature.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,7 +158,7 @@ jobs:
         run: CARGO_ARGS="--profile ci" make -C ./lancedb remote-tests
 
   macos:
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         mac-runner: ["macos-14", "macos-15"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,8 +3421,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "rand 0.9.5",
@@ -4777,8 +4777,8 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lance"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -4852,8 +4852,8 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow-scalar"
 version = "58.0.0"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow-stats"
 version = "58.0.0"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4898,8 +4898,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrayref",
  "crunchy",
@@ -4909,8 +4909,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4948,8 +4948,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4979,8 +4979,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4997,8 +4997,8 @@ dependencies = [
 
 [[package]]
 name = "lance-derive"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5007,8 +5007,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -5043,8 +5043,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -5074,8 +5074,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -5141,8 +5141,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index-core"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5164,8 +5164,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -5208,8 +5208,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5225,8 +5225,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5238,8 +5238,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5293,8 +5293,8 @@ dependencies = [
 
 [[package]]
 name = "lance-select"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5309,8 +5309,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -5349,8 +5349,8 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5363,8 +5363,8 @@ dependencies = [
 
 [[package]]
 name = "lance-tokenizer"
-version = "9.0.0-rc.1"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.0.0-rc.1#cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d"
+version = "9.1.0-beta.4"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.4#3b2420bca2ac3bc33ed3ee02866f0d4c3afb8b65"
 dependencies = [
  "icu_segmenter",
  "jieba-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ categories = ["database-implementations"]
 rust-version = "1.91.0"
 
 [workspace.dependencies]
-lance = { "version" = "=9.0.0-rc.1", default-features = false, "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-core = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-datagen = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-file = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-io = { "version" = "=9.0.0-rc.1", default-features = false, "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-index = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-linalg = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace-impls = { "version" = "=9.0.0-rc.1", default-features = false, "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-table = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-testing = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-datafusion = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-encoding = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
-lance-arrow = { "version" = "=9.0.0-rc.1", "tag" = "v9.0.0-rc.1", "git" = "https://github.com/lance-format/lance.git" }
+lance = { "version" = "=9.1.0-beta.4", default-features = false, "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-core = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-datagen = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-file = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-io = { "version" = "=9.1.0-beta.4", default-features = false, "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-index = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-linalg = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace-impls = { "version" = "=9.1.0-beta.4", default-features = false, "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-table = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-testing = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-datafusion = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-encoding = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
+lance-arrow = { "version" = "=9.1.0-beta.4", "tag" = "v9.1.0-beta.4", "git" = "https://github.com/lance-format/lance.git" }
 ahash = "0.8"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arrow.version>15.0.0</arrow.version>
-        <lance-core.version>9.0.0-rc.1</lance-core.version>
+        <lance-core.version>9.1.0-beta.4</lance-core.version>
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.30.0</spotless.version>
         <spotless.java.googlejavaformat.version>1.7</spotless.java.googlejavaformat.version>

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -3886,7 +3886,7 @@ class AsyncHybridQuery(AsyncStandardQuery, AsyncVectorQueryBase):
               Take: columns="_rowid, _score, (vector), (text)"
                 CoalesceBatchesExec: target_batch_size=1024
                   GlobalLimitExec: skip=0, fetch=10
-                    MatchQuery: column=text, query=hello
+                    MatchQuery: column=text, query=[hello]
 
         Parameters
         ----------

--- a/python/python/tests/test_query.py
+++ b/python/python/tests/test_query.py
@@ -1273,7 +1273,7 @@ async def test_explain_plan_fts(table_async: AsyncTable):
     query = await table_async.search("dog", query_type="fts", fts_columns="text")
     plan = await query.explain_plan()
     # Should show FTS details (issue #2465 is now fixed)
-    assert "MatchQuery: column=text, query=dog" in plan
+    assert "MatchQuery: column=text, query=[dog]" in plan
     assert "GlobalLimitExec" in plan  # Default limit
 
     # Test FTS query with limit
@@ -1281,7 +1281,7 @@ async def test_explain_plan_fts(table_async: AsyncTable):
         "dog", query_type="fts", fts_columns="text"
     )
     plan_with_limit = await query_with_limit.limit(1).explain_plan()
-    assert "MatchQuery: column=text, query=dog" in plan_with_limit
+    assert "MatchQuery: column=text, query=[dog]" in plan_with_limit
     assert "GlobalLimitExec: skip=0, fetch=1" in plan_with_limit
 
     # Test FTS query with offset and limit
@@ -1289,7 +1289,7 @@ async def test_explain_plan_fts(table_async: AsyncTable):
         "dog", query_type="fts", fts_columns="text"
     )
     plan_with_offset = await query_with_offset.offset(1).limit(1).explain_plan()
-    assert "MatchQuery: column=text, query=dog" in plan_with_offset
+    assert "MatchQuery: column=text, query=[dog]" in plan_with_offset
     assert "GlobalLimitExec: skip=1, fetch=1" in plan_with_offset
 
 
@@ -1333,7 +1333,7 @@ async def test_explain_plan_with_filters(table_async: AsyncTable):
         "dog", query_type="fts", fts_columns="text"
     )
     plan_fts_filter = await query_fts_filter.where("id = 1").explain_plan()
-    assert "MatchQuery: column=text, query=dog" in plan_fts_filter
+    assert "MatchQuery: column=text, query=[dog]" in plan_fts_filter
     assert "LanceRead" in plan_fts_filter
     assert "full_filter=id = Int64(1)" in plan_fts_filter  # Should show filter details
 


### PR DESCRIPTION
Updates the Rust workspace Lance dependencies and Java `lance-core` from `v9.0.0-rc.1` to [`v9.1.0-beta.4`](https://github.com/lance-format/lance/releases/tag/v9.1.0-beta.4).

The new release is API-compatible with LanceDB, so no source compatibility changes are required.
