### PR TITLE
ci: use thin LTO and a larger runner for the Windows wheel build

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -108,7 +108,7 @@ jobs:
           if-no-files-found: error
   windows:
     timeout-minutes: 90
-    runs-on: windows-2025-8x-x64
+    runs-on: windows-latest
     env:
       # link.exe is single-threaded and the long pole on Windows builds. Use
       # rustc's bundled lld-link instead.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -108,11 +108,17 @@ jobs:
           if-no-files-found: error
   windows:
     timeout-minutes: 90
-    runs-on: windows-latest
+    runs-on: windows-2025-8x-x64
     env:
       # link.exe is single-threaded and the long pole on Windows builds. Use
       # rustc's bundled lld-link instead.
       CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld
+      # Fat LTO of the cdylib is single-threaded and the peak-memory step of the
+      # build. ThinLTO parallelizes it across the runner's cores, at some cost
+      # to runtime performance on our least performance-sensitive platform.
+      # Matches what the nodejs Windows builds already do in npm-publish.yml.
+      CARGO_PROFILE_RELEASE_LTO: thin
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The Windows wheel job is the slowest job in the PyPI release workflow. Fat LTO of the cdylib is single-threaded and the peak-memory step of the build, so it does not get faster with more cores — and it has already caused rustc-LLVM OOM on the Windows runners for the nodejs builds.

Switch the job to thin LTO with 16 codegen units on a `windows-2025-8x-x64` runner, trading some runtime performance on our least performance-sensitive platform for build time. This matches what the nodejs Windows builds in `npm-publish.yml` already do.

`pypi-publish.yml` is in this workflow's `pull_request` paths filter, so this PR triggers a dry-run build that shows the new timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)