### PR TITLE
fix(node): validate inferred types across records

### DIFF
--- a/nodejs/__test__/arrow.test.ts
+++ b/nodejs/__test__/arrow.test.ts
@@ -449,6 +449,20 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
         );
       });
 
+      it("will accept consistent inferred types across records", function () {
+        const table = makeArrowTable([{ value: 1 }, { value: 2 }]);
+
+        expect(table.getChild("value")?.type.toString()).toEqual(
+          new Float64().toString(),
+        );
+      });
+
+      it("will reject inconsistent inferred types across records", function () {
+        expect(() =>
+          makeArrowTable([{ value: 1 }, { value: "two" }]),
+        ).toThrow("Failed to infer schema for data");
+      });
+
       it("will allow a schema to be provided", async function () {
         await checkTableCreation(
           async (records, _, schema) =>

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -489,8 +489,8 @@ function inferSchema(
       } else if (schema === undefined) {
         const currentType = pathTree.get(path);
         const newType = inferType(value, path, opts);
-        if (currentType !== newType) {
-          new Error(`Failed to infer schema for data. Previously inferred type \
+        if (currentType?.toString() !== newType?.toString()) {
+          throw new Error(`Failed to infer schema for data. Previously inferred type \
                      ${currentType} but found ${newType} at row ${rowI}. Consider \
                      providing an explicit schema.`);
         }


### PR DESCRIPTION
## What does this PR do?

Fixes inferred schema validation for Node.js records containing multiple rows.

The implementation:

- Compares inferred Arrow types by their semantic representation instead of
  object identity.
- Throws an error when a field changes type across records.
- Adds regression tests for consistent and inconsistent inferred types.

## Why is this needed?

Previously, identical inferred types from different records were different objects and failed an identity comparison. More importantly, the resulting `Error` was never thrown, so incompatible values could pass schema inference silently.

## Testing

Added tests covering:

- Consistent numeric types across multiple records.
- Inconsistent numeric/string types across records.
