### PR TITLE
fix(python): add on_bad_vectors="keep" to allow NaN vectors

### DIFF
--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -227,6 +227,7 @@ class Table:
         mode: Literal["append", "overwrite"],
         progress: Optional[Any] = None,
         write_parallelism: Optional[int] = None,
+        on_nan_vectors: Optional[Literal["error", "keep"]] = None,
     ) -> AddResult: ...
     async def update(
         self, updates: Dict[str, str], where: Optional[str]

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -331,7 +331,9 @@ class DBConnection(EnforceOverrides):
             schema that's specified.
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
-            One of "error", "drop", "fill".
+            One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+            containing NaNs are kept unchanged; wrong-size vectors still raise
+            an error.
         fill_value: float
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         storage_options: dict, optional
@@ -1498,7 +1500,9 @@ class AsyncConnection(object):
             schema that's specified.
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
-            One of "error", "drop", "fill".
+            One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+            containing NaNs are kept unchanged; wrong-size vectors still raise
+            an error.
         fill_value: float
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         storage_options: dict, optional

--- a/python/python/lancedb/merge.py
+++ b/python/python/lancedb/merge.py
@@ -173,7 +173,9 @@ class LanceMergeInsertBuilder(object):
             can be anything you use for [`add`][lancedb.table.Table.add]
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
-            One of "error", "drop", "fill".
+            One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+            containing NaNs are kept unchanged; wrong-size vectors still raise
+            an error.
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         timeout: Optional[timedelta], default None

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -350,7 +350,7 @@ def _sanitize_data(
         in the input table before casting.
     metadata : Optional[dict], default None
         The embedding metadata to add to the schema.
-    on_bad_vectors : Literal["error", "drop", "fill", "null"], default "error"
+    on_bad_vectors : Literal["error", "drop", "fill", "null", "keep"], default "error"
         What to do if any of the vectors are not the same size or contains NaNs.
     fill_value : float, default 0.0
         The value to use when filling vectors. Only used if on_bad_vectors="fill".
@@ -1247,7 +1247,9 @@ class Table(ABC):
             "append" and "overwrite".
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
-            One of "error", "drop", "fill".
+            One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+            containing NaNs are added unchanged (rows with NaNs are not indexed
+            for vector search); wrong-size vectors still raise an error.
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         progress: bool, callable, or tqdm-like, optional
@@ -3265,7 +3267,9 @@ class LanceTable(Table):
             "append" and "overwrite".
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
-            One of "error", "drop", "fill", "null".
+            One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+            containing NaNs are added unchanged (rows with NaNs are not indexed
+            for vector search); wrong-size vectors still raise an error.
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         progress: bool, callable, or tqdm-like, optional
@@ -3578,7 +3582,9 @@ class LanceTable(Table):
             data but will validate against any schema that's specified.
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
-            One of "error", "drop", "fill", "null".
+            One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+            containing NaNs are added unchanged (rows with NaNs are not indexed
+            for vector search); wrong-size vectors still raise an error.
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         embedding_functions: list of EmbeddingFunctionModel, default None
@@ -4188,7 +4194,8 @@ def _handle_bad_vector_column(
         The name of the vector column.
     on_bad_vectors: str, default "error"
         What to do if any of the vectors are not the same size or contains NaNs.
-        One of "error", "drop", "fill", "null".
+        One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+        containing NaNs are kept unchanged; wrong-size vectors still raise an error.
     fill_value: float, default 0.0
         The value to use when filling vectors. Only used if on_bad_vectors="fill".
     """
@@ -4270,6 +4277,15 @@ def _handle_bad_vector_column(
                     "`fill_value` must not be None if `on_bad_vectors` is 'fill'"
                 )
             vec_arr = _fill_bad_vector_values(vec_arr, dim, fill_value)
+        elif on_bad_vectors == "keep":
+            if pc.any(has_wrong_dim).as_py():
+                raise ValueError(
+                    f"Vector column '{vector_column_name}' has variable length "
+                    "vectors. on_bad_vectors='keep' only keeps NaN values. "
+                    "Set on_bad_vectors='drop' to remove wrong-size vectors, "
+                    "set on_bad_vectors='fill' and fill_value=<value> to replace them, "
+                    "or set on_bad_vectors='null' to replace them with null."
+                )
         else:
             raise ValueError(f"Invalid value for on_bad_vectors: {on_bad_vectors}")
 
@@ -5114,7 +5130,9 @@ class AsyncTable:
             "append" and "overwrite".
         on_bad_vectors: str, default "error"
             What to do if any of the vectors are not the same size or contains NaNs.
-            One of "error", "drop", "fill", "null".
+            One of "error", "drop", "fill", "null", "keep". With "keep", vectors
+            containing NaNs are added unchanged (rows with NaNs are not indexed
+            for vector search); wrong-size vectors still raise an error.
         fill_value: float, default 0.
             The value to use when filling vectors. Only used if on_bad_vectors="fill".
         progress: callable or tqdm-like, optional
@@ -5162,6 +5180,7 @@ class AsyncTable:
                 mode or "append",
                 progress=progress,
                 write_parallelism=write_parallelism,
+                on_nan_vectors="keep" if on_bad_vectors == "keep" else None,
             )
         except RuntimeError as e:
             if "Cast error" in str(e):

--- a/python/python/lancedb/types.py
+++ b/python/python/lancedb/types.py
@@ -24,7 +24,7 @@ DistanceType = Literal["l2", "cosine", "dot"]
 DistanceTypeWithHamming = Literal["l2", "cosine", "dot", "hamming"]
 
 # Vector handling literals
-OnBadVectorsType = Literal["error", "drop", "fill", "null"]
+OnBadVectorsType = Literal["error", "drop", "fill", "null", "keep"]
 
 # Mode literals
 AddMode = Literal["append", "overwrite"]

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -1766,6 +1766,61 @@ def test_add_with_nans(mem_db: DBConnection):
     assert np.allclose(filled_vectors[22.0], np.array([5.0, 0.0]))
 
 
+def test_add_with_nans_keep(mem_db: DBConnection):
+    """on_bad_vectors="keep" adds NaN vectors unchanged (issue #3153)."""
+    schema = pa.schema(
+        [
+            pa.field("vector", pa.list_(pa.float32(), 2), nullable=True),
+            pa.field("item", pa.string(), nullable=True),
+        ],
+    )
+    table = mem_db.create_table("test", schema=schema)
+
+    table.add(
+        [
+            {"vector": [3.1, 4.1], "item": "good"},
+            {"vector": [np.nan, 5.0], "item": "nan"},
+        ],
+        on_bad_vectors="keep",
+    )
+    assert len(table) == 2
+    vectors = {row["item"]: row["vector"] for row in table.to_arrow().to_pylist()}
+    assert np.allclose(vectors["good"], np.array([3.1, 4.1]))
+    assert np.isnan(vectors["nan"][0])
+    assert vectors["nan"][1] == 5.0
+
+    # Wrong-size vectors are still rejected with "keep". The error is raised
+    # while the record batch reader is consumed, so Arrow may surface it as a
+    # RuntimeError wrapping the original ValueError.
+    with pytest.raises((ValueError, RuntimeError), match="variable length"):
+        table.add([{"vector": [5.0], "item": "short"}], on_bad_vectors="keep")
+
+
+def test_add_with_nans_keep_unclassified_vector_column(mem_db: DBConnection):
+    """Fixed-size-list float columns too small to be classified as vector
+    columns can also carry NaN with on_bad_vectors="keep" (issue #3153)."""
+    schema = pa.schema([pa.field("data", pa.list_(pa.float32(), 2))])
+    table = mem_db.create_table("test", schema=schema)
+    batch = pa.table(
+        {
+            "data": pa.array(
+                [np.array([np.nan, 1.0], dtype=np.float32)],
+                type=schema.field("data").type,
+            )
+        },
+        schema=schema,
+    )
+
+    with pytest.raises(ValueError, match="NaN"):
+        table.add(batch)
+
+    table.add(batch, on_bad_vectors="keep")
+    assert len(table) == 1
+    values = table.to_arrow()["data"].to_pylist()[0]
+    assert np.isnan(values[0])
+    assert values[1] == 1.0
+
+
 def test_add_with_empty_fixed_size_list_drops_bad_rows(mem_db: DBConnection):
     class Schema(LanceModel):
         text: str

--- a/python/src/table.rs
+++ b/python/src/table.rs
@@ -21,7 +21,8 @@ use lancedb::blob::{BlobFile, BlobRangeRequest};
 use lancedb::index::scalar::FtsIndexBuilder;
 use lancedb::table::{
     AddDataMode, ColumnAlteration, Duration, FieldMetadataUpdate, FtsToken as LanceDbFtsToken,
-    NewColumnTransform, OptimizeAction, OptimizeOptions, Ref, Table as LanceDbTable,
+    NaNVectorBehavior, NewColumnTransform, OptimizeAction, OptimizeOptions, Ref,
+    Table as LanceDbTable,
 };
 use lancedb::tokenize as lancedb_tokenize;
 use pyo3::{
@@ -628,13 +629,14 @@ impl Table {
         })
     }
 
-    #[pyo3(signature = (data, mode, progress=None, write_parallelism=None))]
+    #[pyo3(signature = (data, mode, progress=None, write_parallelism=None, on_nan_vectors=None))]
     pub fn add<'a>(
         self_: PyRef<'a, Self>,
         data: PyScannable,
         mode: String,
         progress: Option<Py<PyAny>>,
         write_parallelism: Option<usize>,
+        on_nan_vectors: Option<String>,
     ) -> PyResult<Bound<'a, PyAny>> {
         let mut op = self_.inner_ref()?.add(data);
         if mode == "append" {
@@ -643,6 +645,18 @@ impl Table {
             op = op.mode(AddDataMode::Overwrite);
         } else {
             return Err(PyValueError::new_err(format!("Invalid mode: {}", mode)));
+        }
+        match on_nan_vectors.as_deref() {
+            None | Some("error") => {}
+            Some("keep") => {
+                op = op.on_nan_vectors(NaNVectorBehavior::Keep);
+            }
+            Some(other) => {
+                return Err(PyValueError::new_err(format!(
+                    "Invalid on_nan_vectors: {}",
+                    other
+                )));
+            }
         }
         if let Some(write_parallelism) = write_parallelism {
             op = op.write_parallelism(write_parallelism);


### PR DESCRIPTION
Closes #3153

Adding data with NaN values in a float vector column started failing in 0.30.0 with `Vector column contains NaN values`. The Rust core already supports keeping them via `NaNVectorBehavior::Keep`, but the Python bindings never exposed it, so every Python write took the reject path.

This adds `"keep"` to `OnBadVectorsType` and plumbs it through `AsyncTable.add` to the Rust add builder. Per the discussion on the issue, `"keep"` only keeps NaN and other float edge cases — wrong-size vectors still raise, since @mtauraso asked for bad sizes to keep erroring.

Verified with the repro from the issue: the default still raises, and `on_bad_vectors="keep"` round-trips `[nan, 1.0]` unchanged. New tests cover the NaN-kept, wrong-size-still-errors, and unclassified-vector-column cases; `pytest python/tests/test_table.py` passes (136 tests). `cargo clippy`, `cargo fmt`, and `ruff` are clean.

Two notes for reviewers:
- The wrong-size test asserts `pytest.raises((ValueError, RuntimeError))` because that `ValueError` is raised lazily while Arrow consumes the record-batch reader, so it surfaces wrapped as a `RuntimeError`. I followed the repo's existing idiom rather than papering over it; happy to translate the exception instead if you prefer.
- Remote tables take the same `on_bad_vectors` argument, but NaN handling there is enforced server-side, so a remote table may still reject NaN even with `"keep"`. I had no remote endpoint to verify that parity.
