### PR TITLE
docs: correct the documented default retry statuses

### DIFF
--- a/docs/src/js/interfaces/RetryConfig.md
+++ b/docs/src/js/interfaces/RetryConfig.md
@@ -84,7 +84,7 @@ optional statuses: number[];
 ```
 
 The HTTP status codes for which to retry the request. Default is
-[429, 500, 502, 503].
+[409, 429, 500, 502, 503, 504].
 
 You can also set this via the environment variable
 `LANCE_CLIENT_RETRY_STATUSES`. Use a comma-separated list of integers.

--- a/nodejs/src/remote.rs
+++ b/nodejs/src/remote.rs
@@ -63,7 +63,7 @@ pub struct RetryConfig {
     /// `LANCE_CLIENT_RETRY_BACKOFF_JITTER`.
     pub backoff_jitter: Option<f64>,
     /// The HTTP status codes for which to retry the request. Default is
-    /// [429, 500, 502, 503].
+    /// [409, 429, 500, 502, 503, 504].
     ///
     /// You can also set this via the environment variable
     /// `LANCE_CLIENT_RETRY_STATUSES`. Use a comma-separated list of integers.

--- a/python/python/lancedb/remote/__init__.py
+++ b/python/python/lancedb/remote/__init__.py
@@ -112,7 +112,7 @@ class RetryConfig:
         `LANCE_CLIENT_RETRY_BACKOFF_JITTER`.
     statuses: Optional[List[int]
         The HTTP status codes for which to retry the request. Default is
-        [429, 500, 502, 503].
+        [409, 429, 500, 502, 503, 504].
 
         You can also set this via the environment variable
         `LANCE_CLIENT_RETRY_STATUSES`. Use a comma-separated list of integers.


### PR DESCRIPTION
#2349 changed the default retryable status codes to `[409, 429, 500, 502, 503, 504]`, but only the Rust docstring was updated. The Python and TypeScript bindings — and the generated TypeScript API reference — still document the old `[429, 500, 502, 503]`.

The actual default is set in `ResolvedRetryConfig::try_from` in `rust/lancedb/src/remote/retry.rs`, and `rust/lancedb/src/remote/client.rs` already documents it correctly. This brings the other three in line.

Docs only — no behavior change.

Split out from #3963 per the "one problem at a time" guidance in `CONTRIBUTING.md`.
