### PR TITLE
docs: document StreamingDataset connection_factory parameter

### DIFF
--- a/python/python/lancedb/streaming.py
+++ b/python/python/lancedb/streaming.py
@@ -122,6 +122,13 @@ class StreamingDataset(IterableDataset):
         are yielded.  Receives one batch at a time and must return an iterable
         whose length equals the number of rows in the batch.  When ``None``
         (the default) rows are returned as plain Python dicts.
+    connection_factory:
+        Optional callable ``(table_name: str) -> table`` used to reopen the
+        table when the dataset is unpickled in a multi-worker DataLoader
+        process.  When set, only the table name is serialised and the factory
+        reconnects in the worker without embedding credentials.  When
+        ``None`` (the default), the table's own picklable reopen state is used
+        instead.
     worker_info_override:
         If set, used in place of ``torch.utils.data.get_worker_info()`` to
         determine the DataLoader worker assignment.  Intended for unit tests


### PR DESCRIPTION
## Description

`StreamingDataset` accepts `connection_factory` (and `columns`) but the class docstring Parameters section omitted `connection_factory`.

## Fix

Document `connection_factory`: used when unpickling into multi-worker DataLoader processes to reopen the table by name without embedding credentials.

`columns` was already documented.

## Linked Issue

Closes #3693
