### PR TITLE
docs(rust): use LanceDB Arrow re-exports

### DIFF
--- a/rust/lancedb/examples/simple.rs
+++ b/rust/lancedb/examples/simple.rs
@@ -7,10 +7,10 @@
 
 use std::sync::Arc;
 
-use arrow_array::types::Float32Type;
-use arrow_array::{FixedSizeListArray, Int32Array, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
 use futures::TryStreamExt;
+use lancedb::arrow::arrow_array::types::Float32Type;
+use lancedb::arrow::arrow_array::{FixedSizeListArray, Int32Array, RecordBatch};
+use lancedb::arrow::arrow_schema::{DataType, Field, Schema};
 use lancedb::connection::Connection;
 use lancedb::index::Index;
 use lancedb::query::{ExecutableQuery, QueryBase};

--- a/rust/lancedb/src/lib.rs
+++ b/rust/lancedb/src/lib.rs
@@ -23,6 +23,11 @@
 //! cargo add lancedb
 //! ```
 //!
+//! Use the Arrow crates re-exported from [`arrow`] when building schemas, arrays, and
+//! record batches for LanceDB. Arrow types from different crate versions are distinct
+//! Rust types, so declaring independent `arrow-array` or `arrow-schema` dependencies
+//! can cause type errors if their versions do not match LanceDB's dependencies.
+//!
 //! ## Crate Features
 //!
 //! - `aws` - Enable AWS S3 object store support.
@@ -85,9 +90,11 @@
 //!
 //! ```rust
 //! # use std::sync::Arc;
-//! use arrow_array::{RecordBatch, RecordBatchIterator};
-//! use arrow_schema::{DataType, Field, Schema};
-//! # use arrow_array::{FixedSizeListArray, Float32Array, Int32Array, types::Float32Type};
+//! use lancedb::arrow::arrow_array::{RecordBatch, RecordBatchIterator};
+//! use lancedb::arrow::arrow_schema::{DataType, Field, Schema};
+//! # use lancedb::arrow::arrow_array::{
+//! #     FixedSizeListArray, Float32Array, Int32Array, types::Float32Type,
+//! # };
 //!
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! # let tmpdir = tempfile::tempdir().unwrap();
@@ -132,9 +139,11 @@
 //!
 //! ```no_run
 //! # use std::sync::Arc;
-//! # use arrow_array::{FixedSizeListArray, types::Float32Type, RecordBatch,
-//! #   RecordBatchIterator, Int32Array};
-//! # use arrow_schema::{Schema, Field, DataType};
+//! # use lancedb::arrow::arrow_array::{
+//! #     FixedSizeListArray, Int32Array, RecordBatch, RecordBatchIterator,
+//! #     types::Float32Type,
+//! # };
+//! # use lancedb::arrow::arrow_schema::{DataType, Field, Schema};
 //! use lancedb::index::Index;
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! # let tmpdir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- explain that Rust callers should use the Arrow crates re-exported by `lancedb::arrow`
- update the crate quick-start doctests to build Arrow values from those re-exports
- update the checked-in `simple` example so it cannot drift to an incompatible Arrow crate version

Fixes #1207.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1 --quiet`
- static checks that the documented crates are publicly re-exported and both examples use them
- `git diff --check`
- attempted `cargo check --quiet -p lancedb --example simple`; dependency compilation stopped in the unmodified `lance-encoding` build script because `protoc` is not installed in this environment