### PR TITLE
feat: compute column sizes in bytes

### DIFF
--- a/docs/src/js/interfaces/TableStatistics.md
+++ b/docs/src/js/interfaces/TableStatistics.md
@@ -15,19 +15,15 @@ optional columnBytes: Record<string, number>;
 ```
 
 The compressed on-disk bytes of each column, keyed by dotted field path
-("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each get
-their own entry, and every entry covers the field's own bytes plus its
-whole subtree, so a struct reports its total while its children report
-the breakdown (the top-level entries alone sum to `totalBytes`). List
-elements are not broken out: a list column reports a single total with
-its element bytes rolled in. Path segments containing anything other
-than letters, digits, or `_` are backtick-quoted, so a subfield named
-`a.b` under `meta` is keyed as "meta.`a.b`".
+("meta", "meta.geo", "meta.geo.lat"). A struct's subfields get their own
+entries *in addition to* the struct's, so sum only the top-level entries
+to reach `totalBytes` — summing every entry double-counts. Undefined
+when the backend provides no per-column breakdown (e.g. older remote
+servers).
 
-Counts data-file bytes only: blob sidecar payloads and index files are
-not included, and blob columns therefore report just their descriptor
-bytes. Undefined when the backend provides no per-column breakdown
-(e.g. older remote servers).
+For the full contract — path quoting, list elements, and which bytes are
+excluded — see `TableStatistics::column_bytes` at
+<https://docs.rs/lancedb/latest/lancedb/table/struct.TableStatistics.html>.
 
 ***
 

--- a/docs/src/js/interfaces/TableStatistics.md
+++ b/docs/src/js/interfaces/TableStatistics.md
@@ -15,14 +15,19 @@ optional columnBytes: Record<string, number>;
 ```
 
 The compressed on-disk bytes of each column, keyed by dotted field path
-("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an entry
-covering the field's own bytes plus its whole subtree, so a struct
-reports its total while its children report the breakdown (the
-top-level entries alone sum to `totalBytes`). Counts data-file bytes
-only: blob sidecar payloads and index files are not included, and blob
-columns therefore report just their descriptor bytes. Undefined when
-the backend provides no per-column breakdown (e.g. older remote
-servers).
+("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each get
+their own entry, and every entry covers the field's own bytes plus its
+whole subtree, so a struct reports its total while its children report
+the breakdown (the top-level entries alone sum to `totalBytes`). List
+elements are not broken out: a list column reports a single total with
+its element bytes rolled in. Path segments containing anything other
+than letters, digits, or `_` are backtick-quoted, so a subfield named
+`a.b` under `meta` is keyed as "meta.`a.b`".
+
+Counts data-file bytes only: blob sidecar payloads and index files are
+not included, and blob columns therefore report just their descriptor
+bytes. Undefined when the backend provides no per-column breakdown
+(e.g. older remote servers).
 
 ***
 

--- a/docs/src/js/interfaces/TableStatistics.md
+++ b/docs/src/js/interfaces/TableStatistics.md
@@ -8,6 +8,24 @@
 
 ## Properties
 
+### columnBytes?
+
+```ts
+optional columnBytes: Record<string, number>;
+```
+
+The compressed on-disk bytes of each column, keyed by dotted field path
+("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an entry
+covering the field's own bytes plus its whole subtree, so a struct
+reports its total while its children report the breakdown (the
+top-level entries alone sum to `totalBytes`). Counts data-file bytes
+only: blob sidecar payloads and index files are not included, and blob
+columns therefore report just their descriptor bytes. Undefined when
+the backend provides no per-column breakdown (e.g. older remote
+servers).
+
+***
+
 ### fragmentStats
 
 ```ts

--- a/docs/src/python/python.md
+++ b/docs/src/python/python.md
@@ -30,6 +30,8 @@ is also an [asynchronous API client](#connections-asynchronous).
 
 ::: lancedb.table.Table
 
+::: lancedb.table.TableStatistics
+
 ::: lancedb.table.FragmentStatistics
 
 ::: lancedb.table.FragmentSummaryStats

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -240,7 +240,34 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
         numIndices: 0,
         numRows: 3,
         totalBytes: 44,
+        columnBytes: { id: 44 },
       });
+    });
+
+    it("should report per-column bytes, including nested fields", async () => {
+      const conn = await connect(tmpDir.name);
+      const nested = await conn.createTable("nested_stats", [
+        { id: 1, meta: { a: 1, b: "one" } },
+        { id: 2, meta: { a: 2, b: "two" } },
+      ]);
+      const stats = await nested.stats();
+      const columnBytes = stats.columnBytes!;
+
+      // Nested fields get their own dotted-path entries.
+      expect(Object.keys(columnBytes).sort()).toEqual([
+        "id",
+        "meta",
+        "meta.a",
+        "meta.b",
+      ]);
+      expect(columnBytes["meta.a"]).toBeGreaterThan(0);
+      expect(columnBytes["meta.b"]).toBeGreaterThan(0);
+      // A struct's entry covers its whole subtree.
+      expect(columnBytes["meta"]).toBeGreaterThanOrEqual(
+        columnBytes["meta.a"] + columnBytes["meta.b"],
+      );
+      // Top-level entries alone sum to the table total.
+      expect(columnBytes["id"] + columnBytes["meta"]).toBe(stats.totalBytes);
     });
 
     it("should overwrite data if asked", async () => {

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -270,6 +270,23 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
       expect(columnBytes["id"] + columnBytes["meta"]).toBe(stats.totalBytes);
     });
 
+    it("should not break out list elements as their own column", async () => {
+      const conn = await connect(tmpDir.name);
+      const lists = await conn.createTable("list_stats", [
+        { id: 1, tags: ["a", "b"] },
+        { id: 2, tags: ["c", "d"] },
+      ]);
+      const stats = await lists.stats();
+      const columnBytes = stats.columnBytes!;
+
+      // A list's element is an encoding detail, not a column, so there is no
+      // redundant "tags.item" entry duplicating "tags".
+      expect(Object.keys(columnBytes).sort()).toEqual(["id", "tags"]);
+      // The element bytes are rolled into the list column, not dropped.
+      expect(columnBytes["tags"]).toBeGreaterThan(0);
+      expect(columnBytes["id"] + columnBytes["tags"]).toBe(stats.totalBytes);
+    });
+
     it("should overwrite data if asked", async () => {
       const addRes = await table.add([{ id: 1 }, { id: 2 }]);
       expect(addRes).toHaveProperty("version");

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -1019,19 +1019,15 @@ pub struct TableStatistics {
     pub fragment_stats: FragmentStatistics,
 
     /// The compressed on-disk bytes of each column, keyed by dotted field path
-    /// ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each get
-    /// their own entry, and every entry covers the field's own bytes plus its
-    /// whole subtree, so a struct reports its total while its children report
-    /// the breakdown (the top-level entries alone sum to `totalBytes`). List
-    /// elements are not broken out: a list column reports a single total with
-    /// its element bytes rolled in. Path segments containing anything other
-    /// than letters, digits, or `_` are backtick-quoted, so a subfield named
-    /// `a.b` under `meta` is keyed as "meta.`a.b`".
+    /// ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields get their own
+    /// entries *in addition to* the struct's, so sum only the top-level entries
+    /// to reach `totalBytes` — summing every entry double-counts. Undefined
+    /// when the backend provides no per-column breakdown (e.g. older remote
+    /// servers).
     ///
-    /// Counts data-file bytes only: blob sidecar payloads and index files are
-    /// not included, and blob columns therefore report just their descriptor
-    /// bytes. Undefined when the backend provides no per-column breakdown
-    /// (e.g. older remote servers).
+    /// For the full contract — path quoting, list elements, and which bytes are
+    /// excluded — see `TableStatistics::column_bytes` at
+    /// <https://docs.rs/lancedb/latest/lancedb/table/struct.TableStatistics.html>.
     pub column_bytes: Option<HashMap<String, i64>>,
 }
 

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -1019,14 +1019,19 @@ pub struct TableStatistics {
     pub fragment_stats: FragmentStatistics,
 
     /// The compressed on-disk bytes of each column, keyed by dotted field path
-    /// ("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an entry
-    /// covering the field's own bytes plus its whole subtree, so a struct
-    /// reports its total while its children report the breakdown (the
-    /// top-level entries alone sum to `totalBytes`). Counts data-file bytes
-    /// only: blob sidecar payloads and index files are not included, and blob
-    /// columns therefore report just their descriptor bytes. Undefined when
-    /// the backend provides no per-column breakdown (e.g. older remote
-    /// servers).
+    /// ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each get
+    /// their own entry, and every entry covers the field's own bytes plus its
+    /// whole subtree, so a struct reports its total while its children report
+    /// the breakdown (the top-level entries alone sum to `totalBytes`). List
+    /// elements are not broken out: a list column reports a single total with
+    /// its element bytes rolled in. Path segments containing anything other
+    /// than letters, digits, or `_` are backtick-quoted, so a subfield named
+    /// `a.b` under `meta` is keyed as "meta.`a.b`".
+    ///
+    /// Counts data-file bytes only: blob sidecar payloads and index files are
+    /// not included, and blob columns therefore report just their descriptor
+    /// bytes. Undefined when the backend provides no per-column breakdown
+    /// (e.g. older remote servers).
     pub column_bytes: Option<HashMap<String, i64>>,
 }
 

--- a/nodejs/src/table.rs
+++ b/nodejs/src/table.rs
@@ -1017,6 +1017,17 @@ pub struct TableStatistics {
 
     /// Statistics on table fragments
     pub fragment_stats: FragmentStatistics,
+
+    /// The compressed on-disk bytes of each column, keyed by dotted field path
+    /// ("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an entry
+    /// covering the field's own bytes plus its whole subtree, so a struct
+    /// reports its total while its children report the breakdown (the
+    /// top-level entries alone sum to `totalBytes`). Counts data-file bytes
+    /// only: blob sidecar payloads and index files are not included, and blob
+    /// columns therefore report just their descriptor bytes. Undefined when
+    /// the backend provides no per-column breakdown (e.g. older remote
+    /// servers).
+    pub column_bytes: Option<HashMap<String, i64>>,
 }
 
 #[napi(object)]
@@ -1074,6 +1085,12 @@ impl From<lancedb::table::TableStatistics> for TableStatistics {
                     p99: v.fragment_stats.lengths.p99 as i64,
                 },
             },
+            column_bytes: v.column_bytes.map(|columns| {
+                columns
+                    .into_iter()
+                    .map(|(path, bytes)| (path, bytes as i64))
+                    .collect()
+            }),
         }
     }
 }

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -63,7 +63,16 @@ from ..query import (
     LanceTakeQueryBuilder,
     LanceVectorQueryBuilder,
 )
-from ..table import AsyncTable, BlobMode, Branches, IndexStatistics, Query, Table, Tags
+from ..table import (
+    AsyncTable,
+    BlobMode,
+    Branches,
+    IndexStatistics,
+    Query,
+    Table,
+    TableStatistics,
+    Tags,
+)
 from ..types import BaseTokenizerType
 
 
@@ -1010,7 +1019,7 @@ class RemoteTable(Table):
     ):
         return LOOP.run(self._table.wait_for_index(index_names, timeout))
 
-    def stats(self):
+    def stats(self) -> TableStatistics:
         return LOOP.run(self._table.stats())
 
     @property

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -6144,12 +6144,22 @@ class TableStatistics:
         The total number of indices in the table.
     fragment_stats: FragmentStatistics
         Statistics about fragments in the table.
+    column_bytes: dict[str, int] | None
+        The compressed on-disk bytes of each column, keyed by dotted field path
+        ("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an entry
+        covering the field's own bytes plus its whole subtree, so a struct
+        reports its total while its children report the breakdown (the
+        top-level entries alone sum to ``total_bytes``). Counts data-file bytes
+        only: blob sidecar payloads and index files are not included, and blob
+        columns therefore report just their descriptor bytes. ``None`` when the
+        backend provides no per-column breakdown (e.g. older remote servers).
     """
 
     total_bytes: int
     num_rows: int
     num_indices: int
     fragment_stats: FragmentStatistics
+    column_bytes: Optional[Dict[str, int]] = None
 
 
 @dataclass

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -1018,6 +1018,13 @@ class Table(ABC):
     def stats(self) -> TableStatistics:
         """
         Retrieve table and fragment statistics.
+
+        Returns
+        -------
+        TableStatistics
+            Subscript access (``stats["total_bytes"]``) is still supported for
+            backwards compatibility with the older API, which returned a
+            dictionary.
         """
         raise NotImplementedError
 
@@ -4948,8 +4955,15 @@ class AsyncTable:
     async def stats(self) -> TableStatistics:
         """
         Retrieve table and fragment statistics.
+
+        Returns
+        -------
+        TableStatistics
+            Subscript access (``stats["total_bytes"]``) is still supported for
+            backwards compatibility with the older API, which returned a
+            dictionary.
         """
-        return await self._inner.stats()
+        return TableStatistics._from_dict(await self._inner.stats())
 
     async def uri(self) -> str:
         """
@@ -6146,13 +6160,19 @@ class TableStatistics:
         Statistics about fragments in the table.
     column_bytes: dict[str, int] | None
         The compressed on-disk bytes of each column, keyed by dotted field path
-        ("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an entry
-        covering the field's own bytes plus its whole subtree, so a struct
-        reports its total while its children report the breakdown (the
-        top-level entries alone sum to ``total_bytes``). Counts data-file bytes
-        only: blob sidecar payloads and index files are not included, and blob
-        columns therefore report just their descriptor bytes. ``None`` when the
-        backend provides no per-column breakdown (e.g. older remote servers).
+        ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each get their
+        own entry, and every entry covers the field's own bytes plus its whole
+        subtree, so a struct reports its total while its children report the
+        breakdown (the top-level entries alone sum to ``total_bytes``). List
+        elements are not broken out: a list column reports a single total with
+        its element bytes rolled in. Path segments containing anything other
+        than letters, digits, or ``_`` are backtick-quoted, so a subfield named
+        ``a.b`` under ``meta`` is keyed as ``meta.`a.b```.
+
+        Counts data-file bytes only: blob sidecar payloads and index files are
+        not included, and blob columns therefore report just their descriptor
+        bytes. ``None`` when the backend provides no per-column breakdown (e.g.
+        older remote servers).
     """
 
     total_bytes: int
@@ -6160,6 +6180,26 @@ class TableStatistics:
     num_indices: int
     fragment_stats: FragmentStatistics
     column_bytes: Optional[Dict[str, int]] = None
+
+    @classmethod
+    def _from_dict(cls, stats: Dict[str, Any]) -> TableStatistics:
+        fragment_stats = stats["fragment_stats"]
+        return cls(
+            total_bytes=stats["total_bytes"],
+            num_rows=stats["num_rows"],
+            num_indices=stats["num_indices"],
+            fragment_stats=FragmentStatistics(
+                num_fragments=fragment_stats["num_fragments"],
+                num_small_fragments=fragment_stats["num_small_fragments"],
+                lengths=FragmentSummaryStats(**fragment_stats["lengths"]),
+            ),
+            column_bytes=stats.get("column_bytes"),
+        )
+
+    # This exists for backwards compatibility with an older API, which returned
+    # a dictionary instead of a class.
+    def __getitem__(self, key):
+        return getattr(self, key)
 
 
 @dataclass
@@ -6181,6 +6221,11 @@ class FragmentStatistics:
     num_fragments: int
     num_small_fragments: int
     lengths: FragmentSummaryStats
+
+    # This exists for backwards compatibility with an older API, which returned
+    # a dictionary instead of a class.
+    def __getitem__(self, key):
+        return getattr(self, key)
 
 
 @dataclass
@@ -6213,6 +6258,11 @@ class FragmentSummaryStats:
     p50: int
     p75: int
     p99: int
+
+    # This exists for backwards compatibility with an older API, which returned
+    # a dictionary instead of a class.
+    def __getitem__(self, key):
+        return getattr(self, key)
 
 
 class Tags:

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -6160,19 +6160,15 @@ class TableStatistics:
         Statistics about fragments in the table.
     column_bytes: dict[str, int] | None
         The compressed on-disk bytes of each column, keyed by dotted field path
-        ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each get their
-        own entry, and every entry covers the field's own bytes plus its whole
-        subtree, so a struct reports its total while its children report the
-        breakdown (the top-level entries alone sum to ``total_bytes``). List
-        elements are not broken out: a list column reports a single total with
-        its element bytes rolled in. Path segments containing anything other
-        than letters, digits, or ``_`` are backtick-quoted, so a subfield named
-        ``a.b`` under ``meta`` is keyed as ``meta.`a.b```.
+        ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields get their own
+        entries *in addition to* the struct's, so sum only the top-level entries
+        to reach ``total_bytes`` -- summing every entry double-counts. ``None``
+        when the backend provides no per-column breakdown (e.g. older remote
+        servers).
 
-        Counts data-file bytes only: blob sidecar payloads and index files are
-        not included, and blob columns therefore report just their descriptor
-        bytes. ``None`` when the backend provides no per-column breakdown (e.g.
-        older remote servers).
+        For the full contract -- path quoting, list elements, and which bytes
+        are excluded -- see ``TableStatistics::column_bytes`` at
+        https://docs.rs/lancedb/latest/lancedb/table/struct.TableStatistics.html
     """
 
     total_bytes: int

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -20,6 +20,7 @@ from lancedb.conftest import MockTextEmbeddingFunction
 from lancedb.query import ColumnOrdering
 from lancedb.remote import ClientConfig
 from lancedb.remote.errors import HttpError, RetryError
+from lancedb.table import TableStatistics
 import pytest
 import pyarrow as pa
 
@@ -1009,9 +1010,9 @@ def test_stats():
         table = db.create_table("test", [{"id": 1}])
         res = table.stats()
         print(f"{res=}")
-        # A server that omits the per-column breakdown reports it as None
-        # rather than leaving the key out.
-        assert res == {**stats, "column_bytes": None}
+        # A server that omits the per-column breakdown reports it as None.
+        assert res == TableStatistics._from_dict({**stats, "column_bytes": None})
+        assert res.column_bytes is None
 
 
 def test_stats_column_bytes():
@@ -1053,7 +1054,11 @@ def test_stats_column_bytes():
 
     with mock_lancedb_connection(handler) as db:
         table = db.create_table("test", [{"id": 1}])
-        assert table.stats() == stats
+        res = table.stats()
+        # The dotted paths are opaque to the client: whatever breakdown the
+        # server sends is passed through verbatim.
+        assert res == TableStatistics._from_dict(stats)
+        assert res.column_bytes == stats["column_bytes"]
 
 
 @contextlib.contextmanager

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -1009,7 +1009,51 @@ def test_stats():
         table = db.create_table("test", [{"id": 1}])
         res = table.stats()
         print(f"{res=}")
-        assert res == stats
+        # A server that omits the per-column breakdown reports it as None
+        # rather than leaving the key out.
+        assert res == {**stats, "column_bytes": None}
+
+
+def test_stats_column_bytes():
+    stats = {
+        "total_bytes": 38,
+        "num_rows": 2,
+        "num_indices": 0,
+        "fragment_stats": {
+            "num_fragments": 1,
+            "num_small_fragments": 1,
+            "lengths": {
+                "min": 2,
+                "max": 2,
+                "mean": 2,
+                "p25": 2,
+                "p50": 2,
+                "p75": 2,
+                "p99": 2,
+            },
+        },
+        "column_bytes": {"id": 20, "meta": 18, "meta.a": 18},
+    }
+
+    def handler(request):
+        if request.path == "/v1/table/test/create/?mode=create":
+            request.send_response(200)
+            request.send_header("Content-Type", "application/json")
+            request.end_headers()
+            request.wfile.write(b"{}")
+        elif request.path == "/v1/table/test/stats/":
+            request.send_response(200)
+            request.send_header("Content-Type", "application/json")
+            request.end_headers()
+            request.wfile.write(json.dumps(stats).encode())
+        else:
+            print(request.path)
+            request.send_response(404)
+            request.end_headers()
+
+    with mock_lancedb_connection(handler) as db:
+        table = db.create_table("test", [{"id": 1}])
+        assert table.stats() == stats
 
 
 @contextlib.contextmanager

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -24,7 +24,12 @@ from lancedb.db import AsyncConnection, DBConnection
 from lancedb.embeddings import EmbeddingFunctionConfig, EmbeddingFunctionRegistry
 from lancedb.expr import col, lit
 from lancedb.pydantic import LanceModel, Vector
-from lancedb.table import LanceTable
+from lancedb.table import (
+    FragmentStatistics,
+    FragmentSummaryStats,
+    LanceTable,
+    TableStatistics,
+)
 from pydantic import BaseModel
 
 
@@ -3393,26 +3398,25 @@ def test_stats(mem_db: DBConnection):
     assert len(table) == 2
     stats = table.stats()
     print(f"{stats=}")
-    assert stats == {
-        "total_bytes": 60,
-        "num_rows": 2,
-        "num_indices": 0,
-        "fragment_stats": {
-            "num_fragments": 1,
-            "num_small_fragments": 1,
-            "lengths": {
-                "min": 2,
-                "max": 2,
-                "mean": 2,
-                "p25": 2,
-                "p50": 2,
-                "p75": 2,
-                "p99": 2,
-            },
-        },
+    assert stats == TableStatistics(
+        total_bytes=60,
+        num_rows=2,
+        num_indices=0,
+        fragment_stats=FragmentStatistics(
+            num_fragments=1,
+            num_small_fragments=1,
+            lengths=FragmentSummaryStats(
+                min=2, max=2, mean=2, p25=2, p50=2, p75=2, p99=2
+            ),
+        ),
         # Both columns are counted, and the two together make up total_bytes.
-        "column_bytes": {"text": 34, "id": 26},
-    }
+        column_bytes={"text": 34, "id": 26},
+    )
+    # Subscript access still works, for callers written against the older API
+    # that returned a plain dictionary.
+    assert stats["total_bytes"] == stats.total_bytes == 60
+    assert stats["fragment_stats"]["lengths"]["p99"] == 2
+    assert stats["column_bytes"] == stats.column_bytes
 
 
 def test_stats_column_bytes_nested(mem_db: DBConnection):
@@ -3430,7 +3434,8 @@ def test_stats_column_bytes_nested(mem_db: DBConnection):
         data=[{"id": i, "meta": {"a": i, "b": f"value-{i}"}} for i in range(100)],
         schema=schema,
     )
-    column_bytes = table.stats()["column_bytes"]
+    stats = table.stats()
+    column_bytes = stats.column_bytes
 
     # Nested fields get their own dotted-path entries.
     assert set(column_bytes) == {"id", "meta", "meta.a", "meta.b"}
@@ -3439,7 +3444,63 @@ def test_stats_column_bytes_nested(mem_db: DBConnection):
     # A struct's entry covers its whole subtree.
     assert column_bytes["meta"] >= column_bytes["meta.a"] + column_bytes["meta.b"]
     # Top-level entries alone sum to the table total.
-    assert column_bytes["id"] + column_bytes["meta"] == table.stats()["total_bytes"]
+    assert column_bytes["id"] + column_bytes["meta"] == stats.total_bytes
+
+
+def test_stats_column_bytes_list_elements_not_broken_out(mem_db: DBConnection):
+    """A list's element is an encoding detail, not a column, so it must not
+    appear as a redundant ``tags.item`` entry duplicating ``tags``."""
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int32()),
+            pa.field("tags", pa.list_(pa.utf8())),
+            pa.field("vector", pa.list_(pa.float32(), 4)),
+        ]
+    )
+    table = mem_db.create_table(
+        "list_stats",
+        data=[
+            {"id": i, "tags": [f"tag-{i}", "shared"], "vector": [0.1] * 4}
+            for i in range(100)
+        ],
+        schema=schema,
+    )
+    stats = table.stats()
+
+    assert set(stats.column_bytes) == {"id", "tags", "vector"}
+    # The element bytes are rolled into the list column, not dropped.
+    assert stats.column_bytes["tags"] > 0
+    assert sum(stats.column_bytes.values()) == stats.total_bytes
+
+
+def test_stats_column_bytes_dotted_field_name(mem_db: DBConnection):
+    """A subfield whose name contains a dot is backtick-quoted so it stays
+    distinguishable from the nested path that spells the same way."""
+    schema = pa.schema(
+        [
+            pa.field(
+                "meta",
+                pa.struct(
+                    [
+                        pa.field("a.b", pa.int32()),
+                        pa.field("a", pa.struct([pa.field("b", pa.int32())])),
+                    ]
+                ),
+            )
+        ]
+    )
+    table = mem_db.create_table(
+        "dotted_stats",
+        data=[{"meta": {"a.b": i, "a": {"b": i * 1000}}} for i in range(100)],
+        schema=schema,
+    )
+    stats = table.stats()
+
+    # All four fields are present; naive dotted keying would collide the leaf
+    # named "a.b" with the meta -> a -> b path and silently lose one.
+    assert set(stats.column_bytes) == {"meta", "meta.`a.b`", "meta.a", "meta.a.b"}
+    assert stats.column_bytes["meta.a"] == stats.column_bytes["meta.a.b"]
+    assert stats.column_bytes["meta"] == stats.total_bytes
 
 
 @pytest.mark.asyncio
@@ -3449,8 +3510,8 @@ async def test_stats_column_bytes_async(mem_db_async: AsyncConnection):
         data=[{"text": "foo", "id": 0}, {"text": "bar", "id": 1}],
     )
     stats = await table.stats()
-    assert set(stats["column_bytes"]) == {"text", "id"}
-    assert sum(stats["column_bytes"].values()) == stats["total_bytes"]
+    assert set(stats.column_bytes) == {"text", "id"}
+    assert sum(stats.column_bytes.values()) == stats.total_bytes
 
 
 def test_create_table_empty_list_with_schema(mem_db: DBConnection):

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -3410,7 +3410,47 @@ def test_stats(mem_db: DBConnection):
                 "p99": 2,
             },
         },
+        # Both columns are counted, and the two together make up total_bytes.
+        "column_bytes": {"text": 34, "id": 26},
     }
+
+
+def test_stats_column_bytes_nested(mem_db: DBConnection):
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int32()),
+            pa.field(
+                "meta",
+                pa.struct([pa.field("a", pa.int32()), pa.field("b", pa.utf8())]),
+            ),
+        ]
+    )
+    table = mem_db.create_table(
+        "nested_stats",
+        data=[{"id": i, "meta": {"a": i, "b": f"value-{i}"}} for i in range(100)],
+        schema=schema,
+    )
+    column_bytes = table.stats()["column_bytes"]
+
+    # Nested fields get their own dotted-path entries.
+    assert set(column_bytes) == {"id", "meta", "meta.a", "meta.b"}
+    assert column_bytes["meta.a"] > 0
+    assert column_bytes["meta.b"] > 0
+    # A struct's entry covers its whole subtree.
+    assert column_bytes["meta"] >= column_bytes["meta.a"] + column_bytes["meta.b"]
+    # Top-level entries alone sum to the table total.
+    assert column_bytes["id"] + column_bytes["meta"] == table.stats()["total_bytes"]
+
+
+@pytest.mark.asyncio
+async def test_stats_column_bytes_async(mem_db_async: AsyncConnection):
+    table = await mem_db_async.create_table(
+        "my_table",
+        data=[{"text": "foo", "id": 0}, {"text": "bar", "id": 1}],
+    )
+    stats = await table.stats()
+    assert set(stats["column_bytes"]) == {"text", "id"}
+    assert sum(stats["column_bytes"].values()) == stats["total_bytes"]
 
 
 def test_create_table_empty_list_with_schema(mem_db: DBConnection):

--- a/python/src/table.rs
+++ b/python/src/table.rs
@@ -944,6 +944,10 @@ impl Table {
                 fragment_stats.set_item("lengths", fragment_lengths)?;
                 dict.set_item("fragment_stats", fragment_stats)?;
 
+                // `None` when the backend reports no per-column breakdown
+                // (e.g. an older remote server).
+                dict.set_item("column_bytes", stats.column_bytes)?;
+
                 Ok(Some(dict.unbind()))
             })
         })

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -9764,4 +9764,53 @@ mod tests {
             .unwrap();
         branch.stats().await.unwrap();
     }
+
+    fn stats_handler(body: &'static str) -> Table {
+        Table::new_with_handler("my_table", move |request| {
+            assert_eq!(request.url().path(), "/v1/table/my_table/stats/");
+            http::Response::builder()
+                .status(200)
+                .body(body.to_string())
+                .unwrap()
+        })
+    }
+
+    #[tokio::test]
+    async fn test_stats_column_bytes() {
+        // The dotted paths are opaque to the client: whatever breakdown the
+        // server sends is passed through verbatim, nesting levels and all.
+        let stats = stats_handler(
+            r#"{"total_bytes":56,"num_rows":2,"num_indices":0,"fragment_stats":{"num_fragments":1,"num_small_fragments":1,"lengths":{"min":2,"max":2,"mean":2,"p25":2,"p50":2,"p75":2,"p99":2}},"column_bytes":{"id":20,"meta":36,"meta.a":16,"meta.b":18}}"#,
+        )
+        .stats()
+        .await
+        .unwrap();
+
+        let column_bytes = stats.column_bytes.unwrap();
+        assert_eq!(column_bytes.len(), 4);
+        assert_eq!(column_bytes["id"], 20);
+        assert_eq!(column_bytes["meta"], 36);
+        assert_eq!(column_bytes["meta.a"], 16);
+        assert_eq!(column_bytes["meta.b"], 18);
+        // Top-level entries alone account for the table total.
+        assert_eq!(
+            column_bytes["id"] + column_bytes["meta"],
+            stats.total_bytes as u64
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stats_column_bytes_absent() {
+        // An older server omits the field entirely. That must degrade to `None`
+        // rather than failing the whole stats response.
+        let stats = stats_handler(
+            r#"{"total_bytes":1,"num_rows":3,"num_indices":0,"fragment_stats":{"num_fragments":1,"num_small_fragments":0,"lengths":{"min":3,"max":3,"mean":3,"p25":3,"p50":3,"p75":3,"p99":3}}}"#,
+        )
+        .stats()
+        .await
+        .unwrap();
+
+        assert!(stats.column_bytes.is_none());
+        assert_eq!(stats.num_rows, 3);
+    }
 }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -2096,6 +2096,23 @@ impl Table {
     }
 
     /// Retrieve statistics on the table
+    ///
+    /// See [`TableStatistics`] for the full breakdown, including
+    /// [`TableStatistics::column_bytes`] for the on-disk size of each column.
+    ///
+    /// ```
+    /// # use lancedb::Table;
+    /// # async fn column_sizes(table: &Table) -> Result<(), Box<dyn std::error::Error>> {
+    /// let stats = table.stats().await?;
+    /// println!("{} bytes total", stats.total_bytes);
+    /// if let Some(column_bytes) = &stats.column_bytes {
+    ///     for (path, bytes) in column_bytes {
+    ///         println!("  {path}: {bytes} bytes");
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn stats(&self) -> Result<TableStatistics> {
         self.inner.stats().await
     }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -23,6 +23,7 @@ use lance::dataset::{InsertBuilder, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance::index::scalar::load_segment_params;
 use lance::io::{ObjectStoreParams, WrappingObjectStore};
+use lance_core::datatypes::{Field as LanceField, format_field_path};
 use lance_datafusion::utils::StreamingWriteSource;
 use lance_index::IndexCriteria;
 use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsAccessor};
@@ -3471,38 +3472,17 @@ impl BaseTable for NativeTable {
         let ds_stats = Arc::new(ds_clone).calculate_data_stats().await?;
         let total_bytes = ds_stats.fields.iter().map(|f| f.bytes_on_disk).sum::<u64>() as usize;
 
-        // One entry per field at every nesting level, keyed by dotted path
-        // ("meta", "meta.geo", "meta.geo.lat"). Each entry is the field's own
-        // bytes plus its whole subtree, so a struct reports its total while its
-        // children report the breakdown. Every field gets an entry even when
-        // the stats report no bytes for it (empty table, legacy storage), so
-        // columns appear as 0 rather than being absent.
         let bytes_by_id: HashMap<u32, u64> = ds_stats
             .fields
             .iter()
             .map(|f| (f.id, f.bytes_on_disk))
             .collect();
-        fn subtree_bytes(
-            field: &lance_core::datatypes::Field,
-            path: String,
-            bytes_by_id: &HashMap<u32, u64>,
-            column_bytes: &mut HashMap<String, u64>,
-        ) -> u64 {
-            let mut total = bytes_by_id.get(&(field.id as u32)).copied().unwrap_or(0);
-            for child in &field.children {
-                total += subtree_bytes(
-                    child,
-                    format!("{path}.{}", child.name),
-                    bytes_by_id,
-                    column_bytes,
-                );
-            }
-            column_bytes.insert(path, total);
-            total
-        }
         let mut column_bytes: HashMap<String, u64> = HashMap::new();
+        let mut path = Vec::new();
         for column in &ds.schema().fields {
-            subtree_bytes(column, column.name.clone(), &bytes_by_id, &mut column_bytes);
+            path.push(column.name.as_str());
+            record_column_bytes(column, &mut path, &bytes_by_id, &mut column_bytes);
+            path.pop();
         }
 
         let frags = ds.get_fragments();
@@ -3573,6 +3553,54 @@ impl BaseTable for NativeTable {
     }
 }
 
+/// The bytes stored for `field` itself plus every field nested beneath it, at
+/// any depth.
+///
+/// Fields the stats don't mention count as 0, so a column on an empty table (or
+/// on legacy storage, where `bytes_on_disk` is always 0) reports 0 rather than
+/// being left out of the breakdown entirely.
+fn subtree_bytes(field: &LanceField, bytes_by_id: &HashMap<u32, u64>) -> u64 {
+    let own = u32::try_from(field.id)
+        .ok()
+        .and_then(|id| bytes_by_id.get(&id).copied())
+        .unwrap_or(0);
+    own + field
+        .children
+        .iter()
+        .map(|child| subtree_bytes(child, bytes_by_id))
+        .sum::<u64>()
+}
+
+/// Records one [`TableStatistics::column_bytes`] entry for `field` — keyed by
+/// the dotted path in `path` — and one for each of its named subfields,
+/// recursively.
+///
+/// Only a struct's children are named: a list's element is an encoding detail
+/// with no user-facing name, so its bytes roll up into the list column itself
+/// instead of appearing under a redundant `tags.item` key. Every entry covers
+/// the field's whole subtree either way, so a struct reports its total while
+/// its children report the breakdown.
+///
+/// Paths go through [`format_field_path`], which backtick-quotes any segment
+/// that needs it. Without that, a leaf named `a.b` under `meta` and the path
+/// `meta` -> `a` -> `b` would both key on `meta.a.b` and one would silently
+/// overwrite the other.
+fn record_column_bytes<'a>(
+    field: &'a LanceField,
+    path: &mut Vec<&'a str>,
+    bytes_by_id: &HashMap<u32, u64>,
+    column_bytes: &mut HashMap<String, u64>,
+) {
+    column_bytes.insert(format_field_path(path), subtree_bytes(field, bytes_by_id));
+    if field.logical_type.is_struct() {
+        for child in &field.children {
+            path.push(child.name.as_str());
+            record_column_bytes(child, path, bytes_by_id, column_bytes);
+            path.pop();
+        }
+    }
+}
+
 #[skip_serializing_none]
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct TableStatistics {
@@ -3589,13 +3617,20 @@ pub struct TableStatistics {
     pub fragment_stats: FragmentStatistics,
 
     /// The compressed on-disk bytes of each column, keyed by dotted field
-    /// path ("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an
-    /// entry covering the field's own bytes plus its whole subtree, so a
-    /// struct reports its total while its children report the breakdown (the
-    /// top-level entries alone sum to `total_bytes`). Counts data-file bytes
-    /// only: blob sidecar payloads and index files are not included, and blob
-    /// columns therefore report just their descriptor bytes. `None` when the
-    /// backend provides no per-column breakdown (e.g. older remote servers).
+    /// path ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each
+    /// get their own entry, and every entry covers the field's own bytes plus
+    /// its whole subtree, so a struct reports its total while its children
+    /// report the breakdown (the top-level entries alone sum to
+    /// `total_bytes`). List elements are not broken out: a list column
+    /// reports a single total with its element bytes rolled in. Path segments
+    /// containing anything other than letters, digits, or `_` are
+    /// backtick-quoted, so a subfield named `a.b` under `meta` is keyed as
+    /// ``meta.`a.b` ``.
+    ///
+    /// Counts data-file bytes only: blob sidecar payloads and index files are
+    /// not included, and blob columns therefore report just their descriptor
+    /// bytes. `None` when the backend provides no per-column breakdown (e.g.
+    /// older remote servers).
     #[serde(default)]
     pub column_bytes: Option<HashMap<String, u64>>,
 }
@@ -3635,9 +3670,10 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
+    use arrow_array::builder::{ListBuilder, StringBuilder};
     use arrow_array::{
-        ArrayRef, Int32Array, RecordBatch, RecordBatchIterator, RecordBatchReader, StringArray,
-        StructArray,
+        ArrayRef, FixedSizeListArray, Float32Array, Int32Array, RecordBatch, RecordBatchIterator,
+        RecordBatchReader, StringArray, StructArray,
     };
     use arrow_schema::{DataType, Field, Schema};
     use futures::TryStreamExt;
@@ -5208,5 +5244,136 @@ mod tests {
         );
         // Exactly the four expected paths, nothing else.
         assert_eq!(column_bytes.len(), 4);
+    }
+
+    /// A list's element child is an encoding detail, not a column, so it must
+    /// not show up as a redundant `tags.item` entry duplicating `tags`.
+    #[tokio::test]
+    pub async fn test_stats_column_bytes_list_elements_not_broken_out() {
+        let tmp_dir = tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+        let conn = ConnectBuilder::new(uri).execute().await.unwrap();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "tags",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+                true,
+            ),
+        ]));
+        let mut tags = ListBuilder::new(StringBuilder::new());
+        for i in 0..100 {
+            tags.values().append_value(format!("tag-{i}"));
+            tags.values().append_value("shared");
+            tags.append(true);
+        }
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..100)),
+                Arc::new(tags.finish()),
+                Arc::new(
+                    FixedSizeListArray::try_new(
+                        Arc::new(Field::new("item", DataType::Float32, true)),
+                        4,
+                        Arc::new(Float32Array::from_iter_values(
+                            (0..400).map(|i| i as f32 / 10.0),
+                        )),
+                        None,
+                    )
+                    .unwrap(),
+                ),
+            ],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("list_stats", batch)
+            .execute()
+            .await
+            .unwrap();
+
+        let stats = table.stats().await.unwrap();
+        let column_bytes = stats.column_bytes.unwrap();
+
+        // One entry per column: no `tags.item`, no `vector.item`.
+        assert_eq!(
+            column_bytes.keys().cloned().collect::<HashSet<_>>(),
+            HashSet::from(["id".to_string(), "tags".to_string(), "vector".to_string()])
+        );
+        // The element bytes are rolled into the list column, not dropped.
+        assert!(column_bytes["tags"] > 0);
+        assert!(column_bytes["vector"] > 0);
+        assert_eq!(
+            column_bytes["id"] + column_bytes["tags"] + column_bytes["vector"],
+            stats.total_bytes as u64
+        );
+    }
+
+    /// A subfield whose name contains a dot must not collide with the nested
+    /// path that spells the same way. Here `meta` has both a leaf named `a.b`
+    /// and a struct `a` containing `b`; naive `format!("{path}.{name}")` keying
+    /// would produce `meta.a.b` twice and silently lose one field.
+    #[tokio::test]
+    pub async fn test_stats_column_bytes_dotted_field_name() {
+        let tmp_dir = tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+        let conn = ConnectBuilder::new(uri).execute().await.unwrap();
+
+        let a_fields = vec![Field::new("b", DataType::Int32, true)];
+        let meta_fields = vec![
+            Field::new("a.b", DataType::Int32, true),
+            Field::new("a", DataType::Struct(a_fields.clone().into()), true),
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "meta",
+            DataType::Struct(meta_fields.clone().into()),
+            true,
+        )]));
+        let meta = StructArray::new(
+            meta_fields.into(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..100)) as ArrayRef,
+                Arc::new(StructArray::new(
+                    a_fields.into(),
+                    vec![
+                        Arc::new(Int32Array::from_iter_values((0..100).map(|i| i * 1000)))
+                            as ArrayRef,
+                    ],
+                    None,
+                )) as ArrayRef,
+            ],
+            None,
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(meta)]).unwrap();
+        let table = conn
+            .create_table("dotted_stats", batch)
+            .execute()
+            .await
+            .unwrap();
+
+        let stats = table.stats().await.unwrap();
+        let column_bytes = stats.column_bytes.unwrap();
+
+        // All four fields are present, with the dotted name backtick-quoted so
+        // it stays distinguishable from the `meta` -> `a` -> `b` path.
+        assert_eq!(
+            column_bytes.keys().cloned().collect::<HashSet<_>>(),
+            HashSet::from([
+                "meta".to_string(),
+                "meta.`a.b`".to_string(),
+                "meta.a".to_string(),
+                "meta.a.b".to_string(),
+            ])
+        );
+        assert!(column_bytes["meta.`a.b`"] > 0);
+        assert!(column_bytes["meta.a.b"] > 0);
+        assert_eq!(column_bytes["meta.a"], column_bytes["meta.a.b"]);
+        assert_eq!(column_bytes["meta"], stats.total_bytes as u64);
     }
 }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -23,7 +23,7 @@ use lance::dataset::{InsertBuilder, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance::index::scalar::load_segment_params;
 use lance::io::{ObjectStoreParams, WrappingObjectStore};
-use lance_core::datatypes::{Field as LanceField, format_field_path};
+use lance_core::datatypes::{Field as LanceField, format_field_path_minimal};
 use lance_datafusion::utils::StreamingWriteSource;
 use lance_index::IndexCriteria;
 use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsAccessor};
@@ -3581,17 +3581,26 @@ fn subtree_bytes(field: &LanceField, bytes_by_id: &HashMap<u32, u64>) -> u64 {
 /// the field's whole subtree either way, so a struct reports its total while
 /// its children report the breakdown.
 ///
-/// Paths go through [`format_field_path`], which backtick-quotes any segment
-/// that needs it. Without that, a leaf named `a.b` under `meta` and the path
-/// `meta` -> `a` -> `b` would both key on `meta.a.b` and one would silently
-/// overwrite the other.
+/// Paths go through [`format_field_path_minimal`], which quotes a segment only
+/// when it contains a `.` or a backtick. The quoting is what keeps a leaf named
+/// `a.b` under `meta` distinct from the path `meta` -> `a` -> `b`; without it
+/// both would key on `meta.a.b` and one would silently overwrite the other.
+/// Leaving everything else bare is deliberate: these keys are meant to be shown
+/// to people, so an ordinary name like `user-id` should not arrive wrapped in
+/// backticks. (The stricter [`format_field_path`] is for paths headed into a SQL
+/// expression, which these are not.)
+///
+/// [`format_field_path`]: lance_core::datatypes::format_field_path
 fn record_column_bytes<'a>(
     field: &'a LanceField,
     path: &mut Vec<&'a str>,
     bytes_by_id: &HashMap<u32, u64>,
     column_bytes: &mut HashMap<String, u64>,
 ) {
-    column_bytes.insert(format_field_path(path), subtree_bytes(field, bytes_by_id));
+    column_bytes.insert(
+        format_field_path_minimal(path),
+        subtree_bytes(field, bytes_by_id),
+    );
     if field.logical_type.is_struct() {
         for child in &field.children {
             path.push(child.name.as_str());
@@ -3620,12 +3629,13 @@ pub struct TableStatistics {
     /// path ("meta", "meta.geo", "meta.geo.lat"). A struct's subfields each
     /// get their own entry, and every entry covers the field's own bytes plus
     /// its whole subtree, so a struct reports its total while its children
-    /// report the breakdown (the top-level entries alone sum to
-    /// `total_bytes`). List elements are not broken out: a list column
-    /// reports a single total with its element bytes rolled in. Path segments
-    /// containing anything other than letters, digits, or `_` are
-    /// backtick-quoted, so a subfield named `a.b` under `meta` is keyed as
-    /// ``meta.`a.b` ``.
+    /// report the breakdown. Only the top-level entries sum to `total_bytes`;
+    /// summing every entry double-counts anything nested. List elements are
+    /// not broken out: a list column reports a single total with its element
+    /// bytes rolled in. A path segment is backtick-quoted only when it
+    /// contains a `.` or a backtick, so a subfield named `a.b` under `meta` is
+    /// keyed as ``meta.`a.b` `` while an ordinary name like `user-id` is left
+    /// bare.
     ///
     /// Counts data-file bytes only: blob sidecar payloads and index files are
     /// not included, and blob columns therefore report just their descriptor
@@ -5375,5 +5385,53 @@ mod tests {
         assert!(column_bytes["meta.a.b"] > 0);
         assert_eq!(column_bytes["meta.a"], column_bytes["meta.a.b"]);
         assert_eq!(column_bytes["meta"], stats.total_bytes as u64);
+    }
+
+    /// Quoting is reserved for names that would otherwise be ambiguous. A
+    /// hyphen or a space is not special to a field path, so such names stay
+    /// bare — these keys get shown to people, and `` `user-id` `` would read as
+    /// a formatting bug.
+    #[tokio::test]
+    pub async fn test_stats_column_bytes_names_are_not_over_quoted() {
+        let tmp_dir = tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+        let conn = ConnectBuilder::new(uri).execute().await.unwrap();
+
+        let inner_fields = vec![Field::new("first name", DataType::Utf8, true)];
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("user-id", DataType::Int32, false),
+            Field::new("meta", DataType::Struct(inner_fields.clone().into()), true),
+        ]));
+        let meta = StructArray::new(
+            inner_fields.into(),
+            vec![Arc::new(StringArray::from_iter_values(
+                (0..100).map(|i| format!("name-{i}")),
+            )) as ArrayRef],
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..100)),
+                Arc::new(meta),
+            ],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("unquoted_stats", batch)
+            .execute()
+            .await
+            .unwrap();
+
+        let column_bytes = table.stats().await.unwrap().column_bytes.unwrap();
+
+        assert_eq!(
+            column_bytes.keys().cloned().collect::<HashSet<_>>(),
+            HashSet::from([
+                "user-id".to_string(),
+                "meta".to_string(),
+                "meta.first name".to_string(),
+            ])
+        );
     }
 }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -3454,6 +3454,27 @@ impl BaseTable for NativeTable {
         let ds_stats = Arc::new(ds_clone).calculate_data_stats().await?;
         let total_bytes = ds_stats.fields.iter().map(|f| f.bytes_on_disk).sum::<u64>() as usize;
 
+        // Roll the per-field stats up to top-level columns: every field id in a
+        // column's subtree (struct/list children) maps back to the root column
+        // name. Columns are seeded at 0 so an empty or legacy-storage column
+        // still appears in the map rather than being absent.
+        let mut field_to_column: HashMap<u32, &str> = HashMap::new();
+        let mut column_bytes: HashMap<String, u64> = HashMap::new();
+        for column in &ds.schema().fields {
+            column_bytes.insert(column.name.clone(), 0);
+            let mut subtree = vec![column];
+            while let Some(field) = subtree.pop() {
+                field_to_column.insert(field.id as u32, column.name.as_str());
+                subtree.extend(field.children.iter());
+            }
+        }
+        for field_stats in &ds_stats.fields {
+            if let Some(column) = field_to_column.get(&field_stats.id) {
+                *column_bytes.entry((*column).to_string()).or_insert(0) +=
+                    field_stats.bytes_on_disk;
+            }
+        }
+
         let frags = ds.get_fragments();
         let mut sorted_sizes = join_all(
             frags
@@ -3501,6 +3522,7 @@ impl BaseTable for NativeTable {
             num_rows,
             num_indices,
             fragment_stats: frag_stats,
+            column_bytes: Some(column_bytes),
         };
         Ok(stats)
     }
@@ -3535,6 +3557,14 @@ pub struct TableStatistics {
 
     /// Statistics on table fragments
     pub fragment_stats: FragmentStatistics,
+
+    /// The compressed on-disk bytes of each top-level column, with nested
+    /// fields summed into their root column. Counts data-file bytes only:
+    /// blob sidecar payloads and index files are not included, and blob
+    /// columns therefore report just their descriptor bytes. `None` when the
+    /// backend provides no per-column breakdown (e.g. older remote servers).
+    #[serde(default)]
+    pub column_bytes: Option<HashMap<String, u64>>,
 }
 
 #[skip_serializing_none]
@@ -5052,6 +5082,12 @@ mod tests {
                         p99: 100,
                     },
                 },
+                // Both columns hold identical data, so they split total_bytes
+                // evenly.
+                column_bytes: Some(HashMap::from([
+                    ("id".to_string(), 1150),
+                    ("foo".to_string(), 1150),
+                ])),
             }
         );
         let res = empty_table.stats().await.unwrap();
@@ -5075,6 +5111,11 @@ mod tests {
                         p99: 0,
                     },
                 },
+                // Columns are seeded at 0 even when no fragments exist.
+                column_bytes: Some(HashMap::from([
+                    ("id".to_string(), 0),
+                    ("foo".to_string(), 0),
+                ])),
             }
         )
     }

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -3454,25 +3454,38 @@ impl BaseTable for NativeTable {
         let ds_stats = Arc::new(ds_clone).calculate_data_stats().await?;
         let total_bytes = ds_stats.fields.iter().map(|f| f.bytes_on_disk).sum::<u64>() as usize;
 
-        // Roll the per-field stats up to top-level columns: every field id in a
-        // column's subtree (struct/list children) maps back to the root column
-        // name. Columns are seeded at 0 so an empty or legacy-storage column
-        // still appears in the map rather than being absent.
-        let mut field_to_column: HashMap<u32, &str> = HashMap::new();
+        // One entry per field at every nesting level, keyed by dotted path
+        // ("meta", "meta.geo", "meta.geo.lat"). Each entry is the field's own
+        // bytes plus its whole subtree, so a struct reports its total while its
+        // children report the breakdown. Every field gets an entry even when
+        // the stats report no bytes for it (empty table, legacy storage), so
+        // columns appear as 0 rather than being absent.
+        let bytes_by_id: HashMap<u32, u64> = ds_stats
+            .fields
+            .iter()
+            .map(|f| (f.id, f.bytes_on_disk))
+            .collect();
+        fn subtree_bytes(
+            field: &lance_core::datatypes::Field,
+            path: String,
+            bytes_by_id: &HashMap<u32, u64>,
+            column_bytes: &mut HashMap<String, u64>,
+        ) -> u64 {
+            let mut total = bytes_by_id.get(&(field.id as u32)).copied().unwrap_or(0);
+            for child in &field.children {
+                total += subtree_bytes(
+                    child,
+                    format!("{path}.{}", child.name),
+                    bytes_by_id,
+                    column_bytes,
+                );
+            }
+            column_bytes.insert(path, total);
+            total
+        }
         let mut column_bytes: HashMap<String, u64> = HashMap::new();
         for column in &ds.schema().fields {
-            column_bytes.insert(column.name.clone(), 0);
-            let mut subtree = vec![column];
-            while let Some(field) = subtree.pop() {
-                field_to_column.insert(field.id as u32, column.name.as_str());
-                subtree.extend(field.children.iter());
-            }
-        }
-        for field_stats in &ds_stats.fields {
-            if let Some(column) = field_to_column.get(&field_stats.id) {
-                *column_bytes.entry((*column).to_string()).or_insert(0) +=
-                    field_stats.bytes_on_disk;
-            }
+            subtree_bytes(column, column.name.clone(), &bytes_by_id, &mut column_bytes);
         }
 
         let frags = ds.get_fragments();
@@ -3558,9 +3571,12 @@ pub struct TableStatistics {
     /// Statistics on table fragments
     pub fragment_stats: FragmentStatistics,
 
-    /// The compressed on-disk bytes of each top-level column, with nested
-    /// fields summed into their root column. Counts data-file bytes only:
-    /// blob sidecar payloads and index files are not included, and blob
+    /// The compressed on-disk bytes of each column, keyed by dotted field
+    /// path ("meta", "meta.geo", "meta.geo.lat"). Every nesting level gets an
+    /// entry covering the field's own bytes plus its whole subtree, so a
+    /// struct reports its total while its children report the breakdown (the
+    /// top-level entries alone sum to `total_bytes`). Counts data-file bytes
+    /// only: blob sidecar payloads and index files are not included, and blob
     /// columns therefore report just their descriptor bytes. `None` when the
     /// backend provides no per-column breakdown (e.g. older remote servers).
     #[serde(default)]
@@ -3603,7 +3619,8 @@ mod tests {
     use std::time::Duration;
 
     use arrow_array::{
-        Int32Array, RecordBatch, RecordBatchIterator, RecordBatchReader, StringArray,
+        ArrayRef, Int32Array, RecordBatch, RecordBatchIterator, RecordBatchReader, StringArray,
+        StructArray,
     };
     use arrow_schema::{DataType, Field, Schema};
     use futures::TryStreamExt;
@@ -5118,5 +5135,61 @@ mod tests {
                 ])),
             }
         )
+    }
+
+    #[tokio::test]
+    pub async fn test_stats_nested_column_bytes() {
+        let tmp_dir = tempdir().unwrap();
+        let uri = tmp_dir.path().to_str().unwrap();
+        let conn = ConnectBuilder::new(uri).execute().await.unwrap();
+
+        let inner_fields = vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Utf8, true),
+        ];
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("meta", DataType::Struct(inner_fields.clone().into()), true),
+        ]));
+        let meta = StructArray::new(
+            inner_fields.into(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..100)) as ArrayRef,
+                Arc::new(StringArray::from_iter_values(
+                    (0..100).map(|i| format!("value-{i}")),
+                )) as ArrayRef,
+            ],
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..100)),
+                Arc::new(meta),
+            ],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("nested_stats", batch)
+            .execute()
+            .await
+            .unwrap();
+
+        let stats = table.stats().await.unwrap();
+        let column_bytes = stats.column_bytes.unwrap();
+
+        // Nested fields get their own dotted-path entries.
+        assert!(column_bytes["meta.a"] > 0);
+        assert!(column_bytes["meta.b"] > 0);
+        // A struct's entry covers its whole subtree (its own validity bytes
+        // plus every child).
+        assert!(column_bytes["meta"] >= column_bytes["meta.a"] + column_bytes["meta.b"]);
+        // Top-level entries alone sum to the table total.
+        assert_eq!(
+            column_bytes["id"] + column_bytes["meta"],
+            stats.total_bytes as u64
+        );
+        // Exactly the four expected paths, nothing else.
+        assert_eq!(column_bytes.len(), 4);
     }
 }


### PR DESCRIPTION
There was a request to show the size of each column in the UI. Since we already have bytes_on_disk, this seems cheap to compute, so this just computes it.

For nested fields, it reports the size for each field. e.g. if your fields are `name` and `geo` (which includes `lat` and `lon`), you could get:
- name: 1mb
- geo: 2mb
- geo.lat: 1mb
- geo.lon: 1mb

but the table's total size is 3mb (sum of top-level fields). This seems right to me (e.g. it is correct for each field), you just have to be careful not to naively sum all fields to get the table size. As the table size is already computed (elsewhere), it seems like we won't accidentally do that.

## Note
This PR changes the python return type from a dict to a dataclass, which would be a breaking change - can change it back to a dict if you prefer.