### PR TITLE
fix: hybrid query offset/nprobes and merge_insert delete-condition reset bugs

### DIFF
--- a/python/python/lancedb/merge.py
+++ b/python/python/lancedb/merge.py
@@ -92,8 +92,10 @@ class LanceMergeInsertBuilder(object):
         self._when_not_matched_by_source_delete = True
         if isinstance(condition, Expr):
             self._when_not_matched_by_source_condition_expr = condition._inner
-        elif condition is not None:
+            self._when_not_matched_by_source_condition = None
+        else:
             self._when_not_matched_by_source_condition = condition
+            self._when_not_matched_by_source_condition_expr = None
         return self
 
     def use_index(self, use_index: bool) -> LanceMergeInsertBuilder:

--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -2235,6 +2235,7 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
             reranker=self._reranker,
             limit=self._limit,
             with_row_ids=True,
+            offset=self._offset,
         )
         return self._finish_hybrid_results(results)
 
@@ -2256,6 +2257,7 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
         reranker,
         limit: int,
         with_row_ids: bool,
+        offset: Optional[int] = None,
     ) -> pa.Table:
         if norm == "rank":
             vector_results = LanceHybridQueryBuilder._rank(vector_results, "_distance")
@@ -2332,7 +2334,7 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
             score_i = results.column_names.index("_score")
             results = results.set_column(score_i, "_score", original_scores)
 
-        results = results.slice(length=limit)
+        results = results.slice(offset=offset or 0, length=limit)
 
         if not with_row_ids:
             results = results.drop(["_rowid"])
@@ -2679,8 +2681,12 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
 
         # Apply common configurations
         if self._limit:
-            self._vector_query.limit(self._limit)
-            self._fts_query.limit(self._limit)
+            # The final offset/limit window is sliced out of the combined,
+            # reranked results, so each sub-query must fetch enough rows to
+            # cover the skipped prefix as well as the window itself.
+            sub_query_limit = self._limit + (self._offset or 0)
+            self._vector_query.limit(sub_query_limit)
+            self._fts_query.limit(sub_query_limit)
         if self._columns:
             self._vector_query.select(self._columns)
             self._fts_query.select(self._columns)
@@ -2697,7 +2703,7 @@ class LanceHybridQueryBuilder(LanceQueryBuilder):
             self._fts_query.phrase_query(True)
         if self._distance_type:
             self._vector_query.metric(self._distance_type)
-        if self._minimum_nprobes:
+        if self._minimum_nprobes is not None:
             self._vector_query.minimum_nprobes(self._minimum_nprobes)
         if self._maximum_nprobes is not None:
             self._vector_query.maximum_nprobes(self._maximum_nprobes)

--- a/python/python/tests/test_hybrid_query.py
+++ b/python/python/tests/test_hybrid_query.py
@@ -123,6 +123,44 @@ async def test_async_hybrid_query_default_limit(table: AsyncTable):
     assert texts.count("a") == 1
 
 
+def test_hybrid_query_offset(sync_table: Table):
+    # The offset window of a hybrid query must be a suffix of the same query
+    # run without an offset -- it must not be silently ignored.
+    full = (
+        sync_table.search(query_type="hybrid")
+        .vector([0.0, 0.4])
+        .text("dog")
+        .limit(4)
+        .with_row_id(True)
+        .to_arrow()
+    )
+    assert len(full) == 4
+
+    offset_result = (
+        sync_table.search(query_type="hybrid")
+        .vector([0.0, 0.4])
+        .text("dog")
+        .offset(2)
+        .limit(2)
+        .with_row_id(True)
+        .to_arrow()
+    )
+    assert offset_result["_rowid"].to_pylist() == full["_rowid"].to_pylist()[2:]
+
+
+def test_hybrid_query_minimum_nprobes_zero_raises(sync_table: Table):
+    # minimum_nprobes(0) must raise the same validation error a plain vector
+    # query raises, not silently no-op because 0 is falsy.
+    with pytest.raises(ValueError, match="minimum_nprobes must be greater than 0"):
+        (
+            sync_table.search(query_type="hybrid")
+            .vector([0.0, 0.4])
+            .text("dog")
+            .minimum_nprobes(0)
+            .to_arrow()
+        )
+
+
 def test_hybrid_query_distance_range(sync_table: Table):
     reranker = RRFReranker(return_score="all")
     result = (

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -2364,6 +2364,29 @@ def test_merge_insert_by_source_delete_expr(mem_db: DBConnection):
     assert table.to_arrow().sort_by("a") == expected
 
 
+def test_merge_insert_by_source_delete_reconfigure(mem_db: DBConnection):
+    # Calling when_not_matched_by_source_delete() again with no condition must
+    # widen the delete to unconditional, not keep the earlier condition around.
+    table = mem_db.create_table(
+        "my_table",
+        data=pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]}),
+    )
+    new_data = pa.table({"a": [2, 4], "b": ["x", "z"]})
+
+    merge_insert_res = (
+        table.merge_insert("a")
+        .when_matched_update_all()
+        .when_not_matched_insert_all()
+        .when_not_matched_by_source_delete("a > 2")
+        .when_not_matched_by_source_delete()
+        .execute(new_data)
+    )
+    assert merge_insert_res.num_deleted_rows == 2
+
+    expected = pa.table({"a": [2, 4], "b": ["x", "z"]})
+    assert table.to_arrow().sort_by("a") == expected
+
+
 @pytest.mark.asyncio
 async def test_merge_insert_by_source_delete_expr_async(
     mem_db_async: AsyncConnection,


### PR DESCRIPTION
## Summary

Three small, independent correctness bugs in the Python bindings, each found while auditing `lancedb/query.py` and `lancedb/merge.py`, and each with a regression test.

- `LanceHybridQueryBuilder` (sync hybrid search) silently ignored `.offset()` — it was never forwarded to the vector/FTS sub-queries or applied when slicing the final combined/reranked result, so `.offset(N)` behaved identically to `.offset(0)` with no error. Fixes #3765.
- `LanceHybridQueryBuilder._create_query_builders()` checked `self._minimum_nprobes` for truthiness instead of `is not None` (unlike the adjacent `maximum_nprobes` check, which is already correct). Since `0` is falsy, `.minimum_nprobes(0)` on a hybrid query silently no-opped instead of raising the same `ValueError` a plain vector query raises for the same input. Fixes #3766.
- `LanceMergeInsertBuilder.when_not_matched_by_source_delete()` didn't clear a previously-set condition when called again with no argument (or a different condition type) — the docstring says `None` means "delete all unmatched rows," but a stale condition from an earlier call remained in effect. Fixes #3767.

## Changes

- `python/python/lancedb/query.py`: forward `self._offset` into the per-sub-query fetch limit (`limit + offset`) and apply it when slicing the final result; fix the `minimum_nprobes` truthiness check.
- `python/python/lancedb/merge.py`: `when_not_matched_by_source_delete()` now always overwrites both the string-condition and Expr-condition fields, so the latest call wins (consistent with every other setter on the builder).
- Regression tests added in `python/python/tests/test_hybrid_query.py` and `python/python/tests/test_table.py`.

## Test plan

- [x] `uv run --extra tests pytest python/tests/test_hybrid_query.py -vv` — 14 passed
- [x] `uv run --extra tests pytest python/tests/test_query.py -q -m "not slow and not s3_test"` — 85 passed
- [x] `uv run --extra tests pytest python/tests/test_table.py -q -m "not slow and not s3_test" --deselect python/tests/test_table.py::test_merge_insert` — 127 passed (the deselected test is a pre-existing, unrelated timing-sensitive failure that reproduces identically on `main` without this change)
- [x] `uv run --extra dev ruff format` / `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)