### PR TITLE
fix(python): list every table from table_names() by default

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -257,7 +257,7 @@ class DBConnection(EnforceOverrides):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:
@@ -271,8 +271,9 @@ class DBConnection(EnforceOverrides):
         page_token: str, optional
             The token to use for pagination. If not present, start from the beginning.
             Typically, this token is last table name from the previous page.
-        limit: int, default 10
-            The size of the page to return.
+        limit: int, optional
+            The size of the page to return. If not present, every table is
+            returned.
 
         Returns
         -------
@@ -936,7 +937,7 @@ class LanceDBConnection(DBConnection):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:
@@ -951,8 +952,9 @@ class LanceDBConnection(DBConnection):
             The namespace to list tables in.
         page_token: str, optional
             The token to use for pagination.
-        limit: int, default 10
-            The maximum number of tables to return.
+        limit: int, optional
+            The maximum number of tables to return. If not present, every table
+            is returned.
 
         Returns
         -------
@@ -1543,8 +1545,9 @@ class AsyncConnection(object):
 
             This can be combined with limit to implement pagination by setting this to
             the last table name from the previous page.
-        limit: int, default 10
-            The number of results to return.
+        limit: int, optional
+            The number of results to return. If not present, every table is
+            returned.
 
         Returns
         -------

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -504,7 +504,7 @@ class LanceNamespaceDBConnection(DBConnection):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:
@@ -1039,7 +1039,7 @@ class AsyncLanceNamespaceDBConnection:
     async def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -344,7 +344,7 @@ class RemoteDBConnection(DBConnection):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:
@@ -360,8 +360,9 @@ class RemoteDBConnection(DBConnection):
             Empty list represents root namespace.
         page_token: str
             The last token to start the new page.
-        limit: int, default 10
-            The maximum number of tables to return for each page.
+        limit: int, optional
+            The maximum number of tables to return for each page. If not
+            present, the server decides the page size.
 
         Returns
         -------

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -234,6 +234,18 @@ def test_table_names(tmp_db: lancedb.DBConnection):
     assert len(result) == 3
 
 
+def test_table_names_lists_every_table_by_default(tmp_db: lancedb.DBConnection):
+    for idx in range(15):
+        tmp_db.create_table(f"table_{idx:02d}", data=[{"id": idx}])
+    expected = [f"table_{idx:02d}" for idx in range(15)]
+
+    assert list(tmp_db.table_names()) == expected
+
+    # An explicit limit still pages, and paging still covers the whole database.
+    assert list(tmp_db.table_names(limit=10)) == expected[:10]
+    assert list(tmp_db.table_names("table_09")) == expected[10:]
+
+
 def test_db_contains_and_len_include_all_table_name_pages(tmp_db: lancedb.DBConnection):
     for idx in range(20):
         tmp_db.create_table(f"table_{idx}", data=[{"id": idx}])

--- a/python/python/tests/test_remote_db.py
+++ b/python/python/tests/test_remote_db.py
@@ -363,6 +363,24 @@ def test_remote_connection_serializes():
         assert restored.table_names() == []
 
 
+def test_table_names_sends_no_default_limit():
+    paths = []
+
+    def handler(request):
+        paths.append(request.path)
+        request.send_response(200)
+        request.send_header("Content-Type", "application/json")
+        request.end_headers()
+        request.wfile.write(b'{"tables": ["a", "b"]}')
+
+    with mock_lancedb_connection(handler) as db:
+        assert db.table_names() == ["a", "b"]
+
+    # No limit query parameter: the server decides the page size, as it does for
+    # list_tables().
+    assert paths == ["/v1/table/"]
+
+
 def test_remote_table_is_picklable():
     def handler(request):
         request.close_connection = True


### PR DESCRIPTION
`table_names()` on a synchronous Python connection defaults to `limit=10`, so a
database with more than ten tables answers with ten and nothing in the return
value says the answer was cut.

Repro on 928c3dde, local directory connection:

```python
db = lancedb.connect("/tmp/lancedb-repro-3914")
schema = pa.schema([pa.field("x", pa.int64())])
for i in range(15):
    db.create_table(f"t{i:02d}", schema=schema)
```

Before:

```
sync  table_names(): 10
sync  list_tables(): 15
len(db):             15
"t14" in db.table_names(): False
"t14" in db:               True
```

After:

```
sync  table_names(): 15
sync  list_tables(): 15
len(db):             15
"t14" in db.table_names(): True
"t14" in db:               True
```

The 10 lives only in the Python sync layer. Everywhere else an unset limit
already means every table:

| surface | default limit |
| --- | --- |
| `TableNamesRequest.limit`, `rust/lancedb/src/database.rs:55` | `Option<u32>`, unset |
| `TableNamesOptions.limit`, `nodejs/lancedb/connection.ts:141` | `limit?: number`, unset |
| `AsyncConnection.table_names`, `python/python/lancedb/db.py` | `Optional[int] = None` |
| `list_tables` on every Python connection | `Optional[int] = None` |
| `DBConnection.table_names` and its three overrides | `10` |

`TableNamesRequest.limit` is `Option<u32>` all the way through the PyO3 binding
in `python/src/connection.rs`, and `ListingDatabase::table_names` truncates only
when it is set, so passing `None` needs no change below the Python layer.

## Why unbounded rather than paginating or warning

A warning leaves the wrong answer in place. The caller still gets ten names, and
has to notice a second warning stacked on the `DeprecationWarning` this method
already emits.

Transparent pagination would mean looping on `page_token` inside `table_names()`,
which is what `_all_table_names()` already does for `len(db)` and `name in db`.
It guarantees completeness against Cloud too, but `table_names()` takes
`page_token` and `limit` as arguments, so an internal loop puts the method in
conflict with its own signature, and it turns one request into N with no way to
opt out.

Unbounded is what the Rust core, the Node binding, `AsyncConnection.table_names`
and `list_tables` already do, and it is what the docstring has claimed since the
method was written: "List all tables in this database, in sorted order". It is
the smallest change that makes the Python entry points agree with each other and
with the layer underneath.

## This changes a default

Callers that pass no `limit` now get every table instead of the first ten.

Hand-rolled paging still terminates: `table_names()` followed by
`table_names(page_token=last_name)` returns everything on the first call and
nothing on the second. Anyone using the cap as a cheap sample has to pass
`limit=10` explicitly now.

For remote connections the client stops sending `limit=10`, so the page size
comes from the server, the same as `list_tables()`. That is not a client-side
guarantee of completeness against Cloud, and the remote docstring now says so
instead of implying one.

I titled this `fix` rather than `fix!` because the documented contract did not
change, only the behaviour that failed to meet it. Say the word and I will
retitle.

## Scope

Python only, five definitions: the `DBConnection` abstract method, the embedded,
namespace and remote sync overrides, and the async namespace connection. Rust and
Node already default to no limit, so nothing here makes the bindings diverge; it
removes a divergence. `table_names` stays deprecated in favour of `list_tables`
in all five.

The async docstring in `db.py` also claimed `default 10` while the signature was
already `None`. Corrected in passing since it describes the same parameter.

## Tests

`test_table_names_lists_every_table_by_default` builds fifteen tables and checks
that the default lists all of them, that `limit=10` still pages, and that
`page_token` still resumes. `test_table_names_sends_no_default_limit` asserts the
remote client requests `/v1/table/` with no query string.

Both fail with only the source change reverted:

```
E       AssertionError: assert ['table_00', ...able_05', ...] == ['table_00', ...able_05', ...]
E         Right contains 5 more items, first extra item: 'table_10'
E       AssertionError: assert ['/v1/table/?limit=10'] == ['/v1/table/']
FAILED python/tests/test_db.py::test_table_names_lists_every_table_by_default
FAILED python/tests/test_remote_db.py::test_table_names_sends_no_default_limit
2 failed, 4 warnings in 1.19s
```

and pass with it restored:

```
2 passed, 8 warnings in 0.65s
```

Surrounding modules:

```
$ pytest python/tests/test_db.py python/tests/test_remote_db.py \
    python/tests/test_namespace.py -q -m "not slow and not s3_test"
145 passed, 2 skipped, 126 warnings in 36.80s
```

Whole Python suite, macOS arm64:

```
$ pytest python/tests -q -m "not slow and not s3_test"
966 passed, 25 skipped, 65 deselected, 225 warnings in 72.23s (0:01:12)
```

`ruff format --check` and `ruff check` are clean on the five files and `pyright`
reports 0 errors.

Fixes #3914.
