### PR TITLE
chore(deps): declare more specific futures dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ env_logger = "0.11"
 half = { "version" = "2.7.1", default-features = false, features = [
     "num-traits",
 ] }
-futures = "0"
+futures = "0.3"
 log = "0.4"
 metrics = "0.24"
 metrics-util = "0.19"


### PR DESCRIPTION
Lancedb does not work with any other version of `futures`.

With futures 0.1 it fails like this:

```console
error[E0432]: unresolved imports `futures::StreamExt`, `futures::TryStreamExt`
  --> rust/lancedb/src/arrow.rs:21:23
   |
21 | use futures::{Stream, StreamExt, TryStreamExt};
   |                       ^^^^^^^^^  ^^^^^^^^^^^^ no `TryStreamExt` in the root
   |                       |
   |                       no `StreamExt` in the root
   |

error[E0432]: unresolved import `futures::StreamExt`
  --> rust/lancedb/src/data/scannable.rs:24:5
   |
24 | use futures::StreamExt;
   |     ^^^^^^^^^^^^^^^^^^ no `StreamExt` in the root
   |

error[E0432]: unresolved import `futures::TryStreamExt`
 --> rust/lancedb/src/dataloader/permutation/builder.rs:9:5
  |
9 | use futures::TryStreamExt;
  |     ^^^^^^^^^^^^^^^^^^^^^ no `TryStreamExt` in the root

error[E0432]: unresolved imports `futures::StreamExt`, `futures::TryStreamExt`
  --> rust/lancedb/src/dataloader/permutation/reader.rs:25:15
   |
25 | use futures::{StreamExt, TryStreamExt};
   |               ^^^^^^^^^  ^^^^^^^^^^^^ no `TryStreamExt` in the root
   |               |
   |               no `StreamExt` in the root
   |

error[E0432]: unresolved imports `futures::StreamExt`, `futures::TryStreamExt`
 --> rust/lancedb/src/dataloader/permutation/shuffle.rs:8:15
  |
8 | use futures::{StreamExt, TryStreamExt};
  |               ^^^^^^^^^  ^^^^^^^^^^^^ no `TryStreamExt` in the root
  |               |
  |               no `StreamExt` in the root
  |

error[E0432]: unresolved imports `futures::StreamExt`, `futures::TryStreamExt`
  --> rust/lancedb/src/dataloader/permutation/split.rs:12:15
   |
12 | use futures::{StreamExt, TryStreamExt};
   |               ^^^^^^^^^  ^^^^^^^^^^^^ no `TryStreamExt` in the root
   |               |
   |               no `StreamExt` in the root
   |

error[E0432]: unresolved import `futures::TryStreamExt`
 --> rust/lancedb/src/dataloader/permutation/util.rs:9:5
  |
9 | use futures::TryStreamExt;
  |     ^^^^^^^^^^^^^^^^^^^^^ no `TryStreamExt` in the root

error[E0432]: unresolved imports `futures::StreamExt`, `futures::TryFutureExt`
 --> rust/lancedb/src/io/object_store.rs:8:15
  |
8 | use futures::{StreamExt, TryFutureExt, stream::BoxStream};
  |               ^^^^^^^^^  ^^^^^^^^^^^^ no `TryFutureExt` in the root
  |               |
  |               no `StreamExt` in the root
  |

error[E0432]: unresolved imports `futures::FutureExt`, `futures::TryFutureExt`, `futures::TryStreamExt`, `futures::try_join`
  --> rust/lancedb/src/query.rs:12:15
   |
12 | use futures::{FutureExt, TryFutureExt, TryStreamExt, stream, try_join};
   |               ^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^          ^^^^^^^^ no `try_join` in the root
   |               |          |             |
   |               |          |             no `TryStreamExt` in the root
   |               |          no `TryFutureExt` in the root
   |               no `FutureExt` in the root
   |

error[E0432]: unresolved imports `futures::StreamExt`, `futures::TryStreamExt`
  --> rust/lancedb/src/remote/table/blobs.rs:13:15
   |
13 | use futures::{StreamExt, TryStreamExt};
   |               ^^^^^^^^^  ^^^^^^^^^^^^ no `TryStreamExt` in the root
   |               |
   |               no `StreamExt` in the root
   |

error[E0432]: unresolved imports `futures::SinkExt`, `futures::StreamExt`
  --> rust/lancedb/src/remote/table/insert.rs:20:15
   |
20 | use futures::{SinkExt, StreamExt};
   |               ^^^^^^^  ^^^^^^^^^ no `StreamExt` in the root
   |               |
   |               no `SinkExt` in the root
   |

error[E0432]: unresolved imports `futures::StreamExt`, `futures::TryStreamExt`
  --> rust/lancedb/src/remote/table.rs:58:15
   |
58 | use futures::{StreamExt, TryStreamExt};
   |               ^^^^^^^^^  ^^^^^^^^^^^^ no `TryStreamExt` in the root
   |               |
   |               no `StreamExt` in the root
   |

error[E0432]: unresolved import `futures::StreamExt`
 --> rust/lancedb/src/remote/util.rs:5:23
  |
5 | use futures::{Stream, StreamExt};
  |                       ^^^^^^^^^ no `StreamExt` in the root
  |

error[E0432]: unresolved import `futures::StreamExt`
  --> rust/lancedb/src/table.rs:14:5
   |
14 | use futures::StreamExt;
   |     ^^^^^^^^^^^^^^^^^^ no `StreamExt` in the root
   |

error[E0432]: unresolved import `futures::TryStreamExt`
  --> rust/lancedb/src/table/datafusion/insert.rs:20:5
   |
20 | use futures::TryStreamExt;
   |     ^^^^^^^^^^^^^^^^^^^^^ no `TryStreamExt` in the root

error[E0432]: unresolved import `futures::TryStreamExt`
  --> rust/lancedb/src/table/datafusion/scannable_exec.rs:14:5
   |
14 | use futures::TryStreamExt;
   |     ^^^^^^^^^^^^^^^^^^^^^ no `TryStreamExt` in the root

error[E0432]: unresolved imports `futures::TryFutureExt`, `futures::TryStreamExt`
  --> rust/lancedb/src/table/datafusion.rs:25:15
   |
25 | use futures::{TryFutureExt, TryStreamExt};
   |               ^^^^^^^^^^^^  ^^^^^^^^^^^^ no `TryStreamExt` in the root
   |               |
   |               no `TryFutureExt` in the root

error[E0432]: unresolved import `futures::FutureExt`
 --> rust/lancedb/src/table/delete.rs:3:5
  |
3 | use futures::FutureExt;
  |     ^^^^^^^^^^^^^^^^^^ no `FutureExt` in the root
  |

error[E0432]: unresolved imports `futures::FutureExt`, `futures::TryFutureExt`
 --> rust/lancedb/src/table/merge.rs:9:15
  |
9 | use futures::{FutureExt, TryFutureExt};
  |               ^^^^^^^^^  ^^^^^^^^^^^^ no `TryFutureExt` in the root
  |               |
  |               no `FutureExt` in the root
  |

error[E0432]: unresolved import `futures::future::try_join_all`
  --> rust/lancedb/src/table/query.rs:24:5
   |
24 | use futures::future::try_join_all;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `try_join_all` in `future`
   |

error[E0432]: unresolved import `futures::FutureExt`
  --> rust/lancedb/src/utils/background_cache.rs:12:5
   |
12 | use futures::FutureExt;
   |     ^^^^^^^^^^^^^^^^^^ no `FutureExt` in the root
   |

error[E0432]: unresolved import `futures::FutureExt`
  --> rust/lancedb/src/utils/mod.rs:12:15
   |
12 | use futures::{FutureExt, Stream};
   |               ^^^^^^^^^ no `FutureExt` in the root
   |

error[E0433]: cannot find `join` in `futures`
   --> rust/lancedb/src/remote/table/insert.rs:504:55
    |
504 |         let (producer_result, send_result) = futures::join!(producer, send);
    |                                                       ^^^^ could not find `join` in `futures`

error[E0407]: method `poll_next` is not a member of trait `Stream`
   --> rust/lancedb/src/arrow.rs:108:5
    |
108 | /     fn poll_next(
109 | |         self: Pin<&mut Self>,
110 | |         cx: &mut std::task::Context<'_>,
111 | |     ) -> std::task::Poll<Option<Self::Item>> {
112 | |         let this = self.project();
113 | |         this.stream.poll_next(cx)
114 | |     }
    | |_____^ not a member of trait `Stream`

error[E0407]: method `poll_next` is not a member of trait `Stream`
   --> rust/lancedb/src/utils/mod.rs:362:5
    |
362 | /     fn poll_next(
363 | |         mut self: std::pin::Pin<&mut Self>,
364 | |         cx: &mut std::task::Context<'_>,
365 | |     ) -> std::task::Poll<Option<Self::Item>> {
...   |
391 | |     }
    | |_____^ not a member of trait `Stream`

error[E0407]: method `poll_next` is not a member of trait `Stream`
   --> rust/lancedb/src/utils/mod.rs:433:5
    |
433 | /     fn poll_next(
434 | |         mut self: Pin<&mut Self>,
435 | |         cx: &mut std::task::Context<'_>,
436 | |     ) -> std::task::Poll<Option<Self::Item>> {
...   |
470 | |     }
    | |_____^ not a member of trait `Stream`

error[E0425]: cannot find function `try_unfold` in module `futures::stream`
   --> rust/lancedb/src/remote/table/insert.rs:230:39
    |
230 |         let stream = futures::stream::try_unfold(
    |                                       ^^^^^^^^^^ not found in `futures::stream`

error[E0433]: cannot find `channel` in `futures`
   --> rust/lancedb/src/remote/table/insert.rs:418:22
    |
418 |             futures::channel::mpsc::channel::<Result<Vec<u8>, std::io::Error>>(2);
    |                      ^^^^^^^ could not find `channel` in `futures`
    |

error[E0425]: cannot find function `try_join_all` in module `futures::future`
    --> rust/lancedb/src/remote/table.rs:1062:40
     |
1062 |           let streams = futures::future::try_join_all(futures);
     |                                          ^^^^^^^^^^^^
     |
    ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/join_all.rs:76:1
     |
  76 | / pub fn join_all<I>(i: I) -> JoinAll<I>
  77 | |     where I: IntoIterator,
  78 | |           I::Item: IntoFuture,
     | |______________________________- similarly named function `join_all` defined here
     |

error[E0425]: cannot find function `try_join_all` in module `futures::future`
    --> rust/lancedb/src/remote/table.rs:1660:40
     |
1660 |           let results = futures::future::try_join_all(futures).await?;
     |                                          ^^^^^^^^^^^^
     |
    ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/join_all.rs:76:1
     |
  76 | / pub fn join_all<I>(i: I) -> JoinAll<I>
  77 | |     where I: IntoIterator,
  78 | |           I::Item: IntoFuture,
     | |______________________________- similarly named function `join_all` defined here
     |

error[E0425]: cannot find function `try_join_all` in module `futures::future`
    --> rust/lancedb/src/remote/table.rs:2243:43
     |
2243 |           let plan_texts = futures::future::try_join_all(futures).await?;
     |                                             ^^^^^^^^^^^^
     |
    ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/join_all.rs:76:1
     |
  76 | / pub fn join_all<I>(i: I) -> JoinAll<I>
  77 | |     where I: IntoIterator,
  78 | |           I::Item: IntoFuture,
     | |______________________________- similarly named function `join_all` defined here
     |

error[E0425]: cannot find function `try_join_all` in module `futures::future`
    --> rust/lancedb/src/remote/table.rs:2290:53
     |
2290 |           let analyze_result_texts = futures::future::try_join_all(futures).await?;
     |                                                       ^^^^^^^^^^^^
     |
    ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/join_all.rs:76:1
     |
  76 | / pub fn join_all<I>(i: I) -> JoinAll<I>
  77 | |     where I: IntoIterator,
  78 | |           I::Item: IntoFuture,
     | |______________________________- similarly named function `join_all` defined here
     |

error[E0425]: cannot find function `try_unfold` in module `futures::stream`
  --> rust/lancedb/src/remote/util.rs:21:35
   |
21 |     let stream = futures::stream::try_unfold(
   |                                   ^^^^^^^^^^ not found in `futures::stream`

error[E0191]: the value of the associated type `Error` in `futures::Stream` must be specified
  --> rust/lancedb/src/arrow.rs:70:50
   |
70 | pub type SendableRecordBatchStream = Pin<Box<dyn RecordBatchStream + Send>>;
   |                                                  ^^^^^^^^^^^^^^^^^
   |
help: specify the associated type
   |
70 | pub type SendableRecordBatchStream = Pin<Box<dyn RecordBatchStream<Error = /* Type */> + Send>>;
   |                                                                   ++++++++++++++++++++

error[E0107]: type alias takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> rust/lancedb/src/utils/background_cache.rs:15:31
    |
 15 | type SharedFut<V, E> = Shared<BoxFuture<'static, Result<V, Arc<E>>>>;
    |                               ^^^^^^^^^ ------- help: remove the lifetime argument
    |                               |
    |                               expected 0 lifetime arguments
    |
note: type alias defined here, with 0 lifetime parameters
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/mod.rs:106:14
    |
106 |     pub type BoxFuture<T, E> = ::std::boxed::Box<Future<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^

error[E0107]: type alias takes 2 generic arguments but 1 generic argument was supplied
   --> rust/lancedb/src/utils/background_cache.rs:15:31
    |
 15 | type SharedFut<V, E> = Shared<BoxFuture<'static, Result<V, Arc<E>>>>;
    |                               ^^^^^^^^^          ----------------- supplied 1 generic argument
    |                               |
    |                               expected 2 generic arguments
    |
note: type alias defined here, with 2 generic parameters: `T`, `E`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/mod.rs:106:14
    |
106 |     pub type BoxFuture<T, E> = ::std::boxed::Box<Future<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^ -  -
help: add missing generic argument
    |
 15 | type SharedFut<V, E> = Shared<BoxFuture<'static, Result<V, Arc<E>>, E>>;
    |                                                                   +++

error[E0046]: not all trait items implemented, missing: `Error`, `poll`
   --> rust/lancedb/src/arrow.rs:105:1
    |
105 | impl<S: Stream<Item = Result<arrow_array::RecordBatch>>> Stream for SimpleRecordBatchStream<S> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Error`, `poll` in implementation
    |
    = help: implement the missing item: `type Error = /* Type */;`
    = help: implement the missing item: `fn poll(&mut self) -> std::result::Result<Async<std::option::Option<<Self as futures::Stream>::Item>>, <Self as futures::Stream>::Error> { todo!() }`

error[E0107]: type alias takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> rust/lancedb/src/io/object_store.rs:97:46
    |
 97 |     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
    |                                              ^^^^^^^^^ ------- help: remove the lifetime argument
    |                                              |
    |                                              expected 0 lifetime arguments
    |
note: type alias defined here, with 0 lifetime parameters
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:132:14
    |
132 |     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^

error[E0107]: type alias takes 2 generic arguments but 1 generic argument was supplied
   --> rust/lancedb/src/io/object_store.rs:97:46
    |
 97 |     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
    |                                              ^^^^^^^^^          ------------------ supplied 1 generic argument
    |                                              |
    |                                              expected 2 generic arguments
    |
note: type alias defined here, with 2 generic parameters: `T`, `E`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:132:14
    |
132 |     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^ -  -
help: add missing generic argument
    |
 97 |     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>, E> {
    |                                                                                   +++

error[E0107]: type alias takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> rust/lancedb/src/io/object_store.rs:107:20
    |
107 |         locations: BoxStream<'static, Result<Path>>,
    |                    ^^^^^^^^^ ------- help: remove the lifetime argument
    |                    |
    |                    expected 0 lifetime arguments
    |
note: type alias defined here, with 0 lifetime parameters
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:132:14
    |
132 |     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^

error[E0107]: type alias takes 2 generic arguments but 1 generic argument was supplied
   --> rust/lancedb/src/io/object_store.rs:107:20
    |
107 |         locations: BoxStream<'static, Result<Path>>,
    |                    ^^^^^^^^^          ------------ supplied 1 generic argument
    |                    |
    |                    expected 2 generic arguments
    |
note: type alias defined here, with 2 generic parameters: `T`, `E`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:132:14
    |
132 |     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^ -  -
help: add missing generic argument
    |
107 |         locations: BoxStream<'static, Result<Path>, E>,
    |                                                   +++

error[E0107]: type alias takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> rust/lancedb/src/io/object_store.rs:108:10
    |
108 |     ) -> BoxStream<'static, Result<Path>> {
    |          ^^^^^^^^^ ------- help: remove the lifetime argument
    |          |
    |          expected 0 lifetime arguments
    |
note: type alias defined here, with 0 lifetime parameters
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:132:14
    |
132 |     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^

error[E0107]: type alias takes 2 generic arguments but 1 generic argument was supplied
   --> rust/lancedb/src/io/object_store.rs:108:10
    |
108 |     ) -> BoxStream<'static, Result<Path>> {
    |          ^^^^^^^^^          ------------ supplied 1 generic argument
    |          |
    |          expected 2 generic arguments
    |
note: type alias defined here, with 2 generic parameters: `T`, `E`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:132:14
    |
132 |     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
    |              ^^^^^^^^^ -  -
help: add missing generic argument
    |
108 |     ) -> BoxStream<'static, Result<Path>, E> {
    |                                         +++

error[E0599]: no method named `map_err` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
   --> rust/lancedb/src/dataloader/permutation/builder.rs:208:32
    |
208 |         let stream = df_stream.map_err(|e| Error::Other {
    |                      ----------^^^^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`
    |
   ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/try_stream/mod.rs:248:8
    |
248 |     fn map_err<E, F>(self, f: F) -> MapErr<Self, F>
    |        ------- the method is available for `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` here
    |

error[E0599]: no method named `try_collect` found for struct `DatasetRecordBatchStream` in the current scope
    --> rust/lancedb/src/dataloader/permutation/reader.rs:220:28
     |
 220 |         let batches = data.try_collect::<Vec<_>>().await?;
     |                            ^^^^^^^^^^^
     |

error[E0599]: no method named `map_err` found for struct `DatasetRecordBatchStream` in the current scope
   --> rust/lancedb/src/dataloader/permutation/reader.rs:287:14
    |
286 |           let mut stream = row_ids
    |  __________________________-
287 | |             .map_err(Error::from)
    | |             -^^^^^^^ method not found in `DatasetRecordBatchStream`
    | |_____________|
    |

error[E0599]: the method `chain` exists for struct `futures::stream::Once<_, _>`, but its trait bounds were not satisfied
   --> rust/lancedb/src/dataloader/permutation/reader.rs:307:81
    |
307 |         let stream = futures::stream::once(std::future::ready(Ok(first_batch))).chain(stream);
    |                                                                                 ^^^^^ method cannot be called on `futures::stream::Once<_, _>` due to unsatisfied trait bounds

error[E0308]: mismatched types
   --> rust/lancedb/src/dataloader/permutation/shuffle.rs:120:35
    |
120 |             futures::stream::once(async move { Ok(shuffled) }),
    |             --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<_, _>`, found `async` block
    |             |
    |             arguments to this function are incorrect
    |
    = note:       expected enum `std::result::Result<_, _>`
            found `async` block `{async block@rust/lancedb/src/dataloader/permutation/shuffle.rs:120:35: 120:45}`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
120 |             futures::stream::once(Ok(async move { Ok(shuffled) })),
    |                                   +++                           +
120 |             futures::stream::once(Err(async move { Ok(shuffled) })),
    |                                   ++++                           +

error[E0271]: type mismatch resolving `<Range<u64> as IntoIterator>::Item == Result<_, _>`
   --> rust/lancedb/src/dataloader/permutation/shuffle.rs:228:44
    |
228 |         let stream = futures::stream::iter(0..num_files)
    |                      --------------------- ^^^^^^^^^^^^ expected `Result<_, _>`, found `u64`
    |                      |
    |                      required by a bound introduced by this call
    |
    = note: expected enum `std::result::Result<_, _>`
               found type `u64`
note: required by a bound in `futures::stream::iter`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/iter.rs:31:27
    |
 30 | pub fn iter<J, T, E>(i: J) -> Iter<J::IntoIter>
    |        ---- required by a bound in this function
 31 |     where J: IntoIterator<Item=Result<T, E>>,
    |                           ^^^^^^^^^^^^^^^^^ required by this bound in `iter`

error[E0599]: no method named `then` found for struct `IterStream<I>` in the current scope
   --> rust/lancedb/src/dataloader/permutation/shuffle.rs:229:14
    |
228 |           let stream = futures::stream::iter(0..num_files)
    |  ______________________-
229 | |             .then(move |file_index| {
    | |             -^^^^ method not found in `IterStream<std::ops::Range<u64>>`
    | |_____________|
    |

error[E0599]: no method named `try_collect` found for struct `Pin<Box<dyn lance::io::RecordBatchStream>>` in the current scope
    --> rust/lancedb/src/dataloader/permutation/shuffle.rs:258:26
     |
 250 |                       let batches = reader
     |  ___________________________________-
 251 | |                         .read_stream(
 252 | |                             ReadBatchParams::RangeFull,
 253 | |                             reader.num_rows() as u32,
...    |
 257 | |                         .await?
 258 | |                         .try_collect::<Vec<_>>()
     | |_________________________-^^^^^^^^^^^

error[E0599]: no method named `and_then` found for associated type `impl Future<Output = Result<Arc<...>, ...>> + Send` in the current scope
   --> rust/lancedb/src/query.rs:766:14
    |
765 | /         self.create_plan(QueryExecutionOptions::default())
766 | |             .and_then(|plan| std::future::ready(Ok(plan.schema())))
    | |_____________-^^^^^^^^
    |
   ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/future/try_future/mod.rs:395:8
    |
395 |       fn and_then<Fut, F>(self, f: F) -> AndThen<Self, Fut, F>
    |          -------- the method is available for `impl std::future::Future<Output = std::result::Result<Arc<(dyn ExecutionPlan + 'static)>, error::Error>> + std::marker::Send` here

error[E0599]: no method named `boxed` found for `async` block `{async block@rust/lancedb/src/query.rs:1492:33: 1492:43}` in the current scope
    --> rust/lancedb/src/query.rs:1493:18
     |
1492 |               let hybrid_result = async move { self.execute_hybrid(options).await }
     |  _________________________________-
1493 | |                 .boxed()
     | |                 -^^^^^ method not found in `{async block@rust/lancedb/src/query.rs:1492:33: 1492:43}`
     | |_________________|

error[E0271]: expected `{closure@blobs.rs:181:58}` to return `Result<_, _>`, but it returns `impl Future<Output = Result<Bytes, Error>>`
   --> rust/lancedb/src/remote/table/blobs.rs:181:66
    |
181 |         futures::stream::iter(ranges.iter().cloned().map(|range| self.read_range(range)))
    |         ---------------------                            ------- ^^^^^^^^^^^^^^^^^^^^^^ expected `Result<_, _>`, found future
    |         |                                                |
    |         |                                                this closure
    |         required by a bound introduced by this call

error[E0599]: no method named `buffered` found for struct `IterStream<I>` in the current scope
   --> rust/lancedb/src/remote/table/blobs.rs:182:14
    |
181 | /         futures::stream::iter(ranges.iter().cloned().map(|range| self.read_range(range)))
182 | |             .buffered(BLOB_REQUEST_CONCURRENCY)
    | |             -^^^^^^^^ method not found in `Iter<Map<Cloned<Iter<'_, Range<u64>>>, {closure@...}>>`
    | |_____________|

error[E0599]: no method named `try_next` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
   --> rust/lancedb/src/remote/table/blobs.rs:379:40
    |
379 |         while let Some(batch) = stream.try_next().await? {
    |                                        ^^^^^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`

error[E0271]: type mismatch resolving `<Vec<...> as IntoIterator>::Item == Result<_, _>`
   --> rust/lancedb/src/remote/table/blobs.rs:481:27
    |
481 |     futures::stream::iter(probe_futures)
    |     --------------------- ^^^^^^^^^^^^^ expected `Result<_, _>`, found future
    |     |
    |     required by a bound introduced by this call

error[E0599]: no method named `buffered` found for struct `IterStream<I>` in the current scope
   --> rust/lancedb/src/remote/table/blobs.rs:482:10
    |
481 | /     futures::stream::iter(probe_futures)
482 | |         .buffered(BLOB_REQUEST_CONCURRENCY)
    | |         -^^^^^^^^ method not found in `Iter<IntoIter<impl Future<Output = Result<..., ...>>>>`
    | |_________|

error[E0599]: no method named `next` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
   --> rust/lancedb/src/remote/table/insert.rs:324:37
    |
324 |         let mut first = match input.next().await {
    |                                     ^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`

error[E0599]: no method named `next` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
   --> rust/lancedb/src/remote/table/insert.rs:345:33
    |
345 |             first = match input.next().await {
    |                                 ^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`

error[E0599]: the method `next` exists for mutable reference `&mut Pin<Box<dyn RecordBatchStream + Send>>`, but its trait bounds were not satisfied
   --> rust/lancedb/src/remote/table/insert.rs:446:41
    |
446 |                     None => match input.next().await {
    |                                         ^^^^ method cannot be called on `&mut Pin<Box<dyn RecordBatchStream + Send>>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `Pin<Box<(dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send + 'static)>>: Iterator`
            which is required by `&mut Pin<Box<(dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send + 'static)>>: Iterator`

error[E0599]: no method named `map_err` found for struct `IterStream<I>` in the current scope
   --> rust/lancedb/src/remote/table.rs:688:53
    |
688 |         let stream = futures::stream::iter(batches).map_err(DataFusionError::from);
    |                                                     ^^^^^^^ method not found in `Iter<Box<dyn Iterator<Item = Result<..., ...>> + Send>>`

error[E0599]: no method named `try_collect` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
    --> rust/lancedb/src/remote/table.rs:1378:49
     |
1378 |             let result: Result<Vec<_>> = stream.try_collect().await.map_err(Error::from);
     |                                                 ^^^^^^^^^^^

error[E0599]: no method named `next` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
    --> rust/lancedb/src/remote/table.rs:1509:48
     |
1509 |                 while let Some(batch) = stream.next().await {
     |                                                ^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`

error[E0599]: no method named `boxed` found for opaque type `impl Future<Output = Result<DeleteResult, Error>>` in the current scope
  --> rust/lancedb/src/table/delete.rs:35:51
   |
35 |             let delete_result = dataset.delete(s).boxed().await?;
   |                                                   ^^^^^ method not found in `impl Future<Output = Result<DeleteResult, Error>>`

error[E0599]: no variant, associated function, or constant named `Left` found for enum `Either<A, B>` in the current scope
   --> rust/lancedb/src/table/merge.rs:292:17
    |
292 |         Either::Left(tokio::time::timeout(timeout, future).map(|res| match res {
    |                 ^^^^ variant, associated function, or constant not found in `Either<_, _>`

error[E0599]: `Timeout<impl Future<Output = Result<(Arc<...>, ...), ...>>>` is not an iterator
   --> rust/lancedb/src/table/merge.rs:292:60
    |
292 |           Either::Left(tokio::time::timeout(timeout, future).map(|res| match res {
    |                        --------------------------------------^^^ `Timeout<impl Future<Output = Result<(Arc<...>, ...), ...>>>` is not an iterator
    |
   ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/pin-project-lite-0.2.17/src/lib.rs:745:9
    |
745 | /         $vis struct $ident $($def_generics)*
746 | |         $(where
747 | |             $($where_clause)*)?
...   |
751 | |             ),+
752 | |         }
    | |_________- doesn't satisfy `_: Iterator`
    |
    = note: the following trait bounds were not satisfied:
            `tokio::time::Timeout<impl std::future::Future<Output = std::result::Result<(Arc<lance::Dataset>, MergeStats), lance::Error>>>: Iterator`
            which is required by `&mut tokio::time::Timeout<impl std::future::Future<Output = std::result::Result<(Arc<lance::Dataset>, MergeStats), lance::Error>>>: Iterator`

error[E0599]: no variant, associated function, or constant named `Right` found for enum `Either<A, B>` in the current scope
   --> rust/lancedb/src/table/merge.rs:301:17
    |
301 |         Either::Right(job.execute_reader(new_data).map_err(|e| e.into()))
    |                 ^^^^^ variant, associated function, or constant not found in `Either<_, _>`

error[E0599]: no method named `map_err` found for opaque type `impl Future<Output = Result<(Arc<Dataset>, ...), ...>>` in the current scope
   --> rust/lancedb/src/table/merge.rs:301:52
    |
301 |         Either::Right(job.execute_reader(new_data).map_err(|e| e.into()))
    |                                                    ^^^^^^^ method not found in `impl Future<Output = Result<(Arc<Dataset>, ...), ...>>`

error[E0277]: the trait bound `Iter<Map<IntoIter<RecordBatch>, ...>>: Stream` is not satisfied
   --> rust/lancedb/src/table/query.rs:681:38
    |
681 |     Ok(DatasetRecordBatchStream::new(record_batch_stream))
    |                                      ^^^^^^^^^^^^^^^^^^^ the trait `futures_core::stream::Stream` is not implemented for `Iter<Map<IntoIter<RecordBatch>, ...>>`

error[E0277]: the trait bound `TimeoutStream: futures_core::stream::Stream` is not satisfied
   --> rust/lancedb/src/utils/mod.rs:353:28
    |
353 | impl RecordBatchStream for TimeoutStream {
    |                            ^^^^^^^^^^^^^ unsatisfied trait bound

error[E0046]: not all trait items implemented, missing: `Error`, `poll`
   --> rust/lancedb/src/utils/mod.rs:359:1
    |
359 | impl Stream for TimeoutStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Error`, `poll` in implementation
    |
    = help: implement the missing item: `type Error = /* Type */;`
    = help: implement the missing item: `fn poll(&mut self) -> std::result::Result<Async<std::option::Option<<Self as futures::Stream>::Item>>, <Self as futures::Stream>::Error> { todo!() }`

error[E0277]: the trait bound `MaxBatchLengthStream: futures_core::stream::Stream` is not satisfied
   --> rust/lancedb/src/utils/mod.rs:424:28
    |
424 | impl RecordBatchStream for MaxBatchLengthStream {
    |                            ^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound

error[E0046]: not all trait items implemented, missing: `Error`, `poll`
   --> rust/lancedb/src/utils/mod.rs:430:1
    |
430 | impl Stream for MaxBatchLengthStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Error`, `poll` in implementation
    |
    = help: implement the missing item: `type Error = /* Type */;`
    = help: implement the missing item: `fn poll(&mut self) -> std::result::Result<Async<std::option::Option<<Self as futures::Stream>::Item>>, <Self as futures::Stream>::Error> { todo!() }`

error[E0599]: no method named `map` found for type parameter `I` in the current scope
  --> rust/lancedb/src/arrow.rs:75:45
   |
72 | impl<I: lance::io::RecordBatchStream + 'static> From<I> for SendableRecordBatchStream {
   |      - method `map` not found for this type parameter
...
75 |         let mapped_stream = Box::pin(stream.map(|r| r.map_err(Into::into)));
   |                                             ^^^

error[E0599]: no method named `poll_next` found for struct `Pin<&mut S>` in the current scope
   --> rust/lancedb/src/arrow.rs:113:21
    |
113 |         this.stream.poll_next(cx)
    |                     ^^^^^^^^^
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `poll_next`, perhaps you need to implement one of them:
            candidate #1: `futures_core::stream::Stream`
            candidate #2: `sorts::stream::PartitionedStream`
help: there is a method `collect` with a similar name, but with different arguments
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:563:5
    |
563 | /     fn collect(self) -> Collect<Self>
564 | |         where Self: Sized
    | |_________________________^

error[E0599]: the method `map_err` exists for struct `Pin<Box<dyn Stream<Item = Result<..., ...>> + Send>>`, but its trait bounds were not satisfied
   --> rust/lancedb/src/arrow.rs:150:29
    |
150 |         let stream = stream.map_err(|err| Error::Arrow { source: err });
    |                             ^^^^^^^ method cannot be called due to unsatisfied trait bounds

error[E0308]: mismatched types
  --> rust/lancedb/src/data/scannable.rs:80:26
   |
80 |             stream: once(async move { Ok(batch) }),
   |                     ---- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<_, _>`, found `async` block
   |                     |
   |                     arguments to this function are incorrect
   |
   = note:       expected enum `std::result::Result<_, _>`
           found `async` block `{async block@rust/lancedb/src/data/scannable.rs:80:26: 80:36}`
note: function defined here
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
   |
20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
   |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
   |
80 |             stream: once(Ok(async move { Ok(batch) })),
   |                          +++                        +
80 |             stream: once(Err(async move { Ok(batch) })),
   |                          ++++                        +

error[E0308]: mismatched types
   --> rust/lancedb/src/data/scannable.rs:107:30
    |
107 |                   stream: once(async {
    |  _________________________----_^
    | |                         |
    | |                         arguments to this function are incorrect
108 | |                     Err(Error::InvalidInput {
109 | |                         message: "Cannot scan an empty Vec<RecordBatch>".to_string(),
110 | |                     })
111 | |                 }),
    | |_________________^ expected `Result<_, _>`, found `async` block
    |
    = note:       expected enum `std::result::Result<_, _>`
            found `async` block `{async block@rust/lancedb/src/data/scannable.rs:107:30: 107:35}`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
107 ~                 stream: once(Ok(async {
108 |                     Err(Error::InvalidInput {
109 |                         message: "Cannot scan an empty Vec<RecordBatch>".to_string(),
110 |                     })
111 ~                 })),
    |
107 ~                 stream: once(Err(async {
108 |                     Err(Error::InvalidInput {
109 |                         message: "Cannot scan an empty Vec<RecordBatch>".to_string(),
110 |                     })
111 ~                 })),
    |

error[E0271]: expected `Ok` to return `Result<Result<RecordBatch, Error>, _>`, but it returns `Result<RecordBatch, _>`
   --> rust/lancedb/src/data/scannable.rs:117:52
    |
117 |         Box::pin(SimpleRecordBatchStream { schema, stream })
    |                                                    ^^^^^^ expected `Result<Result<RecordBatch, Error>, _>`, found `Result<RecordBatch, _>`

error[E0308]: mismatched types
   --> rust/lancedb/src/data/scannable.rs:158:59
    |
158 |           let stream = futures::stream::unfold(rx, |mut rx| async move {
    |  ___________________________________________________________^
159 | |             rx.recv().await.map(|batch| (batch, rx))
160 | |         })
    | |_________^ expected `Option<_>`, found `async` block
    |
    = note:       expected enum `std::option::Option<_>`
            found `async` block `{async block@rust/lancedb/src/data/scannable.rs:158:59: 158:69}`
help: try wrapping the expression in `Some`
    |
158 ~         let stream = futures::stream::unfold(rx, |mut rx| Some(async move {
159 |             rx.recv().await.map(|batch| (batch, rx))
160 ~         }))
    |

error[E0599]: the method `fuse` exists for struct `Unfold<Receiver<Result<RecordBatch, Error>>, ..., _>`, but its trait bounds were not satisfied
   --> rust/lancedb/src/data/scannable.rs:161:10
    |
158 |           let stream = futures::stream::unfold(rx, |mut rx| async move {
    |  ______________________-
159 | |             rx.recv().await.map(|batch| (batch, rx))
160 | |         })
161 | |         .fuse();
    | |         -^^^^ method cannot be called due to unsatisfied trait bounds
    | |_________|

error[E0308]: mismatched types
   --> rust/lancedb/src/data/scannable.rs:178:26
    |
178 |               stream: once(async {
    |  _____________________----_^
    | |                     |
    | |                     arguments to this function are incorrect
179 | |                 Err(Error::InvalidInput {
180 | |                     message: "Stream has already been consumed".to_string(),
181 | |                 })
182 | |             }),
    | |_____________^ expected `Result<_, _>`, found `async` block
    |
    = note:       expected enum `std::result::Result<_, _>`
            found `async` block `{async block@rust/lancedb/src/data/scannable.rs:178:26: 178:31}`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
178 ~             stream: once(Ok(async {
179 |                 Err(Error::InvalidInput {
180 |                     message: "Stream has already been consumed".to_string(),
181 |                 })
182 ~             })),
    |
178 ~             stream: once(Err(async {
179 |                 Err(Error::InvalidInput {
180 |                     message: "Stream has already been consumed".to_string(),
181 |                 })
182 ~             })),
    |

error[E0308]: mismatched types
   --> rust/lancedb/src/data/scannable.rs:474:53
    |
474 |                 let prepend = futures::stream::once(std::future::ready(Ok(batch)));
    |                               --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<_, _>`, found `Ready<Result<RecordBatch, _>>`
    |                               |
    |                               arguments to this function are incorrect
    |
    = note: expected enum `std::result::Result<_, _>`
             found struct `std::future::Ready<std::result::Result<arrow_array::RecordBatch, _>>`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
474 |                 let prepend = futures::stream::once(Ok(std::future::ready(Ok(batch))));
    |                                                     +++                             +
474 |                 let prepend = futures::stream::once(Err(std::future::ready(Ok(batch))));
    |                                                     ++++                             +

error[E0599]: the method `chain` exists for struct `futures::stream::Once<_, _>`, but its trait bounds were not satisfied
   --> rust/lancedb/src/data/scannable.rs:477:37
    |
477 |                     stream: prepend.chain(rest),
    |                                     ^^^^^ method cannot be called on `futures::stream::Once<_, _>` due to unsatisfied trait bounds

error[E0308]: mismatched types
   --> rust/lancedb/src/data/scannable.rs:482:47
    |
482 |                 stream: futures::stream::once(std::future::ready(Ok(batch))),
    |                         --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<_, _>`, found `Ready<Result<RecordBatch, _>>`
    |                         |
    |                         arguments to this function are incorrect
    |
    = note: expected enum `std::result::Result<_, _>`
             found struct `std::future::Ready<std::result::Result<arrow_array::RecordBatch, _>>`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
482 |                 stream: futures::stream::once(Ok(std::future::ready(Ok(batch)))),
    |                                               +++                             +
482 |                 stream: futures::stream::once(Err(std::future::ready(Ok(batch)))),
    |                                               ++++                             +

error[E0308]: mismatched types
   --> rust/lancedb/src/data/scannable.rs:486:56
    |
486 |                     let stream = futures::stream::once(std::future::ready(err));
    |                                  --------------------- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<_, _>`, found `Ready<Result<_, Error>>`
    |                                  |
    |                                  arguments to this function are incorrect
    |
    = note: expected enum `std::result::Result<_, _>`
             found struct `std::future::Ready<std::result::Result<_, error::Error>>`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
486 |                     let stream = futures::stream::once(Ok(std::future::ready(err)));
    |                                                        +++                       +
486 |                     let stream = futures::stream::once(Err(std::future::ready(err)));
    |                                                        ++++                       +

error[E0599]: no method named `and_then` found for struct `Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>` in the current scope
   --> rust/lancedb/src/io/object_store.rs:153:32
    |
153 |         Box::pin(put_secondary.and_then(|_| put_primary))
    |                                ^^^^^^^^

error[E0271]: expected `IntoIter<Result<RecordBatch, _>, 1>` to be an iterator that yields `Result<Result<RecordBatch, Error>, _>`, but it yields `Result<RecordBatch, _>`
    --> rust/lancedb/src/query.rs:1465:25
     |
1465 |         return Box::pin(SimpleRecordBatchStream::new(
     |                         ^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Result<RecordBatch, Error>, _>`, found `Result<RecordBatch, _>`

error[E0271]: expected `IntoIter<Result<RecordBatch, _>>` to be an iterator that yields `Result<Result<RecordBatch, Error>, _>`, but it yields `Result<RecordBatch, _>`
    --> rust/lancedb/src/query.rs:1478:14
     |
1478 |     Box::pin(SimpleRecordBatchStream::new(stream::iter(batches), schema))
     |              ^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Result<RecordBatch, Error>, _>`, found `Result<RecordBatch, _>`

error[E0308]: mismatched types
   --> rust/lancedb/src/remote/table/insert.rs:626:44
    |
626 |           let stream = futures::stream::once(async move {
    |  ______________________---------------------_^
    | |                      |
    | |                      arguments to this function are incorrect
...   |
791 | |             Ok::<_, DataFusionError>(batch)
792 | |         });
    | |_________^ expected `Result<_, _>`, found `async` block
    |
    = note:       expected enum `std::result::Result<_, _>`
            found `async` block `{async block@rust/lancedb/src/remote/table/insert.rs:626:44: 626:54}`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
626 ~         let stream = futures::stream::once(Ok(async move {
627 |             // Multipart writes with a byte budget split the partition into
...
791 |             Ok::<_, DataFusionError>(batch)
792 ~         }));
    |
626 ~         let stream = futures::stream::once(Err(async move {
627 |             // Multipart writes with a byte budget split the partition into
...
791 |             Ok::<_, DataFusionError>(batch)
792 ~         }));
    |

error[E0277]: the trait bound `futures::stream::Once<_, _>: futures_core::stream::Stream` is not satisfied
   --> rust/lancedb/src/remote/table/insert.rs:794:12
    |
794 |           Ok(Box::pin(RecordBatchStreamAdapter::new(
    |  ____________^
795 | |             COUNT_SCHEMA.clone(),
796 | |             stream,
797 | |         )))
    | |__________^ the trait `futures_core::stream::Stream` is not implemented for `futures::stream::Once<_, _>`

error[E0599]: no method named `try_collect` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
    --> rust/lancedb/src/remote/table.rs:2442:49
     |
2442 |             let result: Result<Vec<_>> = stream.try_collect().await.map_err(Error::from);
     |                                                 ^^^^^^^^^^^

error[E0277]: the trait bound `impl Stream<Item = Result<Bytes, Error>>: TryStream` is not satisfied
  --> rust/lancedb/src/remote/util.rs:47:35
   |
47 |     Ok(reqwest::Body::wrap_stream(stream))
   |        -------------------------- ^^^^^^ unsatisfied trait bound
   |        |
   |        required by a bound introduced by this call

error[E0599]: no method named `map_ok` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
   --> rust/lancedb/src/table/datafusion/insert.rs:200:30
    |
200 |                 input_stream.map_ok(move |batch| {
    |                 -------------^^^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`

error[E0308]: mismatched types
   --> rust/lancedb/src/table/datafusion/insert.rs:208:44
    |
208 |           let stream = futures::stream::once(async move {
    |  ______________________---------------------_^
    | |                      |
    | |                      arguments to this function are incorrect
209 | |             if let Some(tracker) = tracker
210 | |                 && write_params.write_progress.is_none()
...   |
255 | |             )?)
256 | |         });
    | |_________^ expected `Result<_, _>`, found `async` block
    |
    = note:       expected enum `std::result::Result<_, _>`
            found `async` block `{async block@rust/lancedb/src/table/datafusion/insert.rs:208:44: 208:54}`
note: function defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/once.rs:20:8
    |
 20 | pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
    |        ^^^^
help: try wrapping the expression in a variant of `std::result::Result`
    |
208 ~         let stream = futures::stream::once(Ok(async move {
209 |             if let Some(tracker) = tracker
...
255 |             )?)
256 ~         }));
    |
208 ~         let stream = futures::stream::once(Err(async move {
209 |             if let Some(tracker) = tracker
...
255 |             )?)
256 ~         }));
    |

error[E0277]: the trait bound `futures::stream::Once<_, _>: futures_core::stream::Stream` is not satisfied
   --> rust/lancedb/src/table/datafusion/insert.rs:258:12
    |
258 |           Ok(Box::pin(RecordBatchStreamAdapter::new(
    |  ____________^
259 | |             COUNT_SCHEMA.clone(),
260 | |             stream,
261 | |         )))
    | |__________^ the trait `futures_core::stream::Stream` is not implemented for `futures::stream::Once<_, _>`

error[E0599]: no method named `map_ok` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
   --> rust/lancedb/src/table/datafusion.rs:128:29
    |
128 |         let stream = stream.map_ok(move |batch| {
    |                      -------^^^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`

error[E0599]: no method named `map_err` found for struct `Pin<Box<dyn Future<Output = Result<Arc<...>, ...>> + Send>>` in the current scope
   --> rust/lancedb/src/table/datafusion.rs:245:14
    |
242 |           let plan = self
    |  ____________________-
243 | |             .table
244 | |             .create_plan(&AnyQuery::Query(query), options)
245 | |             .map_err(|err| DataFusionError::External(err.into()))
    | |             -^^^^^^^ method not found in `Pin<Box<dyn Future<Output = Result<Arc<...>, ...>> + Send>>`
    | |_____________|

error[E0599]: no method named `next` found for struct `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>` in the current scope
    --> rust/lancedb/src/table.rs:3048:48
     |
3048 |                 while let Some(batch) = stream.next().await {
     |                                                ^^^^ method not found in `Pin<Box<dyn datafusion_physical_plan::RecordBatchStream + std::marker::Send>>`

error[E0277]: the trait bound `JoinHandle<Result<(), Error>>: Future` is not satisfied
    --> rust/lancedb/src/table.rs:3038:23
     |
3038 |         let handles = FuturesUnordered::new();
     |                       ^^^^^^^^^^^^^^^^^^^^^^^ the trait `futures::Future` is not implemented for `tokio::task::JoinHandle<std::result::Result<(), error::Error>>`

error[E0277]: `FuturesUnordered<JoinHandle<Result<(), Error>>>` is not an iterator
    --> rust/lancedb/src/table.rs:3054:23
     |
3054 |         for handle in handles {
     |                       ^^^^^^^ `FuturesUnordered<JoinHandle<Result<(), Error>>>` is not an iterator

error[E0277]: the trait bound `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}: futures::IntoFuture` is not satisfied
    --> rust/lancedb/src/table.rs:3450:13
     |
3449 |           let mut sorted_sizes = join_all(
     |                                  -------- required by a bound introduced by this call
3450 | /             frags
3451 | |                 .iter()
3452 | |                 .map(|frag| async move { frag.physical_rows().await.unwrap_or(0) }),
     | |___________________________________________________________________________________^ the trait `futures::Future` is not implemented for `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}`
     |
     = note: `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}` implements similarly named trait `std::future::Future`, but not `futures::Future`
     = help: the following other types implement trait `futures::Future`:
               &'a mut F
               AssertUnwindSafe<F>
               BiLockAcquire<T>
               Box<F>
               Concat2<S>
               Either<A, B>
               Finished<T, E>
               Fold<S, F, Fut, T>
             and 43 others
     = note: required for `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}` to implement `futures::IntoFuture`
note: required by a bound in `join_all`
    --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/join_all.rs:78:20
     |
  76 | pub fn join_all<I>(i: I) -> JoinAll<I>
     |        -------- required by a bound in this function
  77 |     where I: IntoIterator,
  78 |           I::Item: IntoFuture,
     |                    ^^^^^^^^^^ required by this bound in `join_all`

error[E0277]: the trait bound `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}: futures::Future` is not satisfied
    --> rust/lancedb/src/table.rs:3449:32
     |
3449 |           let mut sorted_sizes = join_all(
     |  ________________________________^
3450 | |             frags
3451 | |                 .iter()
3452 | |                 .map(|frag| async move { frag.physical_rows().await.unwrap_or(0) }),
3453 | |         )
     | |_________^ the trait `futures::Future` is not implemented for `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}`
     |
     = note: `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}` implements similarly named trait `std::future::Future`, but not `futures::Future`
     = help: the following other types implement trait `futures::Future`:
               &'a mut F
               AssertUnwindSafe<F>
               BiLockAcquire<T>
               Box<F>
               Concat2<S>
               Either<A, B>
               Finished<T, E>
               Fold<S, F, Fut, T>
             and 43 others
     = note: required for `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}` to implement `futures::IntoFuture`
note: required by a bound in `JoinAll`
    --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/join_all.rs:24:20
     |
  22 | pub struct JoinAll<I>
     |            ------- required by a bound in this struct
  23 |     where I: IntoIterator,
  24 |           I::Item: IntoFuture,
     |                    ^^^^^^^^^^ required by this bound in `JoinAll`

error[E0277]: `JoinAll<Map<Iter<'_, FileFragment>, {closure@...}>>` is not a future
    --> rust/lancedb/src/table.rs:3454:10
     |
3449 |           let mut sorted_sizes = join_all(
     |  ________________________________-
3450 | |             frags
3451 | |                 .iter()
3452 | |                 .map(|frag| async move { frag.physical_rows().await.unwrap_or(0) }),
3453 | |         )
     | |_________- this call returns `JoinAll<std::iter::Map<std::slice::Iter<'_, FileFragment>, {closure@rust/lancedb/src/table.rs:3452:22: 3452:28}>>`
3454 |           .await;
     |            ^^^^^ `JoinAll<Map<Iter<'_, FileFragment>, {closure@...}>>` is not a future

error[E0277]: the trait bound `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}: futures::Future` is not satisfied
    --> rust/lancedb/src/table.rs:3454:10
     |
3454 |         .await;
     |          ^^^^^ the trait `futures::Future` is not implemented for `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}`
     |
     = note: `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}` implements similarly named trait `std::future::Future`, but not `futures::Future`
     = help: the following other types implement trait `futures::Future`:
               &'a mut F
               AssertUnwindSafe<F>
               BiLockAcquire<T>
               Box<F>
               Concat2<S>
               Either<A, B>
               Finished<T, E>
               Fold<S, F, Fut, T>
             and 43 others
     = note: required for `{async block@rust/lancedb/src/table.rs:3452:29: 3452:39}` to implement `futures::IntoFuture`
note: required by a bound in `JoinAll`
    --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/future/join_all.rs:24:20
     |
  22 | pub struct JoinAll<I>
     |            ------- required by a bound in this struct
  23 |     where I: IntoIterator,
  24 |           I::Item: IntoFuture,
     |                    ^^^^^^^^^^ required by this bound in `JoinAll`

error[E0282]: type annotations needed
   --> rust/lancedb/src/utils/background_cache.rs:119:40
    |
119 |               inner: Arc::new(Mutex::new(CacheInner {
    |  ________________________________________^
120 | |                 state: State::Empty,
121 | |                 generation: 0,
122 | |             })),
    | |_____________^ cannot infer type of the type parameter `E` declared on the struct `CacheInner`
    |
help: consider specifying the generic arguments
    |
119 |             inner: Arc::new(Mutex::new(CacheInner::<V, E> {
    |                                                  ++++++++

error[E0282]: type annotations needed
   --> rust/lancedb/src/utils/background_cache.rs:134:9
    |
134 |         cache.state.fresh_value(self.ttl, self.refresh_window)
    |         ^^^^^^^^^^^ cannot infer type for type parameter `E`

error[E0282]: type annotations needed
   --> rust/lancedb/src/utils/background_cache.rs:173:23
    |
173 |         cache.state = State::Current(value, clock::now());
    |                       ^^^^^^^^^^^^^^ cannot infer type of the type parameter `E` declared on the enum `State`
    |
help: consider specifying the generic arguments
    |
173 |         cache.state = State::<V, E>::Current(value, clock::now());
    |                            ++++++++

error[E0282]: type annotations needed
   --> rust/lancedb/src/utils/background_cache.rs:182:23
    |
182 |         cache.state = State::Empty;
    |                       ^^^^^^^^^^^^ cannot infer type of the type parameter `E` declared on the enum `State`
    |
help: consider specifying the generic arguments
    |
182 |         cache.state = State::<V, E>::Empty;
    |                            ++++++++

error[E0599]: no method named `boxed` found for `async` block `{async block@rust/lancedb/src/utils/background_cache.rs:269:22: 269:32}` in the current scope
   --> rust/lancedb/src/utils/background_cache.rs:270:14
    |
269 |           let shared = async move { (fetch)().await.map_err(Arc::new) }
    |  ______________________-
270 | |             .boxed()
    | |             -^^^^^ method not found in `{async block@rust/lancedb/src/utils/background_cache.rs:269:22: 269:32}`
    | |_____________|

error[E0277]: the trait bound `TimeoutStream: futures_core::stream::Stream` is not satisfied
   --> rust/lancedb/src/utils/mod.rs:345:9
    |
345 |         Box::pin(Self::new(inner, timeout))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound

error[E0599]: no method named `poll_next` found for struct `Pin<&mut TimeoutStream>` in the current scope
   --> rust/lancedb/src/utils/mod.rs:376:22
    |
376 |                 self.poll_next(cx)
    |                      ^^^^^^^^^
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `poll_next`, perhaps you need to implement one of them:
            candidate #1: `futures_core::stream::Stream`
            candidate #2: `sorts::stream::PartitionedStream`
help: there is a method `collect` with a similar name, but with different arguments
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/futures-0.1.31/src/stream/mod.rs:563:5
    |
563 | /     fn collect(self) -> Collect<Self>
564 | |         where Self: Sized
    | |_________________________^

error[E0599]: no method named `poll_unpin` found for mutable reference `&mut Pin<Box<Sleep>>` in the current scope
   --> rust/lancedb/src/utils/mod.rs:378:75
    |
378 |             TimeoutState::Started { deadline, timeout } => match deadline.poll_unpin(cx) {
    |                                                                           ^^^^^^^^^^ method not found in `&mut Pin<Box<Sleep>>`

error[E0599]: no method named `poll_next` found for struct `Pin<&mut Pin<Box<dyn RecordBatchStream + Send>>>` in the current scope
   --> rust/lancedb/src/utils/mod.rs:386:27
    |
386 |                     inner.poll_next(cx)
    |                           ^^^^^^^^^

error[E0277]: the trait bound `MaxBatchLengthStream: futures_core::stream::Stream` is not satisfied
   --> rust/lancedb/src/utils/mod.rs:419:13
    |
419 |             Box::pin(Self::new(inner, max_batch_length))
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound

error[E0599]: no method named `poll_next` found for struct `Pin<&mut Pin<Box<dyn RecordBatchStream + Send>>>` in the current scope
   --> rust/lancedb/src/utils/mod.rs:439:50
    |
439 |                 return Pin::new(&mut self.inner).poll_next(cx);
    |                                                  ^^^^^^^^^

error[E0599]: no method named `poll_next` found for struct `Pin<&mut Pin<Box<dyn RecordBatchStream + Send>>>` in the current scope
   --> rust/lancedb/src/utils/mod.rs:459:45
    |
459 |             match Pin::new(&mut self.inner).poll_next(cx) {
    |                                             ^^^^^^^^^

Some errors have detailed explanations: E0046, E0107, E0191, E0271, E0277, E0282, E0308, E0407, E0425...
For more information about an error, try `rustc --explain E0046`.
error: could not compile `lancedb` (lib) due to 118 previous errors
```