### PR TITLE
ci(java): run Java 11 and 17 builds in parallel with matrix strategy

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -65,4 +65,4 @@ jobs:
           java-version: ${{ matrix.java-version }}
           cache: "maven"
       - name: Build and install
-        run: ./mvnw clean install
+        run: ./mvnw clean install -Dcheckstyle.skip=true

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -28,9 +28,9 @@ permissions:
   contents: read
 
 jobs:
-  build-java:
+  style-check:
     runs-on: ubuntu-24.04
-    name: Build
+    name: Style Check
     defaults:
       run:
         working-directory: ./java
@@ -45,5 +45,24 @@ jobs:
           cache: "maven"
       - name: Java Style Check
         run: ./mvnw checkstyle:check
+
+  build-java:
+    runs-on: ubuntu-24.04
+    name: Build (Java ${{ matrix.java-version }})
+    strategy:
+      matrix:
+        java-version: [11, 17]
+    defaults:
+      run:
+        working-directory: ./java
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Java ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: "maven"
       - name: Build and install
         run: ./mvnw clean install


### PR DESCRIPTION
## Summary
- Split the single Java 17 build into a **matrix strategy** that runs Java 11 and Java 17 in parallel
- Extract style check into its own job so it runs once (Java-version independent) rather than being duplicated across matrix entries
- Path filtering for `java/**` was already in place per maintainer feedback on the issue

## Before
- Single job: Java 17 only, style check + build sequential

## After
- `style-check` job: runs checkstyle once on Java 17
- `build-java` job: matrix of [11, 17] running in parallel

## Motivation
Closes #1331. Maintainer also noted the path filtering is already done, so this PR focuses on the parallelization.

## Test plan
- [ ] CI passes on both Java 11 and 17