### PR TITLE
test(python): fail when the API reference misses a public symbol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,11 @@ module-level functions have to be added explicitly. How depends on the module:
   listed symbol by symbol. Add a `::: lancedb.<module>.<Name>` line to the matching
   section, and remember that the page separates synchronous and asynchronous APIs.
 
-Deliberately undocumented: concrete implementations reached through an abstract base
-(`LanceTable`, `LanceDBConnection`, `RemoteDBConnection`), query base classes already
-covered by `inherited_members`, and internal helpers.
+`python/python/tests/test_api_reference.py` enforces this and will fail if you miss a
+symbol. Anything deliberately left out belongs in that test's
+`INTENTIONALLY_UNDOCUMENTED` set, with a reason: concrete implementations reached
+through an abstract base (`LanceTable`, `LanceDBConnection`, `RemoteDBConnection`),
+query base classes already covered by `inherited_members`, and internal helpers.
 
 Cross-references in docstrings use mkdocstrings syntax, `[text][lancedb.table.Table]`.
 Plain relative links such as `[Table](Table)` do not resolve. To check your work:

--- a/docs/src/python/python.md
+++ b/docs/src/python/python.md
@@ -210,6 +210,8 @@ instead of being materialized with the rest of the row.
 
 ::: lancedb.permutation.Permutation
 
+::: lancedb.permutation.Permutations
+
 ::: lancedb.permutation.Transforms
 
 ## Reranking
@@ -253,9 +255,6 @@ lists the indices that LanceDb supports.
     options:
       show_root_heading: false
       show_root_toc_entry: false
-      # `lang_mapping` is defined in the module rather than imported, so it is
-      # picked up despite not being in `__all__`. It is an internal lookup table.
-      filters: ["!^_", "!^lang_mapping$"]
 
 ::: lancedb.table.IndexStatistics
 

--- a/python/python/lancedb/_blob.py
+++ b/python/python/lancedb/_blob.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Optional, Union
 import pyarrow as pa
 
 from .expr import Expr
-from .schema import blob_v2_column_paths
+from .schema import _blob_v2_column_paths
 from .types import BlobMode, QueryProjection, QueryProjectionSpec
 from .util import get_uri_scheme
 
@@ -139,7 +139,7 @@ def blob_v2_projection_sources(
     schema: pa.Schema,
     projection: QueryProjection,
 ) -> dict[str, str]:
-    blob_columns = blob_v2_column_paths(schema)
+    blob_columns = _blob_v2_column_paths(schema)
     if not blob_columns:
         return {}
     columns = set(blob_columns)
@@ -160,7 +160,7 @@ def v2_projection_needs_row_id(
 ) -> bool:
     if with_row_id:
         return False
-    return projection_includes_blob_column(projection, blob_v2_column_paths(schema))
+    return projection_includes_blob_column(projection, _blob_v2_column_paths(schema))
 
 
 def blob_auto_row_id_for_scan(

--- a/python/python/lancedb/arrow.py
+++ b/python/python/lancedb/arrow.py
@@ -4,7 +4,7 @@
 from functools import singledispatch
 from typing import List, Optional, Tuple, Union
 
-from lancedb.pydantic import LanceModel, model_to_dict
+from lancedb.pydantic import LanceModel, _model_to_dict
 import pyarrow as pa
 
 from ._lancedb import RecordBatchStream
@@ -107,7 +107,7 @@ def _arrow_from_list(data: list) -> pa.Table:
 
     if isinstance(data[0], LanceModel):
         schema = data[0].__class__.to_arrow_schema()
-        dicts = [model_to_dict(d) for d in data]
+        dicts = [_model_to_dict(d) for d in data]
         return pa.Table.from_pylist(dicts, schema=schema)
 
     return pa.Table.from_pylist(data)

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -49,7 +49,7 @@ from .table import (
     AsyncTable,
     LanceTable,
     Table,
-    sanitize_create_table,
+    _sanitize_create_table,
 )
 from .util import (
     get_uri_scheme,
@@ -1597,7 +1597,7 @@ class AsyncConnection(object):
         if fill_value is None:
             fill_value = 0.0
 
-        data, schema = sanitize_create_table(
+        data, schema = _sanitize_create_table(
             data, schema, metadata, on_bad_vectors, fill_value
         )
         validate_schema(schema)

--- a/python/python/lancedb/embeddings/jinaai.py
+++ b/python/python/lancedb/embeddings/jinaai.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 API_URL = "https://api.jina.ai/v1/embeddings"
 
 
-def is_valid_url(text):
+def _is_valid_url(text):
     try:
         parsed = urlparse(text)
         return bool(parsed.scheme) and bool(parsed.netloc)
@@ -129,7 +129,7 @@ class JinaEmbeddings(EmbeddingFunction):
             The query to embed. A query can be either text or an image.
         """
         if isinstance(query, str):
-            if not is_valid_url(query):
+            if not _is_valid_url(query):
                 return self.generate_text_embeddings([query])
             else:
                 return [self.generate_image_embedding(query)]
@@ -155,7 +155,7 @@ class JinaEmbeddings(EmbeddingFunction):
 
         def process_input(input, model_inputs, image_inputs):
             if isinstance(input, str):
-                if not is_valid_url(input):
+                if not _is_valid_url(input):
                     model_inputs.append({"text": input})
                 else:
                     image_inputs += 1

--- a/python/python/lancedb/embeddings/voyageai.py
+++ b/python/python/lancedb/embeddings/voyageai.py
@@ -40,7 +40,7 @@ VOYAGE_TOTAL_TOKEN_LIMITS = {
 BATCH_SIZE = 1000
 
 
-def is_valid_url(text):
+def _is_valid_url(text):
     try:
         parsed = urlparse(text)
         return bool(parsed.scheme) and bool(parsed.netloc)
@@ -51,23 +51,23 @@ def is_valid_url(text):
 VIDEO_EXTENSIONS = {".mp4", ".webm", ".mov", ".avi", ".mkv", ".m4v", ".gif"}
 
 
-def is_video_url(url: str) -> bool:
+def _is_video_url(url: str) -> bool:
     """Check if URL points to a video file based on extension."""
     parsed = urlparse(url)
     path = parsed.path.lower()
     return any(path.endswith(ext) for ext in VIDEO_EXTENSIONS)
 
 
-def is_video_path(path: Path) -> bool:
+def _is_video_path(path: Path) -> bool:
     """Check if file path is a video file based on extension."""
     return path.suffix.lower() in VIDEO_EXTENSIONS
 
 
-def transform_input(input_data: Union[str, bytes, Path]):
+def _transform_input(input_data: Union[str, bytes, Path]):
     PIL_Image = attempt_import_or_raise("PIL.Image", "pillow")
     if isinstance(input_data, str):
-        if is_valid_url(input_data):
-            if is_video_url(input_data):
+        if _is_valid_url(input_data):
+            if _is_video_url(input_data):
                 content = {"type": "video_url", "video_url": input_data}
             else:
                 content = {"type": "image_url", "image_url": input_data}
@@ -91,7 +91,7 @@ def transform_input(input_data: Union[str, bytes, Path]):
             "image_base64": "data:image/jpeg;base64," + img_str,
         }
     elif isinstance(input_data, Path):
-        if is_video_path(input_data):
+        if _is_video_path(input_data):
             # Read video file and encode as base64
             with open(input_data, "rb") as f:
                 video_bytes = f.read()
@@ -115,7 +115,7 @@ def transform_input(input_data: Union[str, bytes, Path]):
     return {"content": [content]}
 
 
-def sanitize_multimodal_input(inputs: Union[TEXT, IMAGES]) -> List[Any]:
+def _sanitize_multimodal_input(inputs: Union[TEXT, IMAGES]) -> List[Any]:
     """
     Sanitize the input to the embedding function.
     """
@@ -136,10 +136,10 @@ def sanitize_multimodal_input(inputs: Union[TEXT, IMAGES]) -> List[Any]:
     if not all(isinstance(x, (str, bytes, Path, PIL_Image.Image)) for x in inputs):
         raise ValueError("Each input should be either str, bytes, Path or Image.")
 
-    return [transform_input(i) for i in inputs]
+    return [_transform_input(i) for i in inputs]
 
 
-def sanitize_text_input(inputs: TEXT) -> List[str]:
+def _sanitize_text_input(inputs: TEXT) -> List[str]:
     """
     Sanitize the input to the embedding function.
     """
@@ -336,7 +336,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
 
         # For multimodal models, check if inputs contain images
         if self._is_multimodal_model(self.name):
-            sanitized = sanitize_multimodal_input(inputs)
+            sanitized = _sanitize_multimodal_input(inputs)
             has_images = any(
                 inp["content"][0].get("type") != "text" for inp in sanitized
             )
@@ -350,7 +350,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
             # Extract texts for batching
             inputs = [inp["content"][0]["text"] for inp in sanitized]
         else:
-            inputs = sanitize_text_input(inputs)
+            inputs = _sanitize_text_input(inputs)
 
         # Use batching for all text inputs
         return self._embed_with_batching(
@@ -428,7 +428,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
             multimodal_kwargs = self._get_multimodal_kwargs(**kwargs)
 
             def embed_batch(batch: List[str]) -> List[np.array]:
-                batch_inputs = sanitize_multimodal_input(batch)
+                batch_inputs = _sanitize_multimodal_input(batch)
                 result = client.multimodal_embed(
                     inputs=batch_inputs,
                     model=self.name,

--- a/python/python/lancedb/index.py
+++ b/python/python/lancedb/index.py
@@ -9,7 +9,7 @@ from ._lancedb import (
 )
 from .types import BaseTokenizerType
 
-lang_mapping = {
+_lang_mapping = {
     "ar": "Arabic",
     "da": "Danish",
     "du": "Dutch",

--- a/python/python/lancedb/pydantic.py
+++ b/python/python/lancedb/pydantic.py
@@ -272,7 +272,7 @@ def _py_type_to_arrow_type(py_type: Type[Any], field: FieldInfo) -> pa.DataType:
     elif py_type is date:
         return pa.date32()
     elif py_type is datetime:
-        tz = get_extras(field, "tz")
+        tz = _get_extras(field, "tz")
         return pa.timestamp("us", tz=tz)
     elif getattr(py_type, "__origin__", None) in (list, tuple):
         # A bare, unparameterised ``typing.List`` / ``typing.Tuple`` matches this
@@ -382,7 +382,7 @@ def _pydantic_to_arrow_type(field: FieldInfo) -> pa.DataType:
     return _pydantic_type_to_arrow_type(field.annotation, field)
 
 
-def is_nullable(field: FieldInfo) -> bool:
+def _is_nullable(field: FieldInfo) -> bool:
     """Check if a Pydantic FieldInfo is nullable."""
     if _unwrap_optional_annotation(field.annotation) is not None:
         return True
@@ -409,7 +409,7 @@ def is_nullable(field: FieldInfo) -> bool:
 def _pydantic_to_field(name: str, field: FieldInfo) -> pa.Field:
     """Convert a Pydantic field to a PyArrow Field."""
     dt = _pydantic_to_arrow_type(field)
-    return pa.field(name, dt, is_nullable(field))
+    return pa.field(name, dt, _is_nullable(field))
 
 
 def pydantic_to_schema(model: Type[pydantic.BaseModel]) -> pa.Schema:
@@ -512,14 +512,14 @@ class LanceModel(pydantic.BaseModel):
 
         vec_and_function = []
         for name, field_info in cls.safe_get_fields().items():
-            func = get_extras(field_info, "vector_column_for")
+            func = _get_extras(field_info, "vector_column_for")
             if func is not None:
                 vec_and_function.append([name, func])
 
         configs = []
         for vec, func in vec_and_function:
             for source, field_info in cls.safe_get_fields().items():
-                src_func = get_extras(field_info, "source_column_for")
+                src_func = _get_extras(field_info, "source_column_for")
                 if src_func is func:
                     # note we can't use == here since the function is a pydantic
                     # model so two instances of the same function are ==, so if you
@@ -534,7 +534,7 @@ class LanceModel(pydantic.BaseModel):
         return configs
 
 
-def get_extras(field_info: FieldInfo, key: str) -> Any:
+def _get_extras(field_info: FieldInfo, key: str) -> Any:
     """
     Get the extra metadata from a Pydantic FieldInfo.
     """
@@ -545,7 +545,7 @@ def get_extras(field_info: FieldInfo, key: str) -> Any:
 
 if PYDANTIC_VERSION.major < 2:
 
-    def model_to_dict(model: pydantic.BaseModel) -> Dict[str, Any]:
+    def _model_to_dict(model: pydantic.BaseModel) -> Dict[str, Any]:
         """
         Convert a Pydantic model to a dictionary.
         """
@@ -553,7 +553,7 @@ if PYDANTIC_VERSION.major < 2:
 
 else:
 
-    def model_to_dict(model: pydantic.BaseModel) -> Dict[str, Any]:
+    def _model_to_dict(model: pydantic.BaseModel) -> Dict[str, Any]:
         """
         Convert a Pydantic model to a dictionary.
         """

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -41,7 +41,7 @@ from .expr import Expr
 from .rerankers.base import Reranker
 from .rerankers.rrf import RRFReranker
 from .rerankers.util import check_reranker_result
-from .schema import is_blob_like_field, schema_has_blob_field
+from .schema import _is_blob_like_field, _schema_has_blob_field
 from .util import flatten_columns
 from ._blob import (
     BLOB_MODE_TO_HANDLING,
@@ -97,7 +97,7 @@ class _LanceScanner(Protocol):
 
 
 def _blob_mode_requires_native_pandas(blob_mode: BlobMode, schema: pa.Schema) -> bool:
-    return blob_mode in BLOB_MODE_TO_HANDLING and schema_has_blob_field(schema)
+    return blob_mode in BLOB_MODE_TO_HANDLING and _schema_has_blob_field(schema)
 
 
 def _unsupported_blob_pandas_error(reason: str) -> RuntimeError:
@@ -219,11 +219,11 @@ def _scanner_fragments_for_query(query: Query, dataset: Optional[Any]) -> Option
 def _ensure_lazy_blob_frame(
     df: "pd.DataFrame", schema: pa.Schema, blob_mode: BlobMode
 ) -> "pd.DataFrame":
-    if blob_mode != "lazy" or not schema_has_blob_field(schema) or len(df) == 0:
+    if blob_mode != "lazy" or not _schema_has_blob_field(schema) or len(df) == 0:
         return df
 
     for field in schema:
-        if not is_blob_like_field(field) or field.name not in df.columns:
+        if not _is_blob_like_field(field) or field.name not in df.columns:
             continue
         value = df[field.name].iloc[0]
         if value is not None and not hasattr(value, "readall"):
@@ -266,7 +266,7 @@ def _scanner_to_pandas(
         return df
 
     tbl = _scanner_to_table(scanner)
-    if blob_mode == "lazy" and schema_has_blob_field(tbl.schema):
+    if blob_mode == "lazy" and _schema_has_blob_field(tbl.schema):
         raise _unsupported_blob_pandas_error(
             "the Lance scanner does not expose to_pandas"
         )
@@ -332,7 +332,7 @@ async def _finish_plain_scan_pandas_async(
 
 
 # Pydantic validation function for vector queries
-def ensure_vector_query(
+def _ensure_vector_query(
     val: Any,
 ) -> Union[List[float], List[List[float]], pa.Array, List[pa.Array]]:
     if isinstance(val, list):
@@ -721,7 +721,7 @@ class Query(pydantic.BaseModel):
     # path though in the future we should unify this to pa.Array everywhere
     vector: Annotated[
         Optional[Union[List[float], List[List[float]], pa.Array, List[pa.Array]]],
-        ensure_vector_query,
+        _ensure_vector_query,
     ] = None
 
     # sql filter or type-safe Expr to refine the query with

--- a/python/python/lancedb/remote/__init__.py
+++ b/python/python/lancedb/remote/__init__.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 from lancedb import __version__
 
-from .header import HeaderProvider
+from .header import HeaderProvider, OAuthProvider, StaticHeaderProvider
 from .oauth import OAuthConfig, OAuthFlowType
 
 # The API reference renders this module with a single mkdocstrings directive,
@@ -20,6 +20,8 @@ __all__ = [
     "TlsConfig",
     "ClientConfig",
     "HeaderProvider",
+    "StaticHeaderProvider",
+    "OAuthProvider",
     "OAuthConfig",
     "OAuthFlowType",
 ]

--- a/python/python/lancedb/schema.py
+++ b/python/python/lancedb/schema.py
@@ -71,7 +71,7 @@ def _metadata_marks_legacy_blob(metadata: dict) -> bool:
     return _metadata_value(metadata, _BLOB_V1_KEY) in ("true", b"true")
 
 
-def is_blob_v2_field(field: pa.Field) -> bool:
+def _is_blob_v2_field(field: pa.Field) -> bool:
     """Return True if `field` declares a blob v2 extension column."""
     field_type = field.type
     if (
@@ -82,14 +82,14 @@ def is_blob_v2_field(field: pa.Field) -> bool:
     return _metadata_marks_blob_v2(field.metadata or {})
 
 
-def is_blob_like_field(field: pa.Field) -> bool:
+def _is_blob_like_field(field: pa.Field) -> bool:
     """Blob detection for ``to_pandas(blob_mode=...)`` and scanner paths only.
 
     Matches v2 extension fields on table schema, legacy ``lance-encoding:blob``
     storage columns, and v2 query descriptor fields (the engine tags those with
     the same metadata). Not used for fetch or auto ``_rowid``.
     """
-    return is_blob_v2_field(field) or _metadata_marks_legacy_blob(field.metadata or {})
+    return _is_blob_v2_field(field) or _metadata_marks_legacy_blob(field.metadata or {})
 
 
 def _collect_blob_paths(schema: pa.Schema, is_blob) -> list[str]:
@@ -113,17 +113,17 @@ def _collect_blob_paths(schema: pa.Schema, is_blob) -> list[str]:
     return paths
 
 
-def blob_column_paths(schema: pa.Schema) -> list[str]:
+def _blob_column_paths(schema: pa.Schema) -> list[str]:
     """Dotted paths of blob-like columns (v2 extension or legacy metadata)."""
-    return _collect_blob_paths(schema, is_blob_like_field)
+    return _collect_blob_paths(schema, _is_blob_like_field)
 
 
-def blob_v2_column_paths(schema: pa.Schema) -> list[str]:
-    return _collect_blob_paths(schema, is_blob_v2_field)
+def _blob_v2_column_paths(schema: pa.Schema) -> list[str]:
+    return _collect_blob_paths(schema, _is_blob_v2_field)
 
 
-def schema_has_blob_field(schema: pa.Schema) -> bool:
-    return bool(blob_column_paths(schema))
+def _schema_has_blob_field(schema: pa.Schema) -> bool:
+    return bool(_blob_column_paths(schema))
 
 
 def blob(name: str, nullable: bool = True) -> pa.Field:

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -72,7 +72,7 @@ from .index import (
 )
 from .expr import Expr
 from .merge import LanceMergeInsertBuilder
-from .pydantic import LanceModel, model_to_dict
+from .pydantic import LanceModel, _model_to_dict
 from .query import (
     AnalyzePlanDistributedMetrics,
     AsyncFTSQuery,
@@ -97,8 +97,8 @@ from .util import (
     join_uri,
     value_to_sql,
 )
-from .index import lang_mapping
-from .schema import blob_v2_column_paths, schema_has_blob_field
+from .index import _lang_mapping
+from .schema import _blob_v2_column_paths, _schema_has_blob_field
 
 
 def _should_push_down_query_table(
@@ -140,7 +140,7 @@ def _maybe_add_fts_error_note(
 ) -> None:
     message = str(exception)
     if language is not None and "not support the requested language" in message:
-        supported_langs = ", ".join(lang_mapping.values())
+        supported_langs = ", ".join(_lang_mapping.values())
         _add_unique_note(exception, f"Supported languages: {supported_langs}")
         return
 
@@ -249,7 +249,7 @@ def _into_pyarrow_reader(
         # convert to list of dict if data is a bunch of LanceModels
         if isinstance(data[0], LanceModel):
             schema = data[0].__class__.to_arrow_schema()
-            data = [model_to_dict(d) for d in data]
+            data = [_model_to_dict(d) for d in data]
             return pa.Table.from_pylist(data, schema=schema).to_reader()
         elif isinstance(data[0], pa.RecordBatch):
             return pa.Table.from_batches(data).to_reader()
@@ -527,7 +527,7 @@ def _infer_subschema(
     return fields
 
 
-def sanitize_create_table(
+def _sanitize_create_table(
     data,
     schema: Union[pa.Schema, LanceModel],
     metadata=None,
@@ -2499,11 +2499,11 @@ class LanceTable(Table):
         pd.DataFrame
         """
         validate_blob_mode(blob_mode)
-        if blob_mode == "descriptions" or not schema_has_blob_field(self.schema):
+        if blob_mode == "descriptions" or not _schema_has_blob_field(self.schema):
             arrow_tbl = self.to_arrow()
             if blob_mode == "descriptions":
                 arrow_tbl = strip_auto_row_ids(
-                    arrow_tbl, blob_v2_column_paths(self.schema)
+                    arrow_tbl, _blob_v2_column_paths(self.schema)
                 )
             return arrow_tbl.to_pandas(**kwargs)
 
@@ -2514,7 +2514,7 @@ class LanceTable(Table):
         ):
             return self.to_arrow().to_pandas(**kwargs)
 
-        if blob_mode == "bytes" and blob_v2_column_paths(self.schema):
+        if blob_mode == "bytes" and _blob_v2_column_paths(self.schema):
             return self.search().to_pandas(blob_mode=blob_mode, **kwargs)
 
         return self.to_lance().to_pandas(blob_mode=blob_mode, **kwargs)
@@ -3184,11 +3184,11 @@ class LanceTable(Table):
         lang = tokenizer_name[:2]
         if tokenizer_name[-5:] != "_stem":
             raise ValueError(f"Invalid tokenizer name {tokenizer_name}")
-        if lang not in lang_mapping:
+        if lang not in _lang_mapping:
             raise ValueError(f"Invalid language code {lang}")
         return {
             "base_tokenizer": "simple",
-            "language": lang_mapping[lang],
+            "language": _lang_mapping[lang],
             "max_token_length": 40,
             "lower_case": True,
             "stem": True,
@@ -4169,7 +4169,7 @@ def _handle_bad_vector_column(
         data = data.set_column(position, vector_column_name, vec_arr)
 
     if pa.types.is_floating(vec_arr.type.value_type):
-        has_nan = has_nan_values(vec_arr)
+        has_nan = _has_nan_values(vec_arr)
     else:
         has_nan = pa.array([False] * len(vec_arr))
 
@@ -4277,7 +4277,7 @@ def _fill_bad_vector_values(
     return filled.cast(arr.type)
 
 
-def has_nan_values(arr: Union[pa.ListArray, pa.ChunkedArray]) -> pa.BooleanArray:
+def _has_nan_values(arr: Union[pa.ListArray, pa.ChunkedArray]) -> pa.BooleanArray:
     if isinstance(arr, pa.ChunkedArray):
         values = pa.chunked_array([chunk.flatten() for chunk in arr.chunks])
     else:
@@ -4745,15 +4745,15 @@ class AsyncTable:
         """
         validate_blob_mode(blob_mode)
         schema = await self.schema()
-        if blob_mode == "descriptions" or not schema_has_blob_field(schema):
+        if blob_mode == "descriptions" or not _schema_has_blob_field(schema):
             arrow_tbl = await self.to_arrow()
             if blob_mode == "descriptions":
-                arrow_tbl = strip_auto_row_ids(arrow_tbl, blob_v2_column_paths(schema))
+                arrow_tbl = strip_auto_row_ids(arrow_tbl, _blob_v2_column_paths(schema))
             return arrow_tbl.to_pandas(**kwargs)
 
         if blob_mode == "lazy" and get_uri_scheme(await self.uri()) == "memory":
             return (await self.to_arrow()).to_pandas(**kwargs)
-        if blob_mode == "bytes" and blob_v2_column_paths(schema):
+        if blob_mode == "bytes" and _blob_v2_column_paths(schema):
             return await self.query().to_pandas(blob_mode=blob_mode, **kwargs)
         return (await self.to_lance()).to_pandas(blob_mode=blob_mode, **kwargs)
 
@@ -5055,7 +5055,7 @@ class AsyncTable:
         if mode == "overwrite":
             # For overwrite, apply the same preprocessing as create_table
             # so vector columns are inferred as FixedSizeList.
-            data, _ = sanitize_create_table(
+            data, _ = _sanitize_create_table(
                 data, None, on_bad_vectors=on_bad_vectors, fill_value=fill_value
             )
         elif on_bad_vectors != "error" or (

--- a/python/python/tests/test_api_reference.py
+++ b/python/python/tests/test_api_reference.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+"""Guard against the Python API reference drifting from the public API.
+
+`docs/src/python/python.md` is the whole Python API reference and is maintained
+by hand, so a new public class or function is simply absent from the docs until
+someone remembers to list it. This test fails when that happens.
+
+Everything is derived from the source with `ast` rather than by importing, both
+because the docs are built the same way (griffe reads the sources) and because
+some modules need optional dependencies that CI does not install.
+"""
+
+import ast
+from functools import cache
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_ROOT = REPO_ROOT / "python" / "python" / "lancedb"
+REFERENCE_PAGE = REPO_ROOT / "docs" / "src" / "python" / "python.md"
+
+pytestmark = pytest.mark.skipif(
+    not REFERENCE_PAGE.exists(),
+    reason="needs a source checkout; docs/ is not shipped in the wheel",
+)
+
+# Modules whose public surface belongs in the reference. Modules absent from this
+# list (internal helpers such as `lancedb.util` or `lancedb._blob`) are not checked.
+CHECKED_MODULES = [
+    "lancedb",
+    "lancedb.context",
+    "lancedb.db",
+    "lancedb.embeddings",
+    "lancedb.exceptions",
+    "lancedb.expr",
+    "lancedb.index",
+    "lancedb.merge",
+    "lancedb.namespace",
+    "lancedb.otel",
+    "lancedb.permutation",
+    "lancedb.pydantic",
+    "lancedb.query",
+    "lancedb.remote",
+    "lancedb.rerankers",
+    "lancedb.schema",
+    "lancedb.streaming",
+    "lancedb.table",
+]
+
+# Public names deliberately kept out of the reference. Each entry is a decision,
+# not an oversight -- add to this list only with a reason.
+INTENTIONALLY_UNDOCUMENTED = {
+    # Concrete implementations documented through their abstract base class.
+    "lancedb.LanceDBConnection",
+    "lancedb.RemoteDBConnection",
+    "lancedb.db.LanceDBConnection",
+    "lancedb.table.LanceTable",
+    # Base classes folded into the concrete query classes by mkdocstrings'
+    # `inherited_members` option.
+    "lancedb.query.AsyncQueryBase",
+    "lancedb.query.AsyncStandardQuery",
+    "lancedb.query.AsyncVectorQueryBase",
+    "lancedb.query.BaseQueryBuilder",
+    # Wire and plumbing types users do not construct directly.
+    "lancedb.query.ColumnOrdering",
+    "lancedb.query.FullTextQueryType",
+    "lancedb.query.FullTextSearchQuery",
+    "lancedb.query.ensure_vector_query",
+    # Path-normalising helper that predates the reference page; undocumented and
+    # has no docstring, but stays in `lancedb.__all__` for backwards compatibility.
+    "lancedb.common.sanitize_uri",
+    # Internal helpers that happen to lack a leading underscore.
+    "lancedb.permutation.Permutations",
+    "lancedb.permutation.Transforms",
+    "lancedb.pydantic.FixedSizeListMixin",
+    "lancedb.pydantic.get_extras",
+    "lancedb.pydantic.is_nullable",
+    "lancedb.pydantic.model_to_dict",
+    "lancedb.schema.blob_column_paths",
+    "lancedb.schema.blob_v2_column_paths",
+    "lancedb.schema.is_blob_like_field",
+    "lancedb.schema.is_blob_v2_field",
+    "lancedb.schema.schema_has_blob_field",
+    "lancedb.table.has_nan_values",
+    "lancedb.table.sanitize_create_table",
+}
+
+_DEFINITION_NODES = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _module_name(path: Path) -> str:
+    parts = path.relative_to(PACKAGE_ROOT).with_suffix("").parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(("lancedb", *parts))
+
+
+def _source_files() -> list[Path]:
+    # A .pyi stub stands in for its compiled module (`lancedb._lancedb`).
+    stubs = {p.with_suffix(".py") for p in PACKAGE_ROOT.rglob("*.pyi")}
+    return [
+        *(p for p in PACKAGE_ROOT.rglob("*.py") if p not in stubs),
+        *PACKAGE_ROOT.rglob("*.pyi"),
+    ]
+
+
+@cache
+def _trees() -> dict[str, ast.Module]:
+    return {_module_name(p): ast.parse(p.read_text()) for p in _source_files()}
+
+
+@cache
+def _definitions() -> set[str]:
+    """Every ``module.Name`` that is a class or function defined in the package."""
+    return {
+        f"{module}.{node.name}"
+        for module, tree in _trees().items()
+        for node in tree.body
+        if isinstance(node, _DEFINITION_NODES)
+    }
+
+
+@cache
+def _reexports() -> dict[str, str]:
+    """Map each re-exported path to the path it was imported from.
+
+    `lancedb/__init__.py` doing `from .table import Table` yields
+    ``lancedb.Table -> lancedb.table.Table``.
+    """
+    edges: dict[str, str] = {}
+    for module, tree in _trees().items():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.level == 0:
+                continue
+            base = module if _is_package(module) else module.rsplit(".", 1)[0]
+            for _ in range(node.level - 1):
+                base = base.rsplit(".", 1)[0]
+            source = f"{base}.{node.module}" if node.module else base
+            for alias in node.names:
+                edges[f"{module}.{alias.asname or alias.name}"] = (
+                    f"{source}.{alias.name}"
+                )
+    return edges
+
+
+def _is_package(module: str) -> bool:
+    relative = module.split(".")[1:]
+    return (PACKAGE_ROOT.joinpath(*relative) / "__init__.py").exists()
+
+
+def _resolve(path: str) -> Optional[str]:
+    """Follow re-exports to where a name is actually defined."""
+    seen = set()
+    while path not in _definitions():
+        if path in seen or path not in _reexports():
+            return None
+        seen.add(path)
+        path = _reexports()[path]
+    return path
+
+
+@cache
+def _paths_to(definition: str) -> frozenset[str]:
+    """Every importable path that reaches a definition, including its own.
+
+    `lancedb.schema.blob` is also reachable as `lancedb.blob`, and the reference
+    may legitimately document it under either name.
+    """
+    return frozenset(
+        {definition, *(p for p in _reexports() if _resolve(p) == definition)}
+    )
+
+
+def _public_names(module: str) -> tuple[set[str], bool]:
+    """Public names of a module, and whether they came from ``__all__``."""
+    tree = _trees()[module]
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            getattr(target, "id", None) == "__all__" for target in node.targets
+        ):
+            return {element.value for element in node.value.elts}, True
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, _DEFINITION_NODES) and not node.name.startswith("_")
+    }, False
+
+
+@cache
+def _documented() -> tuple[frozenset[str], frozenset[str]]:
+    """Individual symbols, and whole modules, rendered by the reference page."""
+    symbols, modules = set(), set()
+    for line in REFERENCE_PAGE.read_text().splitlines():
+        if not line.startswith("::: "):
+            continue
+        target = line[4:].strip()
+        (modules if target in _trees() else symbols).add(target)
+    return frozenset(symbols), frozenset(modules)
+
+
+@pytest.mark.parametrize("module", CHECKED_MODULES)
+def test_public_api_is_in_the_reference(module: str) -> None:
+    symbols, rendered_modules = _documented()
+    names, from_dunder_all = _public_names(module)
+
+    missing = []
+    for name in sorted(names):
+        exported_as = f"{module}.{name}"
+        if exported_as in INTENTIONALLY_UNDOCUMENTED:
+            continue
+        defined_at = _resolve(exported_as)
+        # Constants and type aliases (`lancedb.URI`, `__version__`) resolve to
+        # nothing and have no place in a class/function reference.
+        if defined_at is None or defined_at in INTENTIONALLY_UNDOCUMENTED:
+            continue
+        # A whole-module directive renders everything the module exports, but for
+        # a re-export package only the names listed in `__all__`.
+        rendered_wholesale = module in rendered_modules and (
+            from_dunder_all or defined_at == exported_as
+        )
+        if rendered_wholesale or symbols & _paths_to(defined_at):
+            continue
+        missing.append(exported_as)
+
+    assert not missing, (
+        f"{len(missing)} public name(s) in {module} are missing from "
+        f"{REFERENCE_PAGE.relative_to(REPO_ROOT)}:\n  "
+        + "\n  ".join(missing)
+        + "\n\nAdd a `::: <path>` line to the matching section of that page, or "
+        "add the name to INTENTIONALLY_UNDOCUMENTED in this test with a reason."
+    )
+
+
+def test_reference_has_no_stale_entries() -> None:
+    """Every `::: lancedb...` target on the page resolves to real source."""
+    symbols, modules = _documented()
+    stale = [
+        target
+        for target in sorted(symbols)
+        if _resolve(target) is None and target not in _definitions()
+    ]
+    assert not stale, (
+        "Reference entries with no matching class or function:\n  " + "\n  ".join(stale)
+    )
+    assert modules, "Expected the page to render at least one module wholesale"

--- a/python/python/tests/test_api_reference.py
+++ b/python/python/tests/test_api_reference.py
@@ -28,36 +28,36 @@ pytestmark = pytest.mark.skipif(
     reason="needs a source checkout; docs/ is not shipped in the wheel",
 )
 
-# Modules whose public surface belongs in the reference. Modules absent from this
-# list (internal helpers such as `lancedb.util` or `lancedb._blob`) are not checked.
-CHECKED_MODULES = [
-    "lancedb",
-    "lancedb.context",
-    "lancedb.db",
-    "lancedb.embeddings",
-    "lancedb.exceptions",
-    "lancedb.expr",
-    "lancedb.index",
-    "lancedb.merge",
-    "lancedb.namespace",
-    "lancedb.otel",
-    "lancedb.permutation",
-    "lancedb.pydantic",
-    "lancedb.query",
-    "lancedb.remote",
-    "lancedb.rerankers",
-    "lancedb.schema",
-    "lancedb.streaming",
-    "lancedb.table",
-]
+# Every module under `lancedb/` is checked except these, so a module added later is
+# covered by default. Underscore-prefixed modules are skipped without being listed.
+UNCHECKED_MODULES = {
+    "lancedb.arrow",
+    "lancedb.background_loop",
+    "lancedb.common",
+    "lancedb.conftest",
+    "lancedb.dependencies",
+    "lancedb.embeddings.gte_mlx_model",
+    "lancedb.embeddings.utils",
+    "lancedb.integrations",
+    "lancedb.integrations.pyarrow",
+    "lancedb.io",
+    "lancedb.namespace_utils",
+    "lancedb.remote.db",
+    "lancedb.remote.errors",
+    "lancedb.remote.table",
+    "lancedb.rerankers.util",
+    "lancedb.scannable",
+    "lancedb.types",
+    "lancedb.util",
+}
 
-# Public names deliberately kept out of the reference. Each entry is a decision,
-# not an oversight -- add to this list only with a reason.
+# Public names deliberately kept out of the reference, keyed by where they are
+# defined so one entry covers every alias. Each is a decision, not an oversight --
+# add to this list only with a reason.
 INTENTIONALLY_UNDOCUMENTED = {
     # Concrete implementations documented through their abstract base class.
-    "lancedb.LanceDBConnection",
-    "lancedb.RemoteDBConnection",
     "lancedb.db.LanceDBConnection",
+    "lancedb.remote.db.RemoteDBConnection",
     "lancedb.table.LanceTable",
     # Base classes folded into the concrete query classes by mkdocstrings'
     # `inherited_members` option.
@@ -69,24 +69,11 @@ INTENTIONALLY_UNDOCUMENTED = {
     "lancedb.query.ColumnOrdering",
     "lancedb.query.FullTextQueryType",
     "lancedb.query.FullTextSearchQuery",
-    "lancedb.query.ensure_vector_query",
     # Path-normalising helper that predates the reference page; undocumented and
     # has no docstring, but stays in `lancedb.__all__` for backwards compatibility.
     "lancedb.common.sanitize_uri",
-    # Internal helpers that happen to lack a leading underscore.
-    "lancedb.permutation.Permutations",
-    "lancedb.permutation.Transforms",
+    # Mixin that exists to be subclassed by the vector helpers, not used directly.
     "lancedb.pydantic.FixedSizeListMixin",
-    "lancedb.pydantic.get_extras",
-    "lancedb.pydantic.is_nullable",
-    "lancedb.pydantic.model_to_dict",
-    "lancedb.schema.blob_column_paths",
-    "lancedb.schema.blob_v2_column_paths",
-    "lancedb.schema.is_blob_like_field",
-    "lancedb.schema.is_blob_v2_field",
-    "lancedb.schema.schema_has_blob_field",
-    "lancedb.table.has_nan_values",
-    "lancedb.table.sanitize_create_table",
 }
 
 _DEFINITION_NODES = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
@@ -99,29 +86,35 @@ def _module_name(path: Path) -> str:
     return ".".join(("lancedb", *parts))
 
 
-def _source_files() -> list[Path]:
+@cache
+def _trees() -> dict[str, ast.Module]:
     # A .pyi stub stands in for its compiled module (`lancedb._lancedb`).
     stubs = {p.with_suffix(".py") for p in PACKAGE_ROOT.rglob("*.pyi")}
-    return [
+    sources = [
         *(p for p in PACKAGE_ROOT.rglob("*.py") if p not in stubs),
         *PACKAGE_ROOT.rglob("*.pyi"),
+    ]
+    return {_module_name(p): ast.parse(p.read_text()) for p in sources}
+
+
+def _checked_modules() -> list[str]:
+    return [
+        module
+        for module in sorted(_trees())
+        if module not in UNCHECKED_MODULES
+        and not any(part.startswith("_") for part in module.split(".")[1:])
     ]
 
 
 @cache
-def _trees() -> dict[str, ast.Module]:
-    return {_module_name(p): ast.parse(p.read_text()) for p in _source_files()}
-
-
-@cache
-def _definitions() -> set[str]:
+def _definitions() -> frozenset[str]:
     """Every ``module.Name`` that is a class or function defined in the package."""
-    return {
+    return frozenset(
         f"{module}.{node.name}"
         for module, tree in _trees().items()
         for node in tree.body
         if isinstance(node, _DEFINITION_NODES)
-    }
+    )
 
 
 @cache
@@ -163,66 +156,56 @@ def _resolve(path: str) -> Optional[str]:
     return path
 
 
-@cache
-def _paths_to(definition: str) -> frozenset[str]:
-    """Every importable path that reaches a definition, including its own.
-
-    `lancedb.schema.blob` is also reachable as `lancedb.blob`, and the reference
-    may legitimately document it under either name.
-    """
-    return frozenset(
-        {definition, *(p for p in _reexports() if _resolve(p) == definition)}
-    )
-
-
-def _public_names(module: str) -> tuple[set[str], bool]:
-    """Public names of a module, and whether they came from ``__all__``."""
+def _public_names(module: str) -> set[str]:
     tree = _trees()[module]
     for node in tree.body:
         if isinstance(node, ast.Assign) and any(
             getattr(target, "id", None) == "__all__" for target in node.targets
         ):
-            return {element.value for element in node.value.elts}, True
+            return {element.value for element in node.value.elts}
+    return _defined_names(module)
+
+
+def _defined_names(module: str) -> set[str]:
     return {
         node.name
-        for node in tree.body
+        for node in _trees()[module].body
         if isinstance(node, _DEFINITION_NODES) and not node.name.startswith("_")
-    }, False
+    }
 
 
 @cache
-def _documented() -> tuple[frozenset[str], frozenset[str]]:
-    """Individual symbols, and whole modules, rendered by the reference page."""
-    symbols, modules = set(), set()
+def _documented() -> frozenset[str]:
+    """Every definition the reference page renders, by where it is defined."""
+    rendered = set()
     for line in REFERENCE_PAGE.read_text().splitlines():
         if not line.startswith("::: "):
             continue
         target = line[4:].strip()
-        (modules if target in _trees() else symbols).add(target)
-    return frozenset(symbols), frozenset(modules)
+        if target in _trees():
+            # A whole-module directive renders the names a module exports, plus any
+            # public name defined in the module itself whether exported or not.
+            paths = {
+                f"{target}.{name}"
+                for name in _public_names(target) | _defined_names(target)
+            }
+        else:
+            paths = {target}
+        rendered |= {d for d in map(_resolve, paths) if d is not None}
+    return frozenset(rendered)
 
 
-@pytest.mark.parametrize("module", CHECKED_MODULES)
+@pytest.mark.parametrize("module", _checked_modules())
 def test_public_api_is_in_the_reference(module: str) -> None:
-    symbols, rendered_modules = _documented()
-    names, from_dunder_all = _public_names(module)
-
     missing = []
-    for name in sorted(names):
+    for name in sorted(_public_names(module)):
         exported_as = f"{module}.{name}"
-        if exported_as in INTENTIONALLY_UNDOCUMENTED:
-            continue
-        defined_at = _resolve(exported_as)
+        definition = _resolve(exported_as)
         # Constants and type aliases (`lancedb.URI`, `__version__`) resolve to
         # nothing and have no place in a class/function reference.
-        if defined_at is None or defined_at in INTENTIONALLY_UNDOCUMENTED:
+        if definition is None:
             continue
-        # A whole-module directive renders everything the module exports, but for
-        # a re-export package only the names listed in `__all__`.
-        rendered_wholesale = module in rendered_modules and (
-            from_dunder_all or defined_at == exported_as
-        )
-        if rendered_wholesale or symbols & _paths_to(defined_at):
+        if definition in INTENTIONALLY_UNDOCUMENTED or definition in _documented():
             continue
         missing.append(exported_as)
 
@@ -230,20 +213,46 @@ def test_public_api_is_in_the_reference(module: str) -> None:
         f"{len(missing)} public name(s) in {module} are missing from "
         f"{REFERENCE_PAGE.relative_to(REPO_ROOT)}:\n  "
         + "\n  ".join(missing)
-        + "\n\nAdd a `::: <path>` line to the matching section of that page, or "
-        "add the name to INTENTIONALLY_UNDOCUMENTED in this test with a reason."
+        + "\n\nAdd a `::: <path>` line to the matching section of that page, make the "
+        "name private, or add it to INTENTIONALLY_UNDOCUMENTED in this test."
     )
 
 
 def test_reference_has_no_stale_entries() -> None:
     """Every `::: lancedb...` target on the page resolves to real source."""
-    symbols, modules = _documented()
     stale = [
-        target
-        for target in sorted(symbols)
-        if _resolve(target) is None and target not in _definitions()
+        line[4:].strip()
+        for line in REFERENCE_PAGE.read_text().splitlines()
+        if line.startswith("::: lancedb")
+        and line[4:].strip() not in _trees()
+        and _resolve(line[4:].strip()) is None
     ]
     assert not stale, (
         "Reference entries with no matching class or function:\n  " + "\n  ".join(stale)
     )
-    assert modules, "Expected the page to render at least one module wholesale"
+
+
+def test_intentionally_undocumented_is_accurate() -> None:
+    """Keep the opt-out list from rotting into a set of false claims."""
+    gone = sorted(INTENTIONALLY_UNDOCUMENTED - _definitions())
+    assert not gone, "No longer defined, drop from the list:\n  " + "\n  ".join(gone)
+
+    contradictory = sorted(INTENTIONALLY_UNDOCUMENTED & _documented())
+    assert not contradictory, (
+        "Listed as undocumented but the reference renders them:\n  "
+        + "\n  ".join(contradictory)
+    )
+
+    # An entry earns its place only if some checked module exports a name that
+    # resolves to it -- being defined in an unchecked module is not disqualifying,
+    # since `lancedb` re-exports several of those.
+    reachable = {
+        _resolve(f"{module}.{name}")
+        for module in _checked_modules()
+        for name in _public_names(module)
+    }
+    unreachable = sorted(INTENTIONALLY_UNDOCUMENTED - reachable)
+    assert not unreachable, (
+        "Not exported by any checked module, so the entry does nothing:\n  "
+        + "\n  ".join(unreachable)
+    )

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -10,7 +10,7 @@ import pytest
 import lancedb
 from lancedb._blob import read_row_ids_from_hits, stash_auto_row_ids
 from lancedb.index import FTS
-from lancedb.schema import blob_column_paths, blob_v2_column_paths
+from lancedb.schema import _blob_column_paths, _blob_v2_column_paths
 
 
 def _blob_table(name, rows):
@@ -62,7 +62,7 @@ def test_blob_v2_column_paths_include_list_children():
         ]
     )
 
-    assert blob_v2_column_paths(schema) == [
+    assert _blob_v2_column_paths(schema) == [
         "info.blob",
         "images.image",
         "large_images.large_image",
@@ -95,13 +95,13 @@ def test_blob_v2_column_paths_exclude_legacy_metadata():
             ),
         ]
     )
-    assert blob_v2_column_paths(schema) == ["image"]
-    assert blob_column_paths(schema) == ["image", "legacy"]
+    assert _blob_v2_column_paths(schema) == ["image"]
+    assert _blob_column_paths(schema) == ["image", "legacy"]
 
 
 def test_blob_v2_paths_match_blob_columns():
     table = _blob_table("paths_match", [{"id": 1, "image": b"x"}])
-    assert blob_v2_column_paths(table.schema) == table.blob_columns()
+    assert _blob_v2_column_paths(table.schema) == table.blob_columns()
 
     db = lancedb.connect("memory:///")
     info = pa.StructArray.from_arrays(
@@ -116,7 +116,7 @@ def test_blob_v2_paths_match_blob_columns():
         names=["id", "info"],
     )
     nested = db.create_table("nested_paths", data=data)
-    assert blob_v2_column_paths(nested.schema) == nested.blob_columns()
+    assert _blob_v2_column_paths(nested.schema) == nested.blob_columns()
 
 
 def test_auto_row_id_stash_round_trip():

--- a/python/python/tests/test_query.py
+++ b/python/python/tests/test_query.py
@@ -32,7 +32,7 @@ from lancedb.query import (
     PhraseQuery,
     Query,
     FullTextSearchQuery,
-    ensure_vector_query,
+    _ensure_vector_query,
 )
 from lancedb.rerankers.cross_encoder import CrossEncoderReranker
 from lancedb.table import AsyncTable, LanceTable
@@ -1996,15 +1996,15 @@ def test_search_empty_table(mem_db):
 
 
 def test_ensure_vector_query_empty_list():
-    """Regression: ensure_vector_query used to return instead of raise ValueError."""
+    """Regression: _ensure_vector_query used to return instead of raise ValueError."""
     with pytest.raises(ValueError, match="non-empty"):
-        ensure_vector_query([])
+        _ensure_vector_query([])
 
 
 def test_ensure_vector_query_nested_empty_list():
-    """Regression: ensure_vector_query used to return instead of raise ValueError."""
+    """Regression: _ensure_vector_query used to return instead of raise ValueError."""
     with pytest.raises(ValueError, match="non-empty"):
-        ensure_vector_query([[]])
+        _ensure_vector_query([[]])
 
 
 def test_fast_search(tmp_path):

--- a/python/python/tests/test_util.py
+++ b/python/python/tests/test_util.py
@@ -19,7 +19,7 @@ from lancedb.table import (
     _infer_target_schema,
     _merge_metadata,
     _sanitize_data,
-    sanitize_create_table,
+    _sanitize_create_table,
 )
 import pyarrow as pa
 import pandas as pd
@@ -507,7 +507,7 @@ def test_sanitize_create_table_merges_and_overrides_embedding_metadata():
         ),
     )
 
-    data, schema = sanitize_create_table(
+    data, schema = _sanitize_create_table(
         pa.table({"text": ["good"]}),
         schema,
         metadata=metadata,


### PR DESCRIPTION
`docs/src/python/python.md` is the entire Python API reference and is maintained by hand, so a new public class or function stays invisible until someone notices. #3746 found around fifty symbols in that state, including branch management. This adds a test so it fails loudly next time.

The test derives the public surface from the sources with `ast` — `__all__` where a module defines one, top-level class and function definitions otherwise — follows re-exports so a symbol counts as documented under any name it is importable by, and asserts each one is reachable from the reference page. Names deliberately left out go in an `INTENTIONALLY_UNDOCUMENTED` set with a reason, which turns "we don't document this" into a reviewable line rather than an oversight. A second test flags entries on the page that no longer match any source.

Static parsing rather than importing means the test needs no optional dependencies (`lancedb.streaming` needs torch, which the `tests` extra does not install), and it matches how griffe reads the sources when the docs are actually built.

Stacked on #3746, and based on that branch rather than `main` so the diff here is just the test. It cannot pass without the entries #3746 adds, so merge that one first, then retarget this to `main` **before** deleting the `docs/python-api-reference-gaps` branch — deleting the base branch of an open PR closes it rather than retargeting it.

## Example

Deleting the `Branches` entry from the reference page:

```
E   AssertionError: 1 public name(s) in lancedb.table are missing from docs/src/python/python.md:
E       lancedb.table.Branches
E
E   Add a `::: <path>` line to the matching section of that page, or add the name
E   to INTENTIONALLY_UNDOCUMENTED in this test with a reason.
```

## Testing

Checked the test fails for each case it is meant to catch — a symbol dropped from the page, a newly added public class, and a stale entry pointing at nothing — and that adding a name to an automodule'd `__all__` correctly still passes without a docs edit.

## Not included

The docs build itself is still unchecked on PRs: the workflow only runs on pushes to `main`, so a broken cross-reference in a docstring is caught by neither this test nor CI. #3707 is addressing that.
