### PR TITLE
fix(node): reject non-string Arrow metadata

### DIFF
--- a/nodejs/__test__/arrow.test.ts
+++ b/nodejs/__test__/arrow.test.ts
@@ -991,6 +991,37 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
 
         expectValidMapField(roundTripped.schema.fields[0]);
       });
+
+      it("preserves string schema metadata", function () {
+        const metadata = new Map([["source", "fixture"]]);
+        const schema = new Schema(
+          [new Field("value", new Int32(), true)],
+          metadata,
+        );
+
+        expect(makeEmptyTable(schema).schema.metadata.get("source")).toBe(
+          "fixture",
+        );
+      });
+
+      it.each([
+        ["non-string keys", new Map<unknown, unknown>([[42, "fixture"]])],
+        ["non-string values", new Map<unknown, unknown>([["source", 42]])],
+        [
+          "non-string keys and values",
+          new Map<unknown, unknown>([[42, false]]),
+        ],
+      ])("rejects schema metadata with %s", function (_, metadataLike) {
+        const metadata = metadataLike as unknown as Map<string, string>;
+        const schema = new Schema(
+          [new Field("value", new Int32(), true)],
+          metadata,
+        );
+
+        expect(() => makeEmptyTable(schema)).toThrow(
+          "Expected metadata, if present, to be a Map<string, string> but it had non-string keys or values",
+        );
+      });
     });
 
     describe("when using two versions of arrow", function () {

--- a/nodejs/lancedb/sanitize.ts
+++ b/nodejs/lancedb/sanitize.ts
@@ -84,7 +84,7 @@ export function sanitizeMetadata(
     throw Error("Expected metadata, if present, to be a Map<string, string>");
   }
   for (const item of metadataLike) {
-    if (!(typeof item[0] === "string" || !(typeof item[1] === "string"))) {
+    if (typeof item[0] !== "string" || typeof item[1] !== "string") {
       throw Error(
         "Expected metadata, if present, to be a Map<string, string> but it had non-string keys or values",
       );


### PR DESCRIPTION
## Summary

- validate Arrow metadata keys and values independently at runtime
- reject malformed foreign schemas before constructing a local Arrow schema
- cover valid and invalid metadata entries across Arrow 15–18

## Testing

- `node_modules/.bin/jest --runInBand __test__/arrow.test.ts -t "schema metadata"`
- `node_modules/.bin/jest --runInBand __test__/arrow.test.ts`
- `node node_modules/@biomejs/biome/bin/biome format --write lancedb/sanitize.ts __test__/arrow.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm run docs`

Fixes #3729