### PR TITLE
fix(python): log when storage_options is ignored in RemoteDBConnection.open_table

### DIFF
--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -415,6 +415,11 @@ class RemoteDBConnection(DBConnection):
 
         if namespace_path is None:
             namespace_path = []
+        if storage_options is not None:
+            logging.info(
+                "storage_options is ignored in LanceDb Cloud"
+                " (storage is managed; set storage_options on connect() instead)"
+            )
         if index_cache_size is not None:
             logging.info(
                 "index_cache_size is ignored in LanceDb Cloud"


### PR DESCRIPTION

`RemoteDBConnection.open_table` accepts `storage_options` and never uses it:

```python
def open_table(
    self,
    name: str,
    *,
    namespace_path: Optional[List[str]] = None,
    storage_options: Optional[Dict[str, str]] = None,
    index_cache_size: Optional[int] = None,
    ...
) -> Table:
    ...
    if index_cache_size is not None:
        logging.info("index_cache_size is ignored in LanceDb Cloud ...")

    table = LOOP.run(self._conn.open_table(name, namespace_path=namespace_path))
```

The value is never passed down and never mentioned. `index_cache_size` is ignored on Cloud in the
same way, but it says so.

I checked this at runtime on 0.34.0, not just by reading it: swapping the inner connection for a
recorder, `open_table("t", storage_options={...})` hands the layer below `['namespace_path']` and
nothing else, no log record is emitted, and the same probe shows `index_cache_size` producing its
message as expected.

This adds the matching log line, so the two ignored parameters behave the same way. `ruff check` and
`ruff format --check` are clean on the file.

A note on severity. This is not a security hole and nothing is exposed. Someone passing credentials
there gets silence instead of an error, and finds out later.

One thing I am unsure about, and it changes the fix. I have assumed per-table storage options are
meaningless on Cloud, which is what the `index_cache_size` line next to it implies about managed
storage. If they are supposed to work, then the right change is to pass them through to
`self._conn.open_table` instead and this patch is the wrong one. Happy to redo it that way.

I did not check whether `create_table` or the async connection have the same gap.
