### PR TITLE
feat(python): refresh VoyageAI models and contextualized embedding path

### DIFF
--- a/docs/src/embeddings/available_embedding_models/text_embedding_functions/voyageai_embedding.md
+++ b/docs/src/embeddings/available_embedding_models/text_embedding_functions/voyageai_embedding.md
@@ -10,14 +10,30 @@ Supported models are:
 
 **Voyage-4 Series (Latest)**
 
+- voyage-4-large (1024 dims, best retrieval quality, 120K batch tokens)
 - voyage-4 (1024 dims, general-purpose and multilingual retrieval, 320K batch tokens)
 - voyage-4-lite (1024 dims, optimized for latency and cost, 1M batch tokens)
-- voyage-4-large (1024 dims, best retrieval quality, 120K batch tokens)
+- voyage-4-nano (1024 dims, open-weight)
+- voyage-code-4 (1024 dims, optimized for code retrieval)
+
+**Contextualized Chunk Embeddings**
+
+- voyage-context-4 (1024 dims)
+- voyage-context-3 (1024 dims)
+
+Contextualized models embed each input string as its own independent document
+(the batch is sent as a flat list of documents with server-side auto-chunking, so
+every input yields exactly one embedding). Inputs are not contextualized against
+one another.
 
 **Voyage-3 Series**
 
+- voyage-3-large
+- voyage-3.5
+- voyage-3.5-lite
 - voyage-3
 - voyage-3-lite
+- voyage-code-3
 
 **Domain-Specific Models**
 
@@ -31,7 +47,7 @@ Supported parameters (to be passed in `create` method) are:
 
 | Parameter | Type | Default Value | Description |
 |---|---|--------|---------|
-| `name` | `str` | `None` | The model ID of the model to use. Supported base models for Text Embeddings: voyage-4, voyage-4-lite, voyage-4-large, voyage-3, voyage-3-lite, voyage-finance-2, voyage-multilingual-2, voyage-law-2, voyage-code-2 |
+| `name` | `str` | `None` | The model ID of the model to use. Supported base models for Text Embeddings: voyage-4-large, voyage-4, voyage-4-lite, voyage-4-nano, voyage-code-4, voyage-context-4, voyage-context-3, voyage-3-large, voyage-3.5, voyage-3.5-lite, voyage-3, voyage-3-lite, voyage-code-3, voyage-finance-2, voyage-multilingual-2, voyage-law-2, voyage-code-2 |
 | `input_type` | `str` | `None` | Type of the input text. Default to None. Other options: query, document. |
 | `truncation` | `bool` | `True` | Whether to truncate the input texts to fit within the context length. |
 

--- a/python/python/lancedb/embeddings/voyageai.py
+++ b/python/python/lancedb/embeddings/voyageai.py
@@ -208,7 +208,10 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
         own independent document: the batch is sent as a flat list of documents
         with server-side auto-chunking, so every input resolves to exactly one
         embedding. Inputs are NOT contextualized against one another, since
-        generic embedding callers pass unrelated texts.
+        generic embedding callers pass unrelated texts. An input longer than the
+        per-chunk ceiling (``CONTEXT_CHUNK_SIZE`` = 32000 tokens) is split into
+        multiple chunks by the server; only the first chunk's embedding is kept,
+        so keep contextualized rows within that budget to embed them in full.
 
     output_dimension : int, optional
         The output dimension for models that support flexible dimensions.

--- a/python/python/lancedb/embeddings/voyageai.py
+++ b/python/python/lancedb/embeddings/voyageai.py
@@ -19,16 +19,24 @@ from .utils import api_key_not_found_help, IMAGES, TEXT
 if TYPE_CHECKING:
     import PIL
 
-# Token limits for different VoyageAI models
+# Total tokens allowed per request for different VoyageAI models. Used to build
+# batches that respect the per-request token budget. Values follow the limits
+# published in the Voyage embeddings API reference; unknown models fall back to
+# the conservative 120K default in `_build_batches`.
 VOYAGE_TOTAL_TOKEN_LIMITS = {
+    "voyage-4-large": 120_000,
     "voyage-4": 320_000,
     "voyage-4-lite": 1_000_000,
-    "voyage-4-large": 120_000,
-    "voyage-context-3": 32_000,
-    "voyage-3.5-lite": 1_000_000,
+    "voyage-4-nano": 120_000,
+    "voyage-code-4": 120_000,
+    "voyage-context-4": 120_000,
+    "voyage-context-3": 120_000,
+    "voyage-3-large": 120_000,
     "voyage-3.5": 320_000,
-    "voyage-3-lite": 120_000,
+    "voyage-3.5-lite": 1_000_000,
     "voyage-3": 120_000,
+    "voyage-3-lite": 120_000,
+    "voyage-code-3": 120_000,
     "voyage-multimodal-3": 120_000,
     "voyage-finance-2": 120_000,
     "voyage-multilingual-2": 120_000,
@@ -38,6 +46,12 @@ VOYAGE_TOTAL_TOKEN_LIMITS = {
 
 # Batch size for embedding requests (max number of items per batch)
 BATCH_SIZE = 1000
+
+# Per-input chunk size (in tokens) for contextualized embedding documents. Each
+# document-side input is sent as its own document with auto-chunking enabled, so
+# a chunk size at the model's per-chunk ceiling guarantees inputs up to this many
+# tokens resolve to exactly one chunk and therefore exactly one embedding.
+CONTEXT_CHUNK_SIZE = 32_000
 
 
 def is_valid_url(text):
@@ -170,20 +184,31 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
     name : str
         The name of the model to use. List of acceptable models:
 
+            * voyage-4-large (1024 dims, best retrieval quality)
             * voyage-4 (1024 dims, general-purpose and multilingual retrieval)
             * voyage-4-lite (1024 dims, optimized for latency and cost)
-            * voyage-4-large (1024 dims, best retrieval quality)
-            * voyage-context-3
+            * voyage-4-nano (1024 dims, open-weight)
+            * voyage-code-4 (1024 dims, optimized for code retrieval)
+            * voyage-context-4 (1024 dims, contextualized chunk embeddings)
+            * voyage-context-3 (1024 dims, contextualized chunk embeddings)
+            * voyage-3-large
             * voyage-3.5
             * voyage-3.5-lite
             * voyage-3
             * voyage-3-lite
-            * voyage-multimodal-3
+            * voyage-code-3
             * voyage-multimodal-3.5
+            * voyage-multimodal-3
             * voyage-finance-2
             * voyage-multilingual-2
             * voyage-law-2
             * voyage-code-2
+
+        Contextualized models (voyage-context-*) embed each input string as its
+        own independent document: the batch is sent as a flat list of documents
+        with server-side auto-chunking, so every input resolves to exactly one
+        embedding. Inputs are NOT contextualized against one another, since
+        generic embedding callers pass unrelated texts.
 
     output_dimension : int, optional
         The output dimension for models that support flexible dimensions.
@@ -221,20 +246,24 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
     _FLEXIBLE_DIM_MODELS: ClassVar[list] = ["voyage-multimodal-3.5"]
     _VALID_DIMENSIONS: ClassVar[list] = [256, 512, 1024, 2048]
     text_embedding_models: list = [
+        "voyage-4-large",
         "voyage-4",
         "voyage-4-lite",
-        "voyage-4-large",
+        "voyage-4-nano",
+        "voyage-code-4",
+        "voyage-3-large",
         "voyage-3.5",
         "voyage-3.5-lite",
         "voyage-3",
         "voyage-3-lite",
+        "voyage-code-3",
         "voyage-finance-2",
         "voyage-multilingual-2",
         "voyage-law-2",
         "voyage-code-2",
     ]
     multimodal_embedding_models: list = ["voyage-multimodal-3", "voyage-multimodal-3.5"]
-    contextual_embedding_models: list = ["voyage-context-3"]
+    contextual_embedding_models: list = ["voyage-context-4", "voyage-context-3"]
 
     def _is_multimodal_model(self, model_name: str):
         return (
@@ -261,13 +290,18 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
         elif self.name == "voyage-code-2":
             return 1536
         elif self.name in [
+            "voyage-4-large",
             "voyage-4",
             "voyage-4-lite",
-            "voyage-4-large",
+            "voyage-4-nano",
+            "voyage-code-4",
+            "voyage-context-4",
             "voyage-context-3",
+            "voyage-3-large",
             "voyage-3.5",
             "voyage-3.5-lite",
             "voyage-3",
+            "voyage-code-3",
             "voyage-multimodal-3",
             "voyage-finance-2",
             "voyage-multilingual-2",
@@ -442,10 +476,27 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction):
         elif self._is_contextual_model(self.name):
 
             def embed_batch(batch: List[str]) -> List[np.array]:
+                # Embed each input as its OWN independent document. The batch is
+                # sent as a flat list[str] (not inputs=[batch], which would treat
+                # the batch as one document's chunks and contextualize unrelated
+                # texts against each other). With auto-chunking and a chunk size
+                # at the model's per-chunk ceiling, every input resolves to
+                # exactly one chunk and one embedding.
+                #
+                # The API rejects auto-chunking for query inputs, so it is only
+                # enabled on the document side.
+                ctx_kwargs = dict(kwargs)
+                if input_type != "query":
+                    ctx_kwargs["enable_auto_chunking"] = True
+                    ctx_kwargs["chunk_size"] = CONTEXT_CHUNK_SIZE
                 result = client.contextualized_embed(
-                    inputs=[batch], model=self.name, input_type=input_type, **kwargs
+                    inputs=batch,
+                    model=self.name,
+                    input_type=input_type,
+                    **ctx_kwargs,
                 )
-                return result.results[0].embeddings
+                # One document per input -> take the single chunk embedding each.
+                return [res.embeddings[0] for res in result.results]
 
             return embed_batch
 

--- a/python/python/lancedb/rerankers/voyageai.py
+++ b/python/python/lancedb/rerankers/voyageai.py
@@ -19,7 +19,7 @@ class VoyageAIReranker(Reranker):
 
     Parameters
     ----------
-    model_name : str, default "rerank-english-v2.0"
+    model_name : str
         The name of the cross encoder model to use. Available voyageai models are:
         - rerank-2.5
         - rerank-2.5-lite
@@ -32,7 +32,7 @@ class VoyageAIReranker(Reranker):
     return_score : str, default "relevance"
         options are "relevance" or "all". Only "relevance" is supported for now.
     api_key : str, default None
-        The API key to use. If None, will use the OPENAI_API_KEY environment variable.
+        The API key to use. If None, will use the VOYAGE_API_KEY environment variable.
     truncation : Optional[bool], default None
     """
 

--- a/python/python/tests/test_embeddings_slow.py
+++ b/python/python/tests/test_embeddings_slow.py
@@ -521,9 +521,11 @@ def test_ollama_embedding(tmp_path):
     "model_name,expected_dims",
     [
         ("voyage-3", 1024),
+        ("voyage-3-large", 1024),
         ("voyage-4", 1024),
         ("voyage-4-lite", 1024),
         ("voyage-4-large", 1024),
+        ("voyage-code-4", 1024),
     ],
 )
 def test_voyageai_embedding_function(model_name, expected_dims, tmp_path):
@@ -540,9 +542,9 @@ def test_voyageai_embedding_function(model_name, expected_dims, tmp_path):
 
     tbl.add(df)
     assert len(tbl.to_pandas()["vector"][0]) == voyageai.ndims()
-    assert voyageai.ndims() == expected_dims, (
-        f"{model_name} should have {expected_dims} dimensions"
-    )
+    assert (
+        voyageai.ndims() == expected_dims
+    ), f"{model_name} should have {expected_dims} dimensions"
 
     # Test search functionality
     result = tbl.search("hello").limit(1).to_pandas()
@@ -553,21 +555,26 @@ def test_voyageai_embedding_function(model_name, expected_dims, tmp_path):
 @pytest.mark.skipif(
     os.environ.get("VOYAGE_API_KEY") is None, reason="VOYAGE_API_KEY not set"
 )
-def test_voyageai_embedding_function_contextual_model():
-    voyageai = (
-        get_registry().get("voyageai").create(name="voyage-context-3", max_retries=0)
-    )
+@pytest.mark.parametrize("model_name", ["voyage-context-4", "voyage-context-3"])
+def test_voyageai_embedding_function_contextual_model(model_name, tmp_path):
+    voyageai = get_registry().get("voyageai").create(name=model_name, max_retries=0)
 
     class TextModel(LanceModel):
         text: str = voyageai.SourceField()
         vector: Vector(voyageai.ndims()) = voyageai.VectorField()
 
     df = pd.DataFrame({"text": ["hello world", "goodbye world"]})
-    db = lancedb.connect("~/lancedb")
+    db = lancedb.connect(tmp_path)
     tbl = db.create_table("test", schema=TextModel, mode="overwrite")
 
+    # Document path: each row is embedded independently -> one vector per row.
     tbl.add(df)
+    assert len(tbl) == 2
     assert len(tbl.to_pandas()["vector"][0]) == voyageai.ndims()
+
+    # Query path: exercises the retrieval branch (no auto-chunking).
+    result = tbl.search("hello").limit(1).to_pandas()
+    assert result["text"][0] == "hello world"
 
 
 @pytest.mark.slow
@@ -816,9 +823,9 @@ def test_colpali(tmp_path):
     # Verify multivector dimensions
     first_row = table.to_arrow().to_pylist()[0]
     assert len(first_row["image_vectors"]) > 1, "Should have multiple image vectors"
-    assert len(first_row["image_vectors"][0]) == func.ndims(), (
-        "Vector dimension mismatch"
-    )
+    assert (
+        len(first_row["image_vectors"][0]) == func.ndims()
+    ), "Vector dimension mismatch"
 
 
 @pytest.mark.slow
@@ -874,9 +881,9 @@ def test_colpali_models(tmp_path, model_name):
 
     first_row = table.to_arrow().to_pylist()[0]
     assert len(first_row["image_vectors"]) > 1, "Should have multiple image vectors"
-    assert len(first_row["image_vectors"][0]) == func.ndims(), (
-        "Vector dimension mismatch"
-    )
+    assert (
+        len(first_row["image_vectors"][0]) == func.ndims()
+    ), "Vector dimension mismatch"
 
 
 @pytest.mark.slow

--- a/python/python/tests/test_embeddings_slow.py
+++ b/python/python/tests/test_embeddings_slow.py
@@ -542,9 +542,9 @@ def test_voyageai_embedding_function(model_name, expected_dims, tmp_path):
 
     tbl.add(df)
     assert len(tbl.to_pandas()["vector"][0]) == voyageai.ndims()
-    assert (
-        voyageai.ndims() == expected_dims
-    ), f"{model_name} should have {expected_dims} dimensions"
+    assert voyageai.ndims() == expected_dims, (
+        f"{model_name} should have {expected_dims} dimensions"
+    )
 
     # Test search functionality
     result = tbl.search("hello").limit(1).to_pandas()
@@ -823,9 +823,9 @@ def test_colpali(tmp_path):
     # Verify multivector dimensions
     first_row = table.to_arrow().to_pylist()[0]
     assert len(first_row["image_vectors"]) > 1, "Should have multiple image vectors"
-    assert (
-        len(first_row["image_vectors"][0]) == func.ndims()
-    ), "Vector dimension mismatch"
+    assert len(first_row["image_vectors"][0]) == func.ndims(), (
+        "Vector dimension mismatch"
+    )
 
 
 @pytest.mark.slow
@@ -881,9 +881,9 @@ def test_colpali_models(tmp_path, model_name):
 
     first_row = table.to_arrow().to_pylist()[0]
     assert len(first_row["image_vectors"]) > 1, "Should have multiple image vectors"
-    assert (
-        len(first_row["image_vectors"][0]) == func.ndims()
-    ), "Vector dimension mismatch"
+    assert len(first_row["image_vectors"][0]) == func.ndims(), (
+        "Vector dimension mismatch"
+    )
 
 
 @pytest.mark.slow

--- a/python/python/tests/test_voyageai_embeddings.py
+++ b/python/python/tests/test_voyageai_embeddings.py
@@ -72,9 +72,9 @@ class TestVoyageAIModelRegistration:
         """Test that each model returns the correct dimensions."""
         registry = get_registry()
         func = registry.get("voyageai").create(name=model_name)
-        assert (
-            func.ndims() == expected_dims
-        ), f"Model {model_name} should have {expected_dims} dimensions"
+        assert func.ndims() == expected_dims, (
+            f"Model {model_name} should have {expected_dims} dimensions"
+        )
 
     def test_unsupported_model_raises_error(self, mock_voyageai_client):
         """Test that unsupported models raise ValueError."""
@@ -111,9 +111,9 @@ class TestVoyageAIModelRegistration:
         """Test that voyage-4 models are classified as text models (not multimodal)."""
         registry = get_registry()
         func = registry.get("voyageai").create(name=model_name)
-        assert not func._is_multimodal_model(
-            model_name
-        ), f"{model_name} should be a text model, not multimodal"
+        assert not func._is_multimodal_model(model_name), (
+            f"{model_name} should be a text model, not multimodal"
+        )
 
     def test_voyage4_models_in_text_embedding_list(self, mock_voyageai_client):
         """Test that voyage-4 models are in the text_embedding_models list."""

--- a/python/python/tests/test_voyageai_embeddings.py
+++ b/python/python/tests/test_voyageai_embeddings.py
@@ -6,6 +6,7 @@
 These tests verify model registration and configuration without requiring API calls.
 """
 
+import pyarrow as pa
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -45,12 +46,19 @@ class TestVoyageAIModelRegistration:
         "model_name,expected_dims",
         [
             # Voyage-4 series (all 1024 dims)
+            ("voyage-4-large", 1024),
             ("voyage-4", 1024),
             ("voyage-4-lite", 1024),
-            ("voyage-4-large", 1024),
+            ("voyage-4-nano", 1024),
+            ("voyage-code-4", 1024),
+            # Contextualized models
+            ("voyage-context-4", 1024),
+            ("voyage-context-3", 1024),
             # Voyage-3 series
+            ("voyage-3-large", 1024),
             ("voyage-3", 1024),
             ("voyage-3-lite", 512),
+            ("voyage-code-3", 1024),
             # Domain-specific models
             ("voyage-finance-2", 1024),
             ("voyage-multilingual-2", 1024),
@@ -64,9 +72,9 @@ class TestVoyageAIModelRegistration:
         """Test that each model returns the correct dimensions."""
         registry = get_registry()
         func = registry.get("voyageai").create(name=model_name)
-        assert func.ndims() == expected_dims, (
-            f"Model {model_name} should have {expected_dims} dimensions"
-        )
+        assert (
+            func.ndims() == expected_dims
+        ), f"Model {model_name} should have {expected_dims} dimensions"
 
     def test_unsupported_model_raises_error(self, mock_voyageai_client):
         """Test that unsupported models raise ValueError."""
@@ -103,9 +111,9 @@ class TestVoyageAIModelRegistration:
         """Test that voyage-4 models are classified as text models (not multimodal)."""
         registry = get_registry()
         func = registry.get("voyageai").create(name=model_name)
-        assert not func._is_multimodal_model(model_name), (
-            f"{model_name} should be a text model, not multimodal"
-        )
+        assert not func._is_multimodal_model(
+            model_name
+        ), f"{model_name} should be a text model, not multimodal"
 
     def test_voyage4_models_in_text_embedding_list(self, mock_voyageai_client):
         """Test that voyage-4 models are in the text_embedding_models list."""
@@ -122,3 +130,126 @@ class TestVoyageAIModelRegistration:
         assert "voyage-4" not in func.multimodal_embedding_models
         assert "voyage-4-lite" not in func.multimodal_embedding_models
         assert "voyage-4-large" not in func.multimodal_embedding_models
+
+    @pytest.mark.parametrize("model_name", ["voyage-context-4", "voyage-context-3"])
+    def test_context_models_classified_as_contextual(
+        self, model_name, mock_voyageai_client
+    ):
+        """voyage-context-* models must route through the contextual API."""
+        registry = get_registry()
+        func = registry.get("voyageai").create(name=model_name)
+        assert model_name in func.contextual_embedding_models
+        assert func._is_contextual_model(model_name)
+        assert not func._is_multimodal_model(model_name)
+
+
+def _make_contextual_result(vectors):
+    """Build a mock contextualized_embed response: one document per vector,
+    each document carrying a single chunk embedding."""
+    result = MagicMock()
+    result.results = [MagicMock(embeddings=[vec]) for vec in vectors]
+    return result
+
+
+class TestVoyageAIContextualEmbeddings:
+    """Tests for the contextualized (voyage-context-*) embedding paths."""
+
+    @pytest.fixture
+    def mock_voyageai_client(self):
+        with patch.dict("os.environ", {"VOYAGE_API_KEY": "test-key"}):
+            with patch("lancedb.embeddings.voyageai.attempt_import_or_raise") as mock:
+                mock_client = MagicMock()
+                mock_voyageai = MagicMock()
+                mock_voyageai.Client.return_value = mock_client
+                mock.return_value = mock_voyageai
+                yield mock_client
+
+    def test_document_path_embeds_each_input_independently(self, mock_voyageai_client):
+        """Document-side inputs are sent as a flat list with auto-chunking, so
+        each string is embedded as its own document -> one embedding per input."""
+        mock_voyageai_client.tokenize.return_value = [["a"], ["b"]]
+        mock_voyageai_client.contextualized_embed.return_value = (
+            _make_contextual_result([[0.1] * 1024, [0.2] * 1024])
+        )
+
+        func = get_registry().get("voyageai").create(name="voyage-context-4")
+        embeddings = func.compute_source_embeddings(pa.array(["hello", "world"]))
+
+        assert embeddings == [[0.1] * 1024, [0.2] * 1024]
+        mock_voyageai_client.contextualized_embed.assert_called_once_with(
+            inputs=["hello", "world"],
+            model="voyage-context-4",
+            input_type="document",
+            enable_auto_chunking=True,
+            chunk_size=32000,
+        )
+
+    def test_query_path_disables_auto_chunking(self, mock_voyageai_client):
+        """The query path must NOT send enable_auto_chunking/chunk_size, since the
+        API rejects auto-chunking when input_type is 'query'."""
+        mock_voyageai_client.contextualized_embed.return_value = (
+            _make_contextual_result([[0.3] * 1024])
+        )
+
+        func = get_registry().get("voyageai").create(name="voyage-context-4")
+        embeddings = func.compute_query_embeddings("find me")
+
+        assert embeddings == [[0.3] * 1024]
+        call = mock_voyageai_client.contextualized_embed.call_args
+        assert call.kwargs["inputs"] == [["find me"]]
+        assert call.kwargs["input_type"] == "query"
+        assert "enable_auto_chunking" not in call.kwargs
+        assert "chunk_size" not in call.kwargs
+
+
+class TestVoyageAITokenBatching:
+    """Tests for token-aware batching of the plain text embedding path."""
+
+    @pytest.fixture
+    def mock_voyageai_client(self):
+        with patch.dict("os.environ", {"VOYAGE_API_KEY": "test-key"}):
+            with patch("lancedb.embeddings.voyageai.attempt_import_or_raise") as mock:
+                mock_client = MagicMock()
+                mock_voyageai = MagicMock()
+                mock_voyageai.Client.return_value = mock_client
+                mock.return_value = mock_voyageai
+                yield mock_client
+
+    def test_splits_at_token_boundary(self, mock_voyageai_client):
+        """Batches split once the per-request token limit would be exceeded."""
+        # voyage-3 has a 120K per-request token budget.
+        mock_voyageai_client.tokenize.return_value = [
+            ["x"] * 50_000,
+            ["x"] * 50_000,
+            ["x"] * 50_000,
+        ]
+        func = get_registry().get("voyageai").create(name="voyage-3")
+
+        batches = list(func._build_batches(mock_voyageai_client, ["t1", "t2", "t3"]))
+
+        # 50K + 50K fits (100K); adding the third (150K) exceeds 120K -> new batch.
+        assert batches == [["t1", "t2"], ["t3"]]
+
+    def test_single_oversized_text_goes_through_alone(self, mock_voyageai_client):
+        """A single text above the token limit is still emitted as its own batch."""
+        mock_voyageai_client.tokenize.return_value = [["x"] * 200_000]
+        func = get_registry().get("voyageai").create(name="voyage-3")
+
+        batches = list(func._build_batches(mock_voyageai_client, ["huge"]))
+
+        assert batches == [["huge"]]
+
+    def test_item_count_cap_respected(self, mock_voyageai_client):
+        """The fixed item-count cap (BATCH_SIZE) still bounds batches even when
+        the token budget is not reached."""
+        from lancedb.embeddings.voyageai import BATCH_SIZE
+
+        n = BATCH_SIZE + 1
+        mock_voyageai_client.tokenize.return_value = [["x"]] * n
+        func = get_registry().get("voyageai").create(name="voyage-3")
+
+        batches = list(func._build_batches(mock_voyageai_client, ["t"] * n))
+
+        assert len(batches) == 2
+        assert len(batches[0]) == BATCH_SIZE
+        assert len(batches[1]) == 1


### PR DESCRIPTION
## What

Refresh the VoyageAI embedding integration against the current Voyage model catalog and correct the contextualized embedding path.

### Models
- Add text models: `voyage-code-4`, `voyage-4-nano`, `voyage-3-large`, `voyage-code-3`.
- Add contextualized model `voyage-context-4` alongside `voyage-context-3`.
- Update `ndims`, the per-request token-limit table, docstrings, and docs to match.

### Contextualized embeddings (`voyage-context-*`)
Each input string is embedded as its **own independent document**. On the document side the batch is sent as a flat `list[str]` with `enable_auto_chunking=True` and `chunk_size=32000`, so every input resolves to exactly one chunk and one embedding — deterministic per-input vectors and trivial result collection.

Inputs are intentionally **not** contextualized against one another: generic `embed_many` callers pass unrelated texts, so cross-input contextualization would be wrong. Previously the batch was sent as a single document's chunks (`inputs=[batch]`), which mixed unrelated inputs; that is fixed here.

The query/retrieval path omits `enable_auto_chunking`/`chunk_size`, because the API rejects auto-chunking when `input_type` is `query`.

### Token-aware batching
The plain-text path builds batches by estimated token count against the per-model token limit (not only a fixed item count).

## Why
Keep the exposed models current, make contextualized embeddings correct and deterministic for generic callers, and respect per-request token budgets.

## Tests
- Unit tests (no network) for model dimensions, contextual classification, the contextualized **document** path (asserts flat `list[str]` + auto-chunking + `chunk_size=32000`, one embedding per input) and the **query** path (asserts auto-chunking is not sent).
- Unit tests for batching: split at the token boundary, a single oversized text still goes through alone, item-count cap respected.
- Slow integration tests extended to `voyage-context-4`, `voyage-code-4`, `voyage-3-large`, and to exercise the contextual query/search path.

All non-slow unit tests pass locally (`pytest python/tests/test_voyageai_embeddings.py`). Ruff check/format clean.
