### PR TITLE
chore: update lance dependency to v9.1.0-beta.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,8 +3421,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "rand 0.9.5",
@@ -4777,8 +4777,8 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lance"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -4852,8 +4852,8 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow-scalar"
 version = "58.0.0"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "lance-arrow-stats"
 version = "58.0.0"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4898,8 +4898,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrayref",
  "crunchy",
@@ -4909,8 +4909,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4948,8 +4948,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4979,8 +4979,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4997,8 +4997,8 @@ dependencies = [
 
 [[package]]
 name = "lance-derive"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5007,8 +5007,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -5043,8 +5043,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -5074,8 +5074,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -5141,8 +5141,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index-core"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5164,8 +5164,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -5208,8 +5208,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5225,8 +5225,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5238,8 +5238,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5293,8 +5293,8 @@ dependencies = [
 
 [[package]]
 name = "lance-select"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5309,8 +5309,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -5349,8 +5349,8 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5363,8 +5363,8 @@ dependencies = [
 
 [[package]]
 name = "lance-tokenizer"
-version = "9.1.0-beta.5"
-source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.5#0f3a4eea3ffed49b271086f2c179d924b389399e"
+version = "9.1.0-beta.7"
+source = "git+https://github.com/lance-format/lance.git?tag=v9.1.0-beta.7#4b6a69a1279c62600bd00c858d2002f53c801bd4"
 dependencies = [
  "icu_segmenter",
  "jieba-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ categories = ["database-implementations"]
 rust-version = "1.91.0"
 
 [workspace.dependencies]
-lance = { "version" = "=9.1.0-beta.5", default-features = false, "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-core = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-datagen = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-file = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-io = { "version" = "=9.1.0-beta.5", default-features = false, "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-index = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-linalg = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-namespace-impls = { "version" = "=9.1.0-beta.5", default-features = false, "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-table = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-testing = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-datafusion = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-encoding = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
-lance-arrow = { "version" = "=9.1.0-beta.5", "tag" = "v9.1.0-beta.5", "git" = "https://github.com/lance-format/lance.git" }
+lance = { "version" = "=9.1.0-beta.7", default-features = false, "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-core = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-datagen = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-file = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-io = { "version" = "=9.1.0-beta.7", default-features = false, "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-index = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-linalg = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-namespace-impls = { "version" = "=9.1.0-beta.7", default-features = false, "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-table = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-testing = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-datafusion = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-encoding = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
+lance-arrow = { "version" = "=9.1.0-beta.7", "tag" = "v9.1.0-beta.7", "git" = "https://github.com/lance-format/lance.git" }
 ahash = "0.8"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arrow.version>15.0.0</arrow.version>
-        <lance-core.version>9.1.0-beta.5</lance-core.version>
+        <lance-core.version>9.1.0-beta.7</lance-core.version>
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.30.0</spotless.version>
         <spotless.java.googlejavaformat.version>1.7</spotless.java.googlejavaformat.version>


### PR DESCRIPTION
Updates the Rust workspace Lance dependencies and Java lance-core from v9.1.0-beta.5 to v9.1.0-beta.7, including the generated Cargo lockfile. No LanceDB compatibility changes were required for this release. See the [Lance v9.1.0-beta.7 release](https://github.com/lance-format/lance/releases/tag/v9.1.0-beta.7).
