### PR TITLE
feat(python): add setup_time property to StreamingDataset

### DIFF
--- a/python/python/lancedb/streaming.py
+++ b/python/python/lancedb/streaming.py
@@ -206,6 +206,10 @@ class StreamingDataset(IterableDataset):
 
         # Build the permutation table once, deterministically.
         builder = permutation_builder(table)
+
+        # Time the full setup: filter configuration + split/shuffle execution.
+        # Set once during __init__; immutable thereafter.
+        t0 = time.perf_counter()
         if filter is not None:
             builder = builder.filter(filter)
         if shuffle:
@@ -215,6 +219,7 @@ class StreamingDataset(IterableDataset):
             ).execute()
         else:
             self._perm_table = builder.split_sequential(fixed=num_splits).execute()
+        self._setup_time = time.perf_counter() - t0
 
         # Contiguous block of global split indices assigned to this rank.
         splits_per_rank = num_splits // world_size
@@ -469,6 +474,17 @@ class StreamingDataset(IterableDataset):
         if self._raw_batches_ref is not None:
             return self._transform_time
         return self._worker_stats[6] / 1_000_000
+
+    @property
+    def setup_time(self) -> float:
+        """Seconds spent building the permutation table during construction.
+
+        Includes applying any configured filter to identify matching row IDs
+        and shuffling/distributing rows across splits.  A high value when a
+        filter is configured suggests that adding an index on the filter
+        column(s) may improve setup time.
+        """
+        return self._setup_time
 
     @property
     def raw_queue_depth(self) -> int:

--- a/python/python/tests/test_elastic_dataloader.py
+++ b/python/python/tests/test_elastic_dataloader.py
@@ -1680,3 +1680,52 @@ def test_doc_example_checkpoint(lance_table):
     assert sorted(consumed + remaining_original) == list(range(NUM_ROWS)), (
         "Consumed + remaining must cover every row exactly once"
     )
+
+
+# ---------------------------------------------------------------------------
+# Setup time reporting tests (issue #3692)
+# ---------------------------------------------------------------------------
+
+
+def test_setup_timing_without_filter(lance_table):
+    """setup_time should be positive even without a filter."""
+    ds = StreamingDataset(lance_table, num_splits=NUM_SPLITS, shuffle_seed=SHUFFLE_SEED)
+    assert isinstance(ds.setup_time, float)
+    assert ds.setup_time > 1e-6
+
+
+def test_setup_timing_with_filter(lance_table):
+    """setup_time should be positive when a filter is set."""
+    ds = StreamingDataset(
+        lance_table,
+        num_splits=NUM_SPLITS,
+        shuffle_seed=SHUFFLE_SEED,
+        filter="id < 60",
+    )
+    assert isinstance(ds.setup_time, float)
+    assert ds.setup_time > 1e-6
+
+
+def test_setup_timing_empty_filter_result(lance_table):
+    """Construction raises ValueError when filter matches fewer rows than splits."""
+    with pytest.raises(ValueError, match="only 0 rows are available"):
+        StreamingDataset(
+            lance_table,
+            num_splits=NUM_SPLITS,
+            shuffle_seed=SHUFFLE_SEED,
+            filter="id < 0",
+        )
+
+
+def test_setup_time_survives_pickle(lance_table):
+    """setup_time must be preserved across DataLoader worker serialization."""
+    ds = StreamingDataset(lance_table, num_splits=NUM_SPLITS, shuffle_seed=SHUFFLE_SEED)
+    original_setup_time = ds.setup_time
+    state = ds.__getstate__()
+    assert "_setup_time" in state
+    assert state["_setup_time"] == original_setup_time
+
+    # Simulate DataLoader worker restore
+    restored = StreamingDataset.__new__(StreamingDataset)
+    restored.__setstate__(state)
+    assert restored.setup_time == original_setup_time


### PR DESCRIPTION
## Summary
- Adds `setup_time` property to `StreamingDataset` that reports seconds
  spent building the permutation table during `__init__`
- Measures filter configuration + split/shuffle execution in a single
  `time.perf_counter()` window
- Property is immutable after construction, serializes naturally via
  existing `__getstate__`/`__setstate__`

## Test plan
- [x] `test_setup_timing_without_filter` — positive value without filter
- [x] `test_setup_timing_with_filter` — positive value with filter
- [x] `test_setup_timing_empty_filter_result` — ValueError on zero rows
- [x] `test_setup_time_survives_pickle` — survives DataLoader serialization

## Files changed:
- python/python/lancedb/streaming.py — added setup_time property + timing in __init__                                                                                                                                                                                             
- python/python/tests/test_elastic_dataloader.py — added 4 test cases

Closes #3692