### PR TITLE
feat: add asynchronous drop table API

### DIFF
--- a/docs/src/js/classes/Connection.md
+++ b/docs/src/js/classes/Connection.md
@@ -386,6 +386,29 @@ Drop an existing table.
 
 ***
 
+### dropTableAsync()
+
+```ts
+abstract dropTableAsync(name, namespacePath?): Promise<Job>
+```
+
+Start dropping a table and return its cleanup job.
+
+The table may become unavailable before its data files are removed. Wait
+on the returned job to know when cleanup has finished.
+
+#### Parameters
+
+* **name**: `string`
+
+* **namespacePath?**: `string`[]
+
+#### Returns
+
+`Promise`&lt;[`Job`](Job.md)&gt;
+
+***
+
 ### getJob()
 
 ```ts

--- a/nodejs/__test__/connection.test.ts
+++ b/nodejs/__test__/connection.test.ts
@@ -89,6 +89,16 @@ describe("given a connection", () => {
     await db.createTable("test4", [{ id: 1 }, { id: 2 }]);
   });
 
+  it("should return a completed job when dropping a local table", async () => {
+    await db.createTable("async-drop", [{ id: 1 }]);
+
+    const job = await db.dropTableAsync("async-drop");
+    expect(job.id).toBeNull();
+    await expect(job.status()).resolves.toBe("finished");
+    await job.wait();
+    await expect(db.tableNames()).resolves.toEqual([]);
+  });
+
   it("should fail if creating table twice, unless overwrite is true", async () => {
     let tbl = await db.createTable("test", [{ id: 1 }, { id: 2 }]);
     await expect(tbl.countRows()).resolves.toBe(2);

--- a/nodejs/lancedb/connection.ts
+++ b/nodejs/lancedb/connection.ts
@@ -328,6 +328,14 @@ export abstract class Connection {
   abstract dropTable(name: string, namespacePath?: string[]): Promise<void>;
 
   /**
+   * Start dropping a table and return its cleanup job.
+   *
+   * The table may become unavailable before its data files are removed. Wait
+   * on the returned job to know when cleanup has finished.
+   */
+  abstract dropTableAsync(name: string, namespacePath?: string[]): Promise<Job>;
+
+  /**
    * Drop all tables in the database.
    * @param {string[]} namespacePath The namespace path to drop tables from (defaults to root namespace).
    */
@@ -703,6 +711,10 @@ export class LocalConnection extends Connection {
 
   async dropTable(name: string, namespacePath?: string[]): Promise<void> {
     return this.inner.dropTable(name, namespacePath ?? []);
+  }
+
+  async dropTableAsync(name: string, namespacePath?: string[]): Promise<Job> {
+    return this.inner.dropTableAsync(name, namespacePath ?? []);
   }
 
   async dropAllTables(namespacePath?: string[]): Promise<void> {

--- a/nodejs/src/connection.rs
+++ b/nodejs/src/connection.rs
@@ -334,6 +334,22 @@ impl Connection {
             .default_error()
     }
 
+    /// Start dropping a table and return its cleanup job.
+    #[napi(catch_unwind)]
+    pub async fn drop_table_async(
+        &self,
+        name: String,
+        namespace_path: Option<Vec<String>>,
+    ) -> napi::Result<crate::job::Job> {
+        let ns = namespace_path.unwrap_or_default();
+        let job = self
+            .get_inner()?
+            .drop_table_async(&name, &ns)
+            .await
+            .default_error()?;
+        Ok(crate::job::Job::new(job))
+    }
+
     #[napi(catch_unwind)]
     pub async fn drop_all_tables(&self, namespace_path: Option<Vec<String>>) -> napi::Result<()> {
         let ns = namespace_path.unwrap_or_default();

--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -198,6 +198,9 @@ class Connection(object):
     async def drop_table(
         self, name: str, namespace_path: Optional[List[str]] = None
     ) -> None: ...
+    async def drop_table_async(
+        self, name: str, namespace_path: Optional[List[str]] = None
+    ) -> Job: ...
     async def drop_all_tables(
         self, namespace_path: Optional[List[str]] = None
     ) -> None: ...

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -1203,9 +1203,8 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        return Job(
-            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
-        )
+        job = LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
+        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override
     def drop_all_tables(self, namespace_path: Optional[List[str]] = None):

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -1204,11 +1204,7 @@ class LanceDBConnection(DBConnection):
         if namespace_path is None:
             namespace_path = []
         return Job(
-            AsyncJob(
-                LOOP.run(
-                    self._conn.drop_table_async(name, namespace_path=namespace_path)
-                )
-            )
+            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
         )
 
     @override

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -1203,8 +1203,9 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        job = LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
-        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
+        return Job(
+            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
+        )
 
     @override
     def drop_all_tables(self, namespace_path: Optional[List[str]] = None):

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -1203,9 +1203,10 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        return Job(
-            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
+        job = LOOP.run(
+            self._conn.drop_table_async(name, namespace_path=namespace_path)
         )
+        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override
     def drop_all_tables(self, namespace_path: Optional[List[str]] = None):

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -1203,9 +1203,7 @@ class LanceDBConnection(DBConnection):
         """
         if namespace_path is None:
             namespace_path = []
-        job = LOOP.run(
-            self._conn.drop_table_async(name, namespace_path=namespace_path)
-        )
+        job = LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
         return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override

--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -524,6 +524,12 @@ class DBConnection(EnforceOverrides):
             namespace_path = []
         raise NotImplementedError
 
+    def drop_table_async(
+        self, name: str, namespace_path: Optional[List[str]] = None
+    ) -> Job:
+        """Start dropping a table and return its cleanup job."""
+        raise NotImplementedError
+
     def rename_table(
         self,
         cur_name: str,
@@ -1183,6 +1189,25 @@ class LanceDBConnection(DBConnection):
         LOOP.run(
             self._conn.drop_table(
                 name, namespace_path=namespace_path, ignore_missing=ignore_missing
+            )
+        )
+
+    @override
+    def drop_table_async(
+        self, name: str, namespace_path: Optional[List[str]] = None
+    ) -> Job:
+        """Start dropping a table and return its cleanup job.
+
+        The table may become unavailable before its data files are removed.
+        Call :meth:`Job.wait` to wait for cleanup to finish.
+        """
+        if namespace_path is None:
+            namespace_path = []
+        return Job(
+            AsyncJob(
+                LOOP.run(
+                    self._conn.drop_table_async(name, namespace_path=namespace_path)
+                )
             )
         )
 
@@ -1962,6 +1987,23 @@ class AsyncConnection(object):
                 raise e
             if f"Table '{name}' was not found" not in str(e):
                 raise e
+
+    async def drop_table_async(
+        self,
+        name: str,
+        *,
+        namespace_path: Optional[List[str]] = None,
+    ) -> AsyncJob:
+        """Start dropping a table and return its cleanup job.
+
+        The table may become unavailable before its data files are removed.
+        Await :meth:`AsyncJob.wait` to wait for cleanup to finish.
+        """
+        if namespace_path is None:
+            namespace_path = []
+        return AsyncJob(
+            await self._inner.drop_table_async(name, namespace_path=namespace_path)
+        )
 
     async def drop_all_tables(self, namespace_path: Optional[List[str]] = None):
         """Drop all tables from the database.

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -632,7 +632,9 @@ class LanceNamespaceDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        job = LOOP.run(self._inner.drop_table_async(name, namespace_path=namespace_path))
+        job = LOOP.run(
+            self._inner.drop_table_async(name, namespace_path=namespace_path)
+        )
         return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -632,10 +632,11 @@ class LanceNamespaceDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        job = LOOP.run(
-            self._inner.drop_table_async(name, namespace_path=namespace_path)
+        return Job(
+            LOOP.run(
+                self._inner.drop_table_async(name, namespace_path=namespace_path)
+            )
         )
-        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override
     def rename_table(

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -49,6 +49,7 @@ from lancedb._lancedb import (
 )
 from lancedb.background_loop import LOOP
 from lancedb.db import AsyncConnection, DBConnection
+from lancedb.job import AsyncJob, Job
 from lance_namespace import (
     LanceNamespace,
     connect as namespace_connect,
@@ -625,6 +626,17 @@ class LanceNamespaceDBConnection(DBConnection):
         LOOP.run(self._inner.drop_table(name, namespace_path=namespace_path))
 
     @override
+    def drop_table_async(
+        self, name: str, namespace_path: Optional[List[str]] = None
+    ) -> Job:
+        """Start dropping a table and return its cleanup job."""
+        if namespace_path is None:
+            namespace_path = []
+        return Job(
+            LOOP.run(self._inner.drop_table_async(name, namespace_path=namespace_path))
+        )
+
+    @override
     def rename_table(
         self,
         cur_name: str,
@@ -1133,6 +1145,14 @@ class AsyncLanceNamespaceDBConnection:
         if namespace_path is None:
             namespace_path = []
         await self._inner.drop_table(name, namespace_path=namespace_path)
+
+    async def drop_table_async(
+        self, name: str, namespace_path: Optional[List[str]] = None
+    ) -> AsyncJob:
+        """Start dropping a table and return its cleanup job."""
+        if namespace_path is None:
+            namespace_path = []
+        return await self._inner.drop_table_async(name, namespace_path=namespace_path)
 
     async def rename_table(
         self,

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -632,9 +632,7 @@ class LanceNamespaceDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        job = LOOP.run(
-            self._inner.drop_table_async(name, namespace_path=namespace_path)
-        )
+        job = LOOP.run(self._inner.drop_table_async(name, namespace_path=namespace_path))
         return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -633,9 +633,7 @@ class LanceNamespaceDBConnection(DBConnection):
         if namespace_path is None:
             namespace_path = []
         return Job(
-            LOOP.run(
-                self._inner.drop_table_async(name, namespace_path=namespace_path)
-            )
+            LOOP.run(self._inner.drop_table_async(name, namespace_path=namespace_path))
         )
 
     @override

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -632,9 +632,10 @@ class LanceNamespaceDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        return Job(
-            LOOP.run(self._inner.drop_table_async(name, namespace_path=namespace_path))
+        job = LOOP.run(
+            self._inner.drop_table_async(name, namespace_path=namespace_path)
         )
+        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override
     def rename_table(

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -664,6 +664,17 @@ class RemoteDBConnection(DBConnection):
         LOOP.run(self._conn.drop_table(name, namespace_path=namespace_path))
 
     @override
+    def drop_table_async(
+        self, name: str, namespace_path: Optional[List[str]] = None
+    ) -> Job:
+        """Start dropping a table and return its cleanup job."""
+        if namespace_path is None:
+            namespace_path = []
+        return Job(
+            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
+        )
+
+    @override
     def rename_table(
         self,
         cur_name: str,

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -23,7 +23,7 @@ import pyarrow as pa
 
 from ..common import DATA
 from ..db import DBConnection, LOOP
-from ..job import Job
+from ..job import AsyncJob, Job
 
 if TYPE_CHECKING:
     from .._lancedb import JobDescription, JobInfo
@@ -670,9 +670,10 @@ class RemoteDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        return Job(
-            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
+        job = LOOP.run(
+            self._conn.drop_table_async(name, namespace_path=namespace_path)
         )
+        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override
     def rename_table(

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -670,9 +670,7 @@ class RemoteDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        job = LOOP.run(
-            self._conn.drop_table_async(name, namespace_path=namespace_path)
-        )
+        job = LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
         return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -23,7 +23,7 @@ import pyarrow as pa
 
 from ..common import DATA
 from ..db import DBConnection, LOOP
-from ..job import Job
+from ..job import AsyncJob, Job
 
 if TYPE_CHECKING:
     from .._lancedb import JobDescription, JobInfo
@@ -670,9 +670,8 @@ class RemoteDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        return Job(
-            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
-        )
+        job = LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
+        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
 
     @override
     def rename_table(

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -23,7 +23,7 @@ import pyarrow as pa
 
 from ..common import DATA
 from ..db import DBConnection, LOOP
-from ..job import AsyncJob, Job
+from ..job import Job
 
 if TYPE_CHECKING:
     from .._lancedb import JobDescription, JobInfo
@@ -670,8 +670,9 @@ class RemoteDBConnection(DBConnection):
         """Start dropping a table and return its cleanup job."""
         if namespace_path is None:
             namespace_path = []
-        job = LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
-        return Job(job if isinstance(job, AsyncJob) else AsyncJob(job))
+        return Job(
+            LOOP.run(self._conn.drop_table_async(name, namespace_path=namespace_path))
+        )
 
     @override
     def rename_table(

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -755,8 +755,7 @@ def test_delete_table(tmp_db: lancedb.DBConnection):
     assert tmp_db.table_names() == []
 
 
-@pytest.mark.asyncio
-async def test_delete_table_async(tmp_db: lancedb.DBConnection):
+def test_drop_table_async(tmp_db: lancedb.DBConnection):
     data = pd.DataFrame(
         {
             "vector": [[3.1, 4.1], [5.9, 26.5]],
@@ -772,13 +771,27 @@ async def test_delete_table_async(tmp_db: lancedb.DBConnection):
 
     assert tmp_db.table_names() == ["test"]
 
-    tmp_db.drop_table("test")
+    job = tmp_db.drop_table_async("test")
+    assert job.id is None
+    assert job.status() == "finished"
+    job.wait()
     assert tmp_db.table_names() == []
 
     tmp_db.create_table("test", data=data)
     assert tmp_db.table_names() == ["test"]
 
     tmp_db.drop_table("does_not_exist", ignore_missing=True)
+
+
+@pytest.mark.asyncio
+async def test_drop_table_async_connection(tmp_db_async: lancedb.AsyncConnection):
+    await tmp_db_async.create_table("test", data=pa.table({"id": [1, 2]}))
+
+    job = await tmp_db_async.drop_table_async("test")
+    assert job.id is None
+    assert await job.status() == "finished"
+    await job.wait()
+    assert await tmp_db_async.table_names() == []
 
 
 def test_drop_database(tmp_db: lancedb.DBConnection):

--- a/python/src/connection.rs
+++ b/python/src/connection.rs
@@ -346,6 +346,23 @@ impl Connection {
         })
     }
 
+    #[pyo3(signature = (name, namespace_path=None))]
+    pub fn drop_table_async(
+        self_: PyRef<'_, Self>,
+        name: String,
+        namespace_path: Option<Vec<String>>,
+    ) -> PyResult<Bound<'_, PyAny>> {
+        let inner = self_.get_inner()?.clone();
+        let ns_path = namespace_path.unwrap_or_default();
+        future_into_py(self_.py(), async move {
+            inner
+                .drop_table_async(name, &ns_path)
+                .await
+                .infer_error()
+                .map(crate::job::Job::new)
+        })
+    }
+
     #[pyo3(signature = (namespace_path=None,))]
     pub fn drop_all_tables(
         self_: PyRef<'_, Self>,

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -565,6 +565,21 @@ impl Connection {
             .await
     }
 
+    /// Start dropping a table and return a handle to the cleanup job.
+    ///
+    /// The table may become unavailable before its physical data is removed.
+    /// Call [`crate::job::Job::wait`] to wait for cleanup to finish. Local
+    /// backends may complete the drop before returning the handle.
+    pub async fn drop_table_async(
+        &self,
+        name: impl AsRef<str>,
+        namespace_path: &[String],
+    ) -> Result<crate::job::Job> {
+        self.internal
+            .drop_table_async(name.as_ref(), namespace_path)
+            .await
+    }
+
     /// Drop the database
     ///
     /// This is the same as dropping all of the tables

--- a/rust/lancedb/src/database.rs
+++ b/rust/lancedb/src/database.rs
@@ -323,6 +323,18 @@ pub trait Database:
     ) -> Result<()>;
     /// Drop a table in the database
     async fn drop_table(&self, name: &str, namespace_path: &[String]) -> Result<()>;
+    /// Start dropping a table and return a handle to the cleanup job.
+    ///
+    /// Backends without asynchronous cleanup complete the drop before
+    /// returning an already-finished job.
+    async fn drop_table_async(
+        &self,
+        name: &str,
+        namespace_path: &[String],
+    ) -> Result<crate::job::Job> {
+        self.drop_table(name, namespace_path).await?;
+        Ok(crate::job::Job::new_done())
+    }
     /// Drop all tables in the database
     async fn drop_all_tables(&self, namespace_path: &[String]) -> Result<()>;
     fn as_any(&self) -> &dyn std::any::Any;

--- a/rust/lancedb/src/remote.rs
+++ b/rust/lancedb/src/remote.rs
@@ -19,6 +19,15 @@ const ARROW_FILE_CONTENT_TYPE: &str = "application/vnd.apache.arrow.file";
 #[cfg(test)]
 const JSON_CONTENT_TYPE: &str = "application/json";
 
+fn extract_job_id(body: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()?
+        .get("job_id")?
+        .as_str()
+        .filter(|job_id| !job_id.is_empty())
+        .map(str::to_string)
+}
+
 pub use client::{ClientConfig, HeaderProvider, RetryConfig, TimeoutConfig, TlsConfig};
 pub use db::{RemoteDatabaseOptions, RemoteDatabaseOptionsBuilder};
 pub use oauth::{OAuthConfig, OAuthFlow, OAuthHeaderProvider};

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -333,7 +333,7 @@ impl<S: HttpSend> RemoteDatabase<S> {
         &self,
         name: &str,
         namespace_path: &[String],
-    ) -> Result<(StatusCode, Option<String>)> {
+    ) -> Result<(String, StatusCode, Option<String>)> {
         let identifier = build_table_identifier(name, namespace_path, &self.client.id_delimiter);
         let cache_key = build_cache_key(name, namespace_path);
         let req = self.client.post(&format!("/v1/table/{}/drop/", identifier));
@@ -351,7 +351,7 @@ impl<S: HttpSend> RemoteDatabase<S> {
                     .filter(|id| !id.is_empty())
                     .map(str::to_string)
             });
-        Ok((status, job_id))
+        Ok((request_id, status, job_id))
     }
 }
 
@@ -929,13 +929,15 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     }
 
     async fn drop_table_async(&self, name: &str, namespace_path: &[String]) -> Result<Job> {
-        let (status, job_id) = self.submit_drop_table(name, namespace_path).await?;
+        let (request_id, status, job_id) = self.submit_drop_table(name, namespace_path).await?;
         Ok(match job_id {
             Some(job_id) => Job::new(Box::new(RemoteJob::new(self.client.clone(), job_id))),
             None if status == StatusCode::ACCEPTED => {
-                return Err(Error::Runtime {
-                    message: "asynchronous drop-table response did not contain a valid job_id"
-                        .to_string(),
+                return Err(Error::Http {
+                    source: "asynchronous drop-table response did not contain a valid job_id"
+                        .into(),
+                    request_id,
+                    status_code: Some(status),
                 });
             }
             None => Job::new_done(),

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -9,6 +9,7 @@ use http::StatusCode;
 use lance_io::object_store::StorageOptions;
 use lance_namespace_impls::{DynamicContextProvider, OperationInfo};
 use moka::future::Cache;
+use reqwest::Response;
 use reqwest::header::CONTENT_TYPE;
 
 use lance_namespace::models::{
@@ -28,12 +29,12 @@ use crate::remote::job::RemoteJob;
 use crate::remote::util::stream_as_body;
 use crate::table::BaseTable;
 
-use super::ARROW_STREAM_CONTENT_TYPE;
 use super::client::{
     ClientConfig, HeaderProvider, HttpSend, RequestResultExt, RestfulLanceDbClient, Sender,
 };
 use super::table::RemoteTable;
 use super::util::parse_server_version;
+use super::{ARROW_STREAM_CONTENT_TYPE, extract_job_id};
 
 // Request structure for the remote clone table API
 #[derive(serde::Serialize)]
@@ -333,25 +334,14 @@ impl<S: HttpSend> RemoteDatabase<S> {
         &self,
         name: &str,
         namespace_path: &[String],
-    ) -> Result<(String, StatusCode, Option<String>)> {
+    ) -> Result<(String, Response)> {
         let identifier = build_table_identifier(name, namespace_path, &self.client.id_delimiter);
         let cache_key = build_cache_key(name, namespace_path);
         let req = self.client.post(&format!("/v1/table/{}/drop/", identifier));
         let (request_id, resp) = self.client.send(req).await?;
         let resp = self.client.check_response(&request_id, resp).await?;
-        let status = resp.status();
         self.table_cache.remove(&cache_key).await;
-        let body = resp.text().await.err_to_http(request_id.clone())?;
-        let job_id = serde_json::from_str::<serde_json::Value>(&body)
-            .ok()
-            .and_then(|value| {
-                value
-                    .get("job_id")
-                    .and_then(|id| id.as_str())
-                    .filter(|id| !id.is_empty())
-                    .map(str::to_string)
-            });
-        Ok((request_id, status, job_id))
+        Ok((request_id, resp))
     }
 }
 
@@ -929,7 +919,10 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     }
 
     async fn drop_table_async(&self, name: &str, namespace_path: &[String]) -> Result<Job> {
-        let (request_id, status, job_id) = self.submit_drop_table(name, namespace_path).await?;
+        let (request_id, response) = self.submit_drop_table(name, namespace_path).await?;
+        let status = response.status();
+        let body = response.text().await.err_to_http(request_id.clone())?;
+        let job_id = extract_job_id(&body);
         Ok(match job_id {
             Some(job_id) => Job::new(Box::new(RemoteJob::new(self.client.clone(), job_id))),
             None if status == StatusCode::ACCEPTED => {
@@ -1531,6 +1524,18 @@ mod tests {
         });
         conn.drop_table("table1", &[]).await.unwrap();
         // NOTE: the API will return 200 even if the table does not exist. So we shouldn't expect 404.
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_does_not_read_response_body() {
+        let conn = Connection::new_with_handler(|_| {
+            http::Response::builder()
+                .status(200)
+                .body(vec![0xff])
+                .unwrap()
+        });
+
+        conn.drop_table("table1", &[]).await.unwrap();
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -23,6 +23,8 @@ use crate::database::{
     JobDescription, JobInfo, OpenTableRequest, ReadConsistency, TableNamesRequest,
 };
 use crate::error::Result;
+use crate::job::Job;
+use crate::remote::job::RemoteJob;
 use crate::remote::util::stream_as_body;
 use crate::table::BaseTable;
 
@@ -323,6 +325,30 @@ impl RemoteDatabase {
             namespace_context_provider,
             tls_config: client_config.tls_config,
         })
+    }
+}
+
+impl<S: HttpSend> RemoteDatabase<S> {
+    async fn submit_drop_table(
+        &self,
+        name: &str,
+        namespace_path: &[String],
+    ) -> Result<Option<String>> {
+        let identifier = build_table_identifier(name, namespace_path, &self.client.id_delimiter);
+        let cache_key = build_cache_key(name, namespace_path);
+        let req = self.client.post(&format!("/v1/table/{}/drop/", identifier));
+        let (request_id, resp) = self.client.send(req).await?;
+        let resp = self.client.check_response(&request_id, resp).await?;
+        let body = resp.text().await.err_to_http(request_id)?;
+        self.table_cache.remove(&cache_key).await;
+        Ok(serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("job_id")
+                    .and_then(|id| id.as_str())
+                    .map(str::to_string)
+            }))
     }
 }
 
@@ -894,13 +920,16 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     }
 
     async fn drop_table(&self, name: &str, namespace_path: &[String]) -> Result<()> {
-        let identifier = build_table_identifier(name, namespace_path, &self.client.id_delimiter);
-        let cache_key = build_cache_key(name, namespace_path);
-        let req = self.client.post(&format!("/v1/table/{}/drop/", identifier));
-        let (request_id, resp) = self.client.send(req).await?;
-        self.client.check_response(&request_id, resp).await?;
-        self.table_cache.remove(&cache_key).await;
-        Ok(())
+        self.submit_drop_table(name, namespace_path)
+            .await
+            .map(|_| ())
+    }
+
+    async fn drop_table_async(&self, name: &str, namespace_path: &[String]) -> Result<Job> {
+        Ok(match self.submit_drop_table(name, namespace_path).await? {
+            Some(job_id) => Job::new(Box::new(RemoteJob::new(self.client.clone(), job_id))),
+            None => Job::new_done(),
+        })
     }
 
     async fn drop_all_tables(&self, namespace_path: &[String]) -> Result<()> {
@@ -1490,6 +1519,32 @@ mod tests {
         });
         conn.drop_table("table1", &[]).await.unwrap();
         // NOTE: the API will return 200 even if the table does not exist. So we shouldn't expect 404.
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_async_returns_job() {
+        let conn = Connection::new_with_handler(|request| {
+            assert_eq!(request.method(), &reqwest::Method::POST);
+            assert_eq!(request.url().path(), "/v1/table/table1/drop/");
+            http::Response::builder()
+                .status(202)
+                .body(r#"{"job_id":"drop-job-123"}"#)
+                .unwrap()
+        });
+
+        let job = conn.drop_table_async("table1", &[]).await.unwrap();
+        assert_eq!(job.id(), Some("drop-job-123"));
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_async_old_server_returns_done_job() {
+        let conn = Connection::new_with_handler(|_| {
+            http::Response::builder().status(200).body("").unwrap()
+        });
+
+        let job = conn.drop_table_async("table1", &[]).await.unwrap();
+        assert_eq!(job.id(), None);
+        assert_eq!(job.status().await.unwrap(), "finished");
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -339,10 +339,12 @@ impl<S: HttpSend> RemoteDatabase<S> {
         let req = self.client.post(&format!("/v1/table/{}/drop/", identifier));
         let (request_id, resp) = self.client.send(req).await?;
         let resp = self.client.check_response(&request_id, resp).await?;
-        let body = resp.text().await.err_to_http(request_id)?;
         self.table_cache.remove(&cache_key).await;
-        Ok(serde_json::from_str::<serde_json::Value>(&body)
+        Ok(resp
+            .text()
+            .await
             .ok()
+            .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
             .and_then(|value| {
                 value
                     .get("job_id")

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -341,15 +341,14 @@ impl<S: HttpSend> RemoteDatabase<S> {
         let resp = self.client.check_response(&request_id, resp).await?;
         let status = resp.status();
         self.table_cache.remove(&cache_key).await;
-        let job_id = resp
-            .text()
-            .await
+        let body = resp.text().await.err_to_http(request_id.clone())?;
+        let job_id = serde_json::from_str::<serde_json::Value>(&body)
             .ok()
-            .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
             .and_then(|value| {
                 value
                     .get("job_id")
                     .and_then(|id| id.as_str())
+                    .filter(|id| !id.is_empty())
                     .map(str::to_string)
             });
         Ok((status, job_id))
@@ -1562,6 +1561,19 @@ mod tests {
     async fn test_drop_table_async_rejects_accepted_response_without_job_id() {
         let conn = Connection::new_with_handler(|_| {
             http::Response::builder().status(202).body("{}").unwrap()
+        });
+
+        let error = conn.drop_table_async("table1", &[]).await.err().unwrap();
+        assert!(error.to_string().contains("valid job_id"));
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_async_rejects_empty_job_id() {
+        let conn = Connection::new_with_handler(|_| {
+            http::Response::builder()
+                .status(202)
+                .body(r#"{"job_id":""}"#)
+                .unwrap()
         });
 
         let error = conn.drop_table_async("table1", &[]).await.err().unwrap();

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -333,14 +333,15 @@ impl<S: HttpSend> RemoteDatabase<S> {
         &self,
         name: &str,
         namespace_path: &[String],
-    ) -> Result<Option<String>> {
+    ) -> Result<(StatusCode, Option<String>)> {
         let identifier = build_table_identifier(name, namespace_path, &self.client.id_delimiter);
         let cache_key = build_cache_key(name, namespace_path);
         let req = self.client.post(&format!("/v1/table/{}/drop/", identifier));
         let (request_id, resp) = self.client.send(req).await?;
         let resp = self.client.check_response(&request_id, resp).await?;
+        let status = resp.status();
         self.table_cache.remove(&cache_key).await;
-        Ok(resp
+        let job_id = resp
             .text()
             .await
             .ok()
@@ -350,7 +351,8 @@ impl<S: HttpSend> RemoteDatabase<S> {
                     .get("job_id")
                     .and_then(|id| id.as_str())
                     .map(str::to_string)
-            }))
+            });
+        Ok((status, job_id))
     }
 }
 
@@ -928,8 +930,15 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     }
 
     async fn drop_table_async(&self, name: &str, namespace_path: &[String]) -> Result<Job> {
-        Ok(match self.submit_drop_table(name, namespace_path).await? {
+        let (status, job_id) = self.submit_drop_table(name, namespace_path).await?;
+        Ok(match job_id {
             Some(job_id) => Job::new(Box::new(RemoteJob::new(self.client.clone(), job_id))),
+            None if status == StatusCode::ACCEPTED => {
+                return Err(Error::Runtime {
+                    message: "asynchronous drop-table response did not contain a valid job_id"
+                        .to_string(),
+                });
+            }
             None => Job::new_done(),
         })
     }
@@ -1547,6 +1556,16 @@ mod tests {
         let job = conn.drop_table_async("table1", &[]).await.unwrap();
         assert_eq!(job.id(), None);
         assert_eq!(job.status().await.unwrap(), "finished");
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_async_rejects_accepted_response_without_job_id() {
+        let conn = Connection::new_with_handler(|_| {
+            http::Response::builder().status(202).body("{}").unwrap()
+        });
+
+        let error = conn.drop_table_async("table1", &[]).await.err().unwrap();
+        assert!(error.to_string().contains("valid job_id"));
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -8,7 +8,7 @@ use self::insert::{RemoteWriteExec, WriteOp};
 use super::client::RequestResultExt;
 use super::client::{HttpSend, RestfulLanceDbClient, Sender};
 use super::db::ServerVersion;
-use super::{ARROW_FILE_CONTENT_TYPE, ARROW_STREAM_CONTENT_TYPE};
+use super::{ARROW_FILE_CONTENT_TYPE, ARROW_STREAM_CONTENT_TYPE, extract_job_id};
 use crate::blob::BlobFile;
 use crate::data::scannable::{PeekedScannable, Scannable, estimate_write_partitions};
 use crate::expr::expr_to_sql_string;
@@ -392,13 +392,7 @@ impl<S: HttpSend> RemoteTable<S> {
             .text()
             .await
             .ok()
-            .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
-            .and_then(|value| {
-                value
-                    .get("job_id")
-                    .and_then(|id| id.as_str())
-                    .map(str::to_string)
-            });
+            .and_then(|body| extract_job_id(&body));
 
         if let Some(wait_timeout) = index.wait_timeout {
             let index_name = index.name.unwrap_or_else(|| format!("{}_idx", column));


### PR DESCRIPTION
## Summary

- add `drop_table_async` and return a job handle while preserving `drop_table`
- consume remote 202 responses with cleanup job IDs and retain older-server compatibility
- expose the API through Python and TypeScript connection wrappers