### PR TITLE
feat: support remote tables in the data loader

### DIFF
--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -255,8 +255,8 @@ class Permutations:
 
     Attributes
     ----------
-    base_table: LanceTable
-        The base table that the permutations are based on.
+    base_table: Table
+        The base table that the permutations are based on.  May be a remote table.
     permutation_table: LanceTable
         The permutation table that defines the splits.
     split_names: list[str]
@@ -289,7 +289,7 @@ class Permutations:
     {'train': 0, 'test': 1}
     """
 
-    def __init__(self, base_table: LanceTable, permutation_table: LanceTable):
+    def __init__(self, base_table: Table, permutation_table: LanceTable):
         self.base_table = base_table
         self.permutation_table = permutation_table
 

--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -1041,6 +1041,10 @@ class Permutation:
         The returned value is passed through the permutation's current transform,
         so `with_format` and `with_transform` affect this method in the same way
         they affect iteration.
+
+        Offsets must be distinct.  A repeated offset resolves to one row rather than
+        two, which would silently misalign a batch, so it raises instead.  Sampling
+        with replacement is therefore not supported here.
         """
         self._ensure_open()
 

--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -1045,6 +1045,13 @@ class Permutation:
         Offsets must be distinct.  A repeated offset resolves to one row rather than
         two, which would silently misalign a batch, so it raises instead.  Sampling
         with replacement is therefore not supported here.
+
+        Rows come back in the order `offsets` names them only when this permutation
+        has a permutation table behind it.  An identity permutation
+        ([Permutation.identity][lancedb.permutation.Permutation.identity]) reads by
+        row offset, which carries no ordering guarantee, so its rows arrive in
+        whatever order the backing store produces — do not pair it with a shuffling
+        sampler.
         """
         self._ensure_open()
 

--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -41,21 +41,21 @@ class PermutationBuilder:
     The permutation is stored in memory and will be lost when the program exits.
     """
 
-    def __init__(self, table: LanceTable):
+    def __init__(self, table: Table):
         """
         Creates a new permutation builder for the given table.
 
         By default, the permutation builder will create a single split that contains all
         rows in the same order as the base table.
+
+        Both local tables and remote tables (LanceDB Cloud and Enterprise) are
+        supported.  Against a remote table the permutation is built by reading every
+        row id over HTTP, so expect the build to cost roughly 8 bytes per row of
+        transfer, and note that it reads the base table only: rows still sitting in a
+        MemWAL that have not been compacted are not part of the permutation, because
+        the LSM scanner does not expose the stable ``_rowid`` a permutation is
+        defined over.
         """
-        if not hasattr(table, "_inner"):
-            raise TypeError(
-                f"PermutationBuilder requires a local LanceTable, "
-                f"got {type(table).__name__}. "
-                "The permutation API is not supported on remote tables. "
-                "Remote tables connect to LanceDB Cloud or Enterprise and do not have "
-                "direct access to the underlying Lance dataset needed for permutations."
-            )
         self._async = async_permutation_builder(table)
 
     def split_random(
@@ -231,7 +231,14 @@ class PermutationBuilder:
         return LOOP.run(do_execute())
 
 
-def permutation_builder(table: LanceTable) -> PermutationBuilder:
+def permutation_builder(table: Table) -> PermutationBuilder:
+    """
+    Creates a new permutation builder for the given table.
+
+    Accepts both local tables and remote tables (LanceDB Cloud and Enterprise); see
+    [PermutationBuilder][lancedb.permutation.PermutationBuilder] for what building a
+    permutation over a remote table costs.
+    """
     return PermutationBuilder(table)
 
 

--- a/python/python/lancedb/streaming.py
+++ b/python/python/lancedb/streaming.py
@@ -75,7 +75,16 @@ class StreamingDataset(IterableDataset):
     Parameters
     ----------
     table:
-        LanceDB table to stream from.
+        LanceDB table to stream from.  Local tables and remote tables (LanceDB Cloud
+        and Enterprise) are both supported.
+
+        Against a remote table every fetch is one HTTP request taking
+        ``read_batch_size`` rows by row id, so ``prefetch_batches`` is what hides the
+        round trip: raise it if ``prefetch_queue_depth`` keeps touching zero.
+        Construction is more expensive too — the permutation is built by reading every
+        row id over HTTP, roughly 8 bytes per row, once per rank.  Rows that are still
+        in an uncompacted MemWAL are not included; see
+        [PermutationBuilder][lancedb.permutation.PermutationBuilder].
     num_splits:
         Number of fixed splits to partition the table into.  Must be divisible
         by ``world_size``.  When used with DataLoader workers it must also be

--- a/python/python/tests/test_elastic_dataloader.py
+++ b/python/python/tests/test_elastic_dataloader.py
@@ -37,6 +37,11 @@ from unittest.mock import patch
 import lancedb
 import pyarrow as pa
 import pytest
+from utils import (
+    MockPermutationServer,
+    assert_server_safe_row_id_requests,
+    mock_remote_table,
+)
 
 torch = pytest.importorskip("torch")
 streaming = pytest.importorskip("lancedb.streaming")
@@ -2118,3 +2123,29 @@ def test_doc_example_checkpoint(lance_table):
     assert sorted(consumed + remaining_original) == list(range(NUM_ROWS)), (
         "Consumed + remaining must cover every row exactly once"
     )
+
+
+# ---------------------------------------------------------------------------
+# Remote tables (LanceDB Cloud / Enterprise)
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_dataset_over_remote_table():
+    """StreamingDataset reads a remote table, with server-safe requests.
+
+    The permutation API used to reject RemoteTable outright, so this is the whole
+    feature end to end: build a permutation over a remote table, then fetch batches
+    from it by row id.
+    """
+    server = MockPermutationServer()
+
+    with mock_remote_table(server) as table:
+        ds = StreamingDataset(table, num_splits=2, shuffle_seed=SHUFFLE_SEED)
+        ids = [row["id"] for row in ds]
+
+    assert sorted(ids) == list(range(server.num_rows)), (
+        "Every row of the remote table must be yielded exactly once"
+    )
+    assert len(server.scans) == 1, "the permutation is built with one row-id scan"
+    assert server.takes, "rows must be fetched with row-id takes"
+    assert_server_safe_row_id_requests(server)

--- a/python/python/tests/test_permutation.py
+++ b/python/python/tests/test_permutation.py
@@ -8,6 +8,11 @@ import pytest
 from lancedb import DBConnection, Table, connect
 from lancedb.background_loop import LOOP
 from lancedb.permutation import Permutation, Permutations, permutation_builder
+from utils import (
+    MockPermutationServer,
+    assert_server_safe_row_id_requests,
+    mock_remote_table,
+)
 
 
 def test_split_random_ratios(mem_db):
@@ -1214,3 +1219,24 @@ def test_remove_rowid_after_select(some_permutation: Permutation):
     perm_without_rowid = perm_with_rowid.remove_columns(["_rowid"])
     assert "_rowid" not in perm_without_rowid.column_names
     assert perm_without_rowid.column_names == ["id"]
+
+
+def test_permutation_over_remote_table():
+    """The permutation API accepts a remote table (LanceDB Cloud / Enterprise).
+
+    It used to reject one outright, which meant a remote table could not be used for
+    training at all.  Rows are addressed by `_rowid` here exactly as `take_row_ids`
+    does, so this also pins the request shapes sent to the server.
+    """
+    server = MockPermutationServer()
+
+    with mock_remote_table(server) as table:
+        permutation_tbl = permutation_builder(table).split_sequential(fixed=2).execute()
+        assert permutation_tbl.count_rows() == server.num_rows
+
+        permutation = Permutation.from_tables(table, permutation_tbl, 0)
+        assert permutation.num_rows == server.num_rows // 2
+        # Offsets are resolved to row ids client-side, then taken in that order.
+        assert permutation.take_offsets([2, 0]) == [{"id": 2}, {"id": 0}]
+
+    assert_server_safe_row_id_requests(server)

--- a/python/python/tests/test_permutation.py
+++ b/python/python/tests/test_permutation.py
@@ -1236,7 +1236,20 @@ def test_permutation_over_remote_table():
 
         permutation = Permutation.from_tables(table, permutation_tbl, 0)
         assert permutation.num_rows == server.num_rows // 2
-        # Offsets are resolved to row ids client-side, then taken in that order.
-        assert permutation.take_offsets([2, 0]) == [{"id": 2}, {"id": 0}]
+
+        # Compare against the permutation's own order rather than assuming one: the
+        # builder sorts by split id, and that sort is not guaranteed to be stable.
+        rows = permutation_tbl.search(None).to_arrow().to_pydict()
+        split0 = [
+            row_id
+            for row_id, split in zip(rows["row_id"], rows["split_id"])
+            if not split
+        ]
+        # The mock table's `id` equals its `_rowid`. Offsets are resolved to row ids
+        # client-side, then taken back in the order asked for.
+        assert permutation.take_offsets([2, 0]) == [
+            {"id": split0[2]},
+            {"id": split0[0]},
+        ]
 
     assert_server_safe_row_id_requests(server)

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -187,9 +187,11 @@ def assert_server_safe_row_id_requests(server):
     the MemWAL LSM scanner rejects ``with_row_id`` because it exposes ``_rowaddr``
     rather than the stable ``_rowid`` a permutation is defined over.
     """
+    # `.get`, not `[...]`: a dropped field should read as the assertion message these
+    # are written for, not as a KeyError.
     for body in server.scans + server.takes:
-        assert body["with_row_id"] is True, body
-        assert body["use_lsm"] is False, body
+        assert body.get("with_row_id") is True, body
+        assert body.get("use_lsm") is False, body
     for body in server.takes:
         assert "_rowid" in body["filter"], body
 

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
+import contextlib
+import http.server
+import json
+import re
+import threading
+
+import lancedb
+import pyarrow as pa
 import pytest
+
+ARROW_FILE_CONTENT_TYPE = "application/vnd.apache.arrow.file"
 
 
 def exception_output(e_info: pytest.ExceptionInfo):
@@ -9,3 +19,168 @@ def exception_output(e_info: pytest.ExceptionInfo):
     # skip traceback part, since it's not worth checking in tests
     lines = traceback.format_exception_only(e_info.type, e_info.value)
     return "".join(lines).strip()
+
+
+def arrow_file_bytes(table: pa.Table) -> bytes:
+    """Serialize to the Arrow IPC *file* framing the /query/ route answers with."""
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_file(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue().to_pybytes()
+
+
+class MockPermutationServer:
+    """A stand-in LanceDB server hosting one table whose ``id`` equals its ``_rowid``.
+
+    Serves the three routes the permutation API and the streaming data loader touch
+    (``describe``, ``count_rows``, ``query``) and records every ``/query/`` body, so a
+    test can assert on the request shapes sent to the server — the part that has to
+    stay compatible rather than merely round-trip locally.
+    """
+
+    def __init__(self, name="remote_data", num_rows=8):
+        self.name = name
+        self.num_rows = num_rows
+        self.query_bodies = []
+
+    def __call__(self, request):
+        path = request.path
+        if path == f"/v1/table/{self.name}/describe/":
+            return self._json(
+                request,
+                {
+                    "version": 1,
+                    "schema": {
+                        "fields": [
+                            {"name": "id", "type": {"type": "int64"}, "nullable": False}
+                        ]
+                    },
+                },
+            )
+        if path == f"/v1/table/{self.name}/count_rows/":
+            self._read_body(request)
+            return self._json(request, self.num_rows)
+        if path == f"/v1/table/{self.name}/query/":
+            return self._query(request, self._read_body(request))
+
+        request.send_response(404)
+        request.end_headers()
+
+    @property
+    def scans(self):
+        """Bodies of the permutation build scan: row ids, no user columns."""
+        return [b for b in self.query_bodies if b.get("columns") == []]
+
+    @property
+    def takes(self):
+        """Bodies of the row-id takes the loader fetches batches with."""
+        return [b for b in self.query_bodies if b.get("filter") is not None]
+
+    @staticmethod
+    def _read_body(request):
+        content_len = int(request.headers.get("Content-Length") or 0)
+        return json.loads(request.rfile.read(content_len)) if content_len else {}
+
+    @staticmethod
+    def _json(request, payload):
+        request.send_response(200)
+        request.send_header("Content-Type", "application/json")
+        request.end_headers()
+        request.wfile.write(json.dumps(payload).encode())
+
+    @staticmethod
+    def _arrow(request, table):
+        body = arrow_file_bytes(table)
+        request.send_response(200)
+        request.send_header("Content-Type", ARROW_FILE_CONTENT_TYPE)
+        request.send_header("Content-Length", str(len(body)))
+        request.end_headers()
+        request.wfile.write(body)
+
+    def _query(self, request, body):
+        self.query_bodies.append(body)
+
+        if body.get("filter") is not None:
+            # A row-id take. Answer in ascending row-id order regardless of the order
+            # asked for, so tests prove the client restores the requested order.
+            row_ids = sorted(int(m) for m in re.findall(r"\d+", body["filter"]))
+            return self._arrow(
+                request,
+                pa.table(
+                    {
+                        "id": pa.array(row_ids, pa.int64()),
+                        "_rowid": pa.array(row_ids, pa.uint64()),
+                    }
+                ),
+            )
+
+        if body.get("columns") == []:
+            # The permutation build scan: row ids only, via the with_row_id flag.
+            return self._arrow(
+                request,
+                pa.table({"_rowid": pa.array(range(self.num_rows), pa.uint64())}),
+            )
+
+        # The bounded schema probe.
+        return self._arrow(request, pa.table({"id": pa.array([0], pa.int64())}))
+
+
+def _make_handler(serve):
+    class MockLanceDBHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            serve(self)
+
+        def do_POST(self):
+            serve(self)
+
+        def log_message(self, *args):
+            pass  # keep pytest output readable
+
+    return MockLanceDBHandler
+
+
+@contextlib.contextmanager
+def mock_remote_table(server):
+    """Run ``server`` on a local port and yield an open remote table against it."""
+    with http.server.HTTPServer(("localhost", 0), _make_handler(server)) as srv:
+        thread = threading.Thread(target=srv.serve_forever)
+        thread.start()
+        try:
+            db = lancedb.connect(
+                "db://dev",
+                api_key="fake",
+                host_override=f"http://localhost:{srv.server_address[1]}",
+                client_config={"timeout_config": {"connect_timeout": 5}},
+            )
+            yield db.open_table(server.name)
+        finally:
+            srv.shutdown()
+            thread.join()
+
+
+def assert_server_safe_row_id_requests(server):
+    """Assert the loader asked for row ids the only way the server accepts.
+
+    The row id must travel as the ``with_row_id`` flag, never as a projected
+    ``_rowid`` column, and every base-table read must pin itself to the base table:
+    the MemWAL LSM scanner rejects ``with_row_id`` because it exposes ``_rowaddr``
+    rather than the stable ``_rowid`` a permutation is defined over.
+    """
+    for body in server.scans + server.takes:
+        assert body["with_row_id"] is True, body
+        assert body["use_lsm"] is False, body
+    for body in server.takes:
+        assert "_rowid" in body["filter"], body
+
+    # A query with no row-id filter and no k asks the server for the whole table.
+    # Only the one-off permutation scan may do that — notably not the schema probe,
+    # which is built once per split per epoch. Takes carry their own bound in the
+    # `IN` list, so their k is irrelevant.
+    unbounded = [
+        b
+        for b in server.query_bodies
+        if b.get("filter") is None and b.get("k", 0) > server.num_rows
+    ]
+    assert unbounded == server.scans, (
+        f"only the permutation scan may be unbounded, got {unbounded}"
+    )

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -74,6 +74,9 @@ class MockPermutationServer:
         if path == f"/v1/table/{self.name}/query/":
             return self._query(request, self._read_body(request))
 
+        # Drain before answering, so an unexpected route cannot desync a
+        # keep-alive connection.
+        self._read_body(request)
         request.send_response(404)
         request.end_headers()
 

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -193,15 +193,20 @@ def assert_server_safe_row_id_requests(server):
     for body in server.takes:
         assert "_rowid" in body["filter"], body
 
-    # A query with no row-id filter and no k asks the server for the whole table.
+    # A filterless query with no effective bound asks the server for the whole table.
     # Only the one-off permutation scan may do that — notably not the schema probe,
     # which is built once per split per epoch. Takes carry their own bound in the
     # `IN` list, so their k is irrelevant.
-    unbounded = [
-        b
-        for b in server.query_bodies
-        if b.get("filter") is None and b.get("k", 0) > server.num_rows
-    ]
+    #
+    # `k == 0` counts as unbounded: lance reads a zero limit as "no limit" rather than
+    # "no rows", so a probe sending 0 is an open scan wearing a small number.
+    def is_unbounded(body):
+        if body.get("filter") is not None:
+            return False
+        k = body.get("k")
+        return k is None or k == 0 or k > server.num_rows
+
+    unbounded = [b for b in server.query_bodies if is_unbounded(b)]
     assert unbounded == server.scans, (
         f"only the permutation scan may be unbounded, got {unbounded}"
     )

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -21,6 +21,17 @@ def exception_output(e_info: pytest.ExceptionInfo):
     return "".join(lines).strip()
 
 
+def parse_in_list(filter_sql: str) -> list[int]:
+    """Pull the integers out of a `<col> IN (a, b, c)` predicate.
+
+    Scoped to the parenthesised list rather than scanning the whole predicate, so a
+    cast or a type name in the rendered SQL cannot contribute phantom values.
+    """
+    match = re.search(r"\bIN\s*\(([^)]*)\)", filter_sql, re.IGNORECASE)
+    assert match is not None, f"expected an IN list, got: {filter_sql}"
+    return [int(m) for m in re.findall(r"-?\d+", match.group(1))]
+
+
 def arrow_file_bytes(table: pa.Table) -> bytes:
     """Serialize to the Arrow IPC *file* framing the /query/ route answers with."""
     sink = pa.BufferOutputStream()
@@ -103,7 +114,7 @@ class MockPermutationServer:
         if body.get("filter") is not None:
             # A row-id take. Answer in ascending row-id order regardless of the order
             # asked for, so tests prove the client restores the requested order.
-            row_ids = sorted(int(m) for m in re.findall(r"\d+", body["filter"]))
+            row_ids = sorted(parse_in_list(body["filter"]))
             return self._arrow(
                 request,
                 pa.table(
@@ -141,8 +152,15 @@ def _make_handler(serve):
 
 @contextlib.contextmanager
 def mock_remote_table(server):
-    """Run ``server`` on a local port and yield an open remote table against it."""
-    with http.server.HTTPServer(("localhost", 0), _make_handler(server)) as srv:
+    """Run ``server`` on a local port and yield an open remote table against it.
+
+    Threading, because the loader fans out ``num_splits * prefetch_batches`` fetch
+    threads; a single-threaded server would serialize them in the accept backlog and
+    hide the prefetch overlap being exercised.
+    """
+    with http.server.ThreadingHTTPServer(
+        ("localhost", 0), _make_handler(server)
+    ) as srv:
         thread = threading.Thread(target=srv.serve_forever)
         thread.start()
         try:

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -32,6 +32,11 @@ def parse_in_list(filter_sql: str) -> list[int]:
     return [int(m) for m in re.findall(r"-?\d+", match.group(1))]
 
 
+def is_row_id_take(body) -> bool:
+    """True when a query body fetches specific rows by row id."""
+    return "_rowid" in (body.get("filter") or "")
+
+
 def arrow_file_bytes(table: pa.Table) -> bytes:
     """Serialize to the Arrow IPC *file* framing the /query/ route answers with."""
     sink = pa.BufferOutputStream()
@@ -87,8 +92,12 @@ class MockPermutationServer:
 
     @property
     def takes(self):
-        """Bodies of the row-id takes the loader fetches batches with."""
-        return [b for b in self.query_bodies if b.get("filter") is not None]
+        """Bodies of the row-id takes the loader fetches batches with.
+
+        Keyed on `_rowid` rather than "has a filter": the schema probe carries a
+        never-true predicate so it ships no rows, and it is not a take.
+        """
+        return [b for b in self.query_bodies if is_row_id_take(b)]
 
     @staticmethod
     def _read_body(request):
@@ -114,7 +123,7 @@ class MockPermutationServer:
     def _query(self, request, body):
         self.query_bodies.append(body)
 
-        if body.get("filter") is not None:
+        if is_row_id_take(body):
             # A row-id take. Answer in ascending row-id order regardless of the order
             # asked for, so tests prove the client restores the requested order.
             row_ids = sorted(parse_in_list(body["filter"]))
@@ -135,8 +144,9 @@ class MockPermutationServer:
                 pa.table({"_rowid": pa.array(range(self.num_rows), pa.uint64())}),
             )
 
-        # The bounded schema probe.
-        return self._arrow(request, pa.table({"id": pa.array([0], pa.int64())}))
+        # The schema probe: bounded and filtered to nothing, so it carries the schema
+        # and no rows.
+        return self._arrow(request, pa.table({"id": pa.array([], pa.int64())}))
 
 
 def _make_handler(serve):
@@ -203,7 +213,7 @@ def assert_server_safe_row_id_requests(server):
     # `k == 0` counts as unbounded: lance reads a zero limit as "no limit" rather than
     # "no rows", so a probe sending 0 is an open scan wearing a small number.
     def is_unbounded(body):
-        if body.get("filter") is not None:
+        if is_row_id_take(body):
             return False
         k = body.get("k")
         return k is None or k == 0 or k > server.num_rows

--- a/python/src/permutation.rs
+++ b/python/src/permutation.rs
@@ -268,7 +268,9 @@ impl PyPermutationReader {
                     .await
                     .infer_error()?
             } else {
-                PermutationReader::identity(base_table).await
+                PermutationReader::identity(base_table)
+                    .await
+                    .infer_error()?
             };
             Ok(Self::from_reader(reader))
         })

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -249,19 +249,28 @@ impl PermutationBuilder {
     fn validate_scan_schema(schema: &arrow_schema::Schema, splitter: &Splitter) -> Result<()> {
         let mut expected = splitter.projected_columns();
         expected.push(ROW_ID.to_string());
-        let actual = schema
+        let mut actual = schema
             .fields()
             .iter()
             .map(|f| f.name().clone())
             .collect::<Vec<_>>();
-        if actual != expected {
-            return Err(Error::Other {
+        // Compared as sets: `apply_hash` finds the row id by name precisely because
+        // where a backing store puts it is not ours to dictate, and a hash strategy
+        // may legitimately name the same column twice.  What matters is that nothing
+        // unrequested came back.
+        let (mut expected_set, mut actual_set) = (expected.clone(), actual.clone());
+        expected_set.sort_unstable();
+        expected_set.dedup();
+        actual_set.sort_unstable();
+        actual_set.dedup();
+        if actual_set != expected_set {
+            actual.sort_unstable();
+            return Err(Error::InvalidInput {
                 message: format!(
                     "Permutation row id scan returned columns {:?}, expected {:?}.  \
                      The table's backing store did not honor the requested projection.",
-                    actual, expected
+                    actual, expected_set
                 ),
-                source: None,
             });
         }
         Ok(())

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -247,17 +247,16 @@ impl PermutationBuilder {
     /// every base column — and `Hash` would silently hash all of them rather than the
     /// configured ones. Fail here instead.
     fn validate_scan_schema(schema: &arrow_schema::Schema, splitter: &Splitter) -> Result<()> {
-        /// Sorted and deduplicated, so the comparison and the error message agree.
+        /// Sorted but not deduplicated, so the comparison and the error message agree.
         fn normalize(mut names: Vec<String>) -> Vec<String> {
             names.sort_unstable();
-            names.dedup();
             names
         }
 
-        // Compared as sets: `apply_hash` finds the row id by name precisely because
-        // where a backing store puts it is not ours to dictate, and a hash strategy
-        // may legitimately name the same column twice.  What matters is that nothing
-        // unrequested came back.
+        // Sorted rather than positional, because `apply_hash` finds the row id by name
+        // precisely since where a backing store puts it is not ours to dictate.
+        // Multiplicity is still compared: `apply_hash` hashes every non-`_rowid` array,
+        // so an extra copy of a hash column would silently change split assignment.
         let mut expected = splitter.projected_columns();
         expected.push(ROW_ID.to_string());
         let expected = normalize(expected);
@@ -366,8 +365,29 @@ impl PermutationBuilder {
             CreateTableRequest::new(name.to_string(), Box::new(streaming_data));
 
         let table = database.create_table(create_table_request).await?;
+        let table = Table::new(table, database);
 
-        Ok(Table::new(table, database))
+        // The splits were sized from `count_rows`, but nothing so far has checked that
+        // the scan actually produced that many rows.  A short scan — a server-side
+        // result cap, a truncated stream, a concurrent delete between the count and the
+        // scan — otherwise just under-fills the trailing splits: `apply_sequential`
+        // assigns ids as data flows and `Shuffler` only objects to seeing *more* rows
+        // than expected, so training would quietly run on less data than was asked for.
+        if let Some(expected) = splitter.expected_row_count(num_rows) {
+            let actual = table.count_rows(None).await? as u64;
+            if actual != expected {
+                return Err(Error::InvalidInput {
+                    message: format!(
+                        "Permutation has {} rows, expected {}.  The row id scan returned \
+                         fewer rows than the table reported; the table may have changed \
+                         while the permutation was being built.",
+                        actual, expected
+                    ),
+                });
+            }
+        }
+
+        Ok(table)
     }
 }
 

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_execution::{disk_manager::DiskManagerBuilder, runtime_env::RuntimeEnvBuilder};
 use datafusion_expr::col;
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use lance_core::ROW_ID;
 use lance_datafusion::exec::SessionContextExt;
 
@@ -274,6 +274,42 @@ impl PermutationBuilder {
         Ok(())
     }
 
+    /// Fail if the row id scan yields a different number of rows than the count that
+    /// sized the splits.
+    ///
+    /// Only for strategies that read the scan to the end — see [`Splitter::drains_source`].
+    fn verify_scanned_row_count(
+        stream: SendableRecordBatchStream,
+        expected: u64,
+    ) -> SendableRecordBatchStream {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let schema = stream.schema();
+        let seen = Arc::new(AtomicU64::new(0));
+        let counted = {
+            let seen = seen.clone();
+            stream.map_ok(move |batch| {
+                seen.fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
+                batch
+            })
+        };
+        let tail = futures::stream::once(async move {
+            let scanned = seen.load(Ordering::Relaxed);
+            (scanned != expected).then(|| {
+                Err(Error::InvalidInput {
+                    message: format!(
+                        "Row id scan returned {} rows, expected {}.  The table may have \
+                         changed while the permutation was being built.",
+                        scanned, expected
+                    ),
+                })
+            })
+        })
+        .filter_map(std::future::ready);
+
+        Box::pin(SimpleRecordBatchStream::new(counted.chain(tail), schema))
+    }
+
     /// Builds the permutation table and stores it in the given database.
     pub async fn build(self) -> Result<Table> {
         // First pass, apply filter and load row ids.  The row id is requested with the
@@ -316,6 +352,14 @@ impl PermutationBuilder {
         // Apply splits
         let rows = rows.execute().await?;
         Self::validate_scan_schema(rows.schema().as_ref(), &splitter)?;
+        // A discarding hash drops rows by data, so its output size cannot be predicted
+        // and the check below cannot see a short scan.  Count the input instead, which
+        // is only safe for strategies that read their source to the end.
+        let rows = if splitter.expected_row_count(num_rows).is_none() && splitter.drains_source() {
+            Self::verify_scanned_row_count(rows, num_rows)
+        } else {
+            rows
+        };
         let split_data = splitter.apply(rows, num_rows).await?;
 
         // Shuffle data if requested
@@ -364,8 +408,8 @@ impl PermutationBuilder {
         let create_table_request =
             CreateTableRequest::new(name.to_string(), Box::new(streaming_data));
 
-        let table = database.create_table(create_table_request).await?;
-        let table = Table::new(table, database);
+        let created = database.create_table(create_table_request).await?;
+        let table = Table::new(created, database.clone());
 
         // The splits were sized from `count_rows`, but nothing so far has checked that
         // the scan actually produced that many rows.  A short scan — a server-side
@@ -376,6 +420,12 @@ impl PermutationBuilder {
         if let Some(expected) = splitter.expected_row_count(num_rows) {
             let actual = table.count_rows(None).await? as u64;
             if actual != expected {
+                // The destination is already committed at this point.  A persisted one
+                // would otherwise be left behind under-filled, and the obvious retry —
+                // rebuilding under the same name — would then fail as already existing.
+                if let PermutationDestination::Permanent(_, table_name) = &self.config.destination {
+                    database.drop_table(table_name, &[]).await?;
+                }
                 return Err(Error::InvalidInput {
                     message: format!(
                         "Permutation has {} rows, expected {}.  The row id scan returned \
@@ -578,6 +628,41 @@ mod tests {
         // constant input.
         assert!(pairs.iter().any(|(_, split_id)| *split_id == 0));
         assert!(pairs.iter().any(|(_, split_id)| *split_id == 1));
+    }
+
+    /// A hash split that discards nothing keeps every scanned row, so its size is as
+    /// predictable as a sequential one — and the short-scan guard has to see that, or a
+    /// truncated scan slips through unnoticed.
+    #[test]
+    fn test_expected_row_count_covers_every_strategy() {
+        let expected =
+            |strategy| Splitter::new(TemporaryDirectory::None, strategy).expected_row_count(5);
+
+        assert_eq!(expected(SplitStrategy::NoSplit), Some(5));
+        assert_eq!(
+            expected(SplitStrategy::Calculated {
+                calculation: "id % 2".to_string()
+            }),
+            Some(5)
+        );
+        assert_eq!(
+            expected(SplitStrategy::Hash {
+                columns: vec!["id".to_string()],
+                split_weights: vec![1, 1],
+                discard_weight: 0,
+            }),
+            Some(5)
+        );
+        // Only a discarding hash is genuinely data-dependent; that one is covered by
+        // counting the scan's input instead.
+        assert_eq!(
+            expected(SplitStrategy::Hash {
+                columns: vec!["id".to_string()],
+                split_weights: vec![1, 1],
+                discard_weight: 1,
+            }),
+            None
+        );
     }
 
     /// The other strategy with a projection of its own: `Calculated` computes the split

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -238,8 +238,18 @@ impl PermutationBuilder {
 
     /// Builds the permutation table and stores it in the given database.
     pub async fn build(self) -> Result<Table> {
-        // First pass, apply filter and load row ids
-        let mut rows = self.base_table.query().select(Select::columns(&[ROW_ID]));
+        // First pass, apply filter and load row ids.  The row id is requested with the
+        // `with_row_id` flag rather than by projecting `_rowid`: that is the shape the
+        // LanceDB server accepts for remote tables, and it appends the row id after any
+        // columns the splitter projects, which `Splitter` relies on.
+        let mut rows = self
+            .base_table
+            .query()
+            .select(Select::Columns(Vec::new()))
+            .with_row_id()
+            // A permutation addresses rows by stable `_rowid`, which the MemWAL LSM
+            // scanner does not expose, so the permutation always reads the base table.
+            .use_lsm(false);
 
         if let Some(filter) = &self.config.filter {
             rows = rows.only_if(filter);
@@ -319,12 +329,66 @@ impl PermutationBuilder {
 
 #[cfg(test)]
 mod tests {
-    use arrow::datatypes::Int32Type;
+    use arrow::array::AsArray;
+    use arrow::datatypes::{Int32Type, UInt64Type};
+    use futures::TryStreamExt;
     use lance_datagen::{BatchCount, RowCount};
+    use std::collections::HashSet;
 
-    use crate::{arrow::LanceDbDatagenExt, connect, dataloader::permutation::split::SplitSizes};
+    use crate::{
+        arrow::LanceDbDatagenExt,
+        connect,
+        dataloader::permutation::split::SplitSizes,
+        query::{ExecutableQuery, QueryBase, Select},
+    };
 
     use super::*;
+
+    /// Collect `(row_id, split_id)` pairs out of a permutation table.
+    async fn permutation_pairs(permutation_table: &Table) -> Vec<(u64, u64)> {
+        let batches = permutation_table
+            .query()
+            .select(Select::Columns(vec![
+                SRC_ROW_ID_COL.to_string(),
+                SPLIT_ID_COLUMN.to_string(),
+            ]))
+            .execute()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let mut pairs = Vec::new();
+        for batch in batches {
+            // `Calculated` splits carry whatever type the SQL produced, so normalize.
+            let to_u64 = |idx: usize| {
+                arrow::compute::cast(batch.column(idx), &arrow_schema::DataType::UInt64).unwrap()
+            };
+            let row_ids = to_u64(0);
+            let split_ids = to_u64(1);
+            let row_ids = row_ids.as_primitive::<UInt64Type>();
+            let split_ids = split_ids.as_primitive::<UInt64Type>();
+            for i in 0..batch.num_rows() {
+                pairs.push((row_ids.value(i), split_ids.value(i)));
+            }
+        }
+        pairs
+    }
+
+    /// A 100-row table whose `col_a` steps 0..100, for the split-strategy tests below.
+    async fn stepped_table(name: &str) -> (tempfile::TempDir, Table) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = connect(temp_dir.path().to_str().unwrap())
+            .execute()
+            .await
+            .unwrap();
+        let data = lance_datagen::gen_batch()
+            .col("col_a", lance_datagen::array::step::<Int32Type>())
+            .into_ldb_stream(RowCount::from(10), BatchCount::from(10));
+        let table = db.create_table(name, data).execute().await.unwrap();
+        (temp_dir, table)
+    }
 
     #[tokio::test]
     async fn test_permutation_table_only_stores_row_id_and_split_id() {
@@ -415,5 +479,68 @@ mod tests {
                 .unwrap(),
             283
         );
+    }
+
+    /// The row id reaches the splitter via `with_row_id` rather than a projected
+    /// `_rowid` column.  `Hash` is one of the two strategies that projects columns of
+    /// its own, and it hashes "every column except the last", so this pins that the row
+    /// id still arrives last and is not itself fed into the hash.
+    #[tokio::test]
+    async fn test_permutation_builder_hash_split() {
+        let (_temp_dir, data_table) = stepped_table("hash_tbl").await;
+
+        let permutation_table = PermutationBuilder::new(data_table.clone())
+            .with_split_strategy(
+                SplitStrategy::Hash {
+                    columns: vec!["col_a".to_string()],
+                    split_weights: vec![1, 1],
+                    discard_weight: 0,
+                },
+                None,
+            )
+            .build()
+            .await
+            .unwrap();
+
+        let pairs = permutation_pairs(&permutation_table).await;
+        assert_eq!(pairs.len(), 100);
+
+        // Every base row appears exactly once. If the row id had been hashed along with
+        // `col_a`, or read from the wrong column, this is what would break.
+        let row_ids: HashSet<u64> = pairs.iter().map(|(row_id, _)| *row_id).collect();
+        assert_eq!(row_ids, (0..100).collect::<HashSet<u64>>());
+        assert!(pairs.iter().all(|(_, split_id)| *split_id < 2));
+        // Both splits should get rows; a constant split id would mean the hash saw a
+        // constant input.
+        assert!(pairs.iter().any(|(_, split_id)| *split_id == 0));
+        assert!(pairs.iter().any(|(_, split_id)| *split_id == 1));
+    }
+
+    /// The other strategy with a projection of its own: `Calculated` computes the split
+    /// id in SQL, and the row id rides alongside it via `with_row_id`.
+    #[tokio::test]
+    async fn test_permutation_builder_calculated_split() {
+        let (_temp_dir, data_table) = stepped_table("calculated_tbl").await;
+
+        let permutation_table = PermutationBuilder::new(data_table.clone())
+            .with_split_strategy(
+                SplitStrategy::Calculated {
+                    calculation: "col_a % 2".to_string(),
+                },
+                None,
+            )
+            .build()
+            .await
+            .unwrap();
+
+        let mut pairs = permutation_pairs(&permutation_table).await;
+        pairs.sort_unstable();
+        assert_eq!(pairs.len(), 100);
+
+        // `col_a` steps 0..100 and row ids follow storage order, so the split id of row
+        // `n` must be `n % 2` — an exact check that the row id was paired with the split
+        // id computed from *its own* row.
+        let expected: Vec<(u64, u64)> = (0..100).map(|row_id| (row_id, row_id % 2)).collect();
+        assert_eq!(pairs, expected);
     }
 }

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -247,29 +247,28 @@ impl PermutationBuilder {
     /// every base column — and `Hash` would silently hash all of them rather than the
     /// configured ones. Fail here instead.
     fn validate_scan_schema(schema: &arrow_schema::Schema, splitter: &Splitter) -> Result<()> {
-        let mut expected = splitter.projected_columns();
-        expected.push(ROW_ID.to_string());
-        let mut actual = schema
-            .fields()
-            .iter()
-            .map(|f| f.name().clone())
-            .collect::<Vec<_>>();
+        /// Sorted and deduplicated, so the comparison and the error message agree.
+        fn normalize(mut names: Vec<String>) -> Vec<String> {
+            names.sort_unstable();
+            names.dedup();
+            names
+        }
+
         // Compared as sets: `apply_hash` finds the row id by name precisely because
         // where a backing store puts it is not ours to dictate, and a hash strategy
         // may legitimately name the same column twice.  What matters is that nothing
         // unrequested came back.
-        let (mut expected_set, mut actual_set) = (expected.clone(), actual.clone());
-        expected_set.sort_unstable();
-        expected_set.dedup();
-        actual_set.sort_unstable();
-        actual_set.dedup();
-        if actual_set != expected_set {
-            actual.sort_unstable();
+        let mut expected = splitter.projected_columns();
+        expected.push(ROW_ID.to_string());
+        let expected = normalize(expected);
+        let actual = normalize(schema.fields().iter().map(|f| f.name().clone()).collect());
+
+        if actual != expected {
             return Err(Error::InvalidInput {
                 message: format!(
                     "Permutation row id scan returned columns {:?}, expected {:?}.  \
                      The table's backing store did not honor the requested projection.",
-                    actual, expected_set
+                    actual, expected
                 ),
             });
         }

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -21,6 +21,7 @@ use crate::{
         util::{TemporaryDirectory, rename_column},
     },
     query::{ExecutableQuery, QueryBase, Select},
+    table::Filter,
 };
 
 pub const SRC_ROW_ID_COL: &str = "row_id";
@@ -236,6 +237,36 @@ impl PermutationBuilder {
         }))
     }
 
+    /// Check that the row-id scan came back with exactly the columns we asked for.
+    ///
+    /// The scan requests the row id with `with_row_id` and an *empty* projection,
+    /// which is a different wire value from "no projection given". A server that read
+    /// the empty list as "all columns" would answer with the whole table, and nothing
+    /// downstream would notice: the split id is appended to whatever arrives and
+    /// `_rowid` is still found by name, so the permutation would silently materialize
+    /// every base column — and `Hash` would silently hash all of them rather than the
+    /// configured ones. Fail here instead.
+    fn validate_scan_schema(schema: &arrow_schema::Schema, splitter: &Splitter) -> Result<()> {
+        let mut expected = splitter.projected_columns();
+        expected.push(ROW_ID.to_string());
+        let actual = schema
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect::<Vec<_>>();
+        if actual != expected {
+            return Err(Error::Other {
+                message: format!(
+                    "Permutation row id scan returned columns {:?}, expected {:?}.  \
+                     The table's backing store did not honor the requested projection.",
+                    actual, expected
+                ),
+                source: None,
+            });
+        }
+        Ok(())
+    }
+
     /// Builds the permutation table and stores it in the given database.
     pub async fn build(self) -> Result<Table> {
         // First pass, apply filter and load row ids.  The row id is requested with the
@@ -266,13 +297,18 @@ impl PermutationBuilder {
         // split id)
         rows = splitter.project(rows);
 
+        // Base-only, to agree with the base-only scan above.  On a remote MemWAL
+        // table a plain `count_rows` is rejected outright rather than merely
+        // disagreeing.
         let num_rows = self
             .base_table
-            .count_rows(self.config.filter.clone())
+            .base_table()
+            .count_base_rows(self.config.filter.clone().map(Filter::Sql))
             .await? as u64;
 
         // Apply splits
         let rows = rows.execute().await?;
+        Self::validate_scan_schema(rows.schema().as_ref(), &splitter)?;
         let split_data = splitter.apply(rows, num_rows).await?;
 
         // Shuffle data if requested

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -95,8 +95,13 @@ impl PermutationReader {
         Self::inner_new(base_table, Some(permutation_table), split).await
     }
 
-    pub async fn identity(base_table: Arc<dyn BaseTable>) -> Self {
-        Self::inner_new(base_table, None, 0).await.unwrap()
+    /// A reader over the base table in storage order, with no permutation.
+    ///
+    /// Fallible: construction counts the base table, which for a remote table is an
+    /// HTTP round trip, so a transient network or auth failure must surface as an
+    /// error rather than a panic across a binding boundary.
+    pub async fn identity(base_table: Arc<dyn BaseTable>) -> Result<Self> {
+        Self::inner_new(base_table, None, 0).await
     }
 
     /// Validates the limit and offset and returns the number of rows that will be read
@@ -459,7 +464,14 @@ impl PermutationReader {
         Ok(offset_map)
     }
 
-    /// Read the rows at `offsets`, in that order.
+    /// Read the rows at `offsets`.
+    ///
+    /// With a permutation table the rows come back in the order `offsets` names them.
+    /// An identity reader does **not** reorder: it filters on `_rowoffset`, and
+    /// [`crate::Table::take_offsets`] makes no ordering guarantee, so rows arrive in
+    /// whatever order the backing store produces. Reordering that branch needs the
+    /// offsets echoed back in the result, which is a change of its own; until then, do
+    /// not rely on identity takes for a shuffled sampler.
     ///
     /// Offsets must be distinct: a repeated offset resolves to a single row, which
     /// would misalign the returned batch against what the caller asked for, so it is
@@ -820,7 +832,9 @@ mod tests {
             .into_mem_table("tbl", RowCount::from(10), BatchCount::from(1))
             .await;
 
-        let reader = PermutationReader::identity(base_table.base_table().clone()).await;
+        let reader = PermutationReader::identity(base_table.base_table().clone())
+            .await
+            .unwrap();
 
         // With no permutation table, take_offsets uses the base table directly
         let offsets = vec![0, 2, 4, 6];
@@ -1002,7 +1016,9 @@ mod tests {
             .into_mem_table("tbl", RowCount::from(10), BatchCount::from(1))
             .await;
 
-        let reader = PermutationReader::identity(base_table.base_table().clone()).await;
+        let reader = PermutationReader::identity(base_table.base_table().clone())
+            .await
+            .unwrap();
 
         let batch = reader.take_offsets(&[], Select::All).await.unwrap();
 

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -151,7 +151,8 @@ impl PermutationReader {
                 ))))
                 .await? as u64
         } else {
-            self.base_table.count_rows(None).await? as u64
+            // Base-only, to agree with the base-only identity scan in `read`.
+            self.base_table.count_base_rows(None).await? as u64
         };
         Self::validate_limit_offset(limit, offset, available_rows)
     }
@@ -189,6 +190,20 @@ impl PermutationReader {
         let has_row_id = Self::has_row_id(&selection)?;
 
         let num_rows = row_ids.num_rows();
+        // One column, positionally — the callers name it differently (`row_id` from a
+        // permutation table, `_rowid` from an identity scan).  Checked rather than
+        // assumed: an identity scan asks for an empty projection plus `with_row_id`,
+        // and a store that answered that with every column would otherwise have its
+        // first data column silently read as row ids.
+        if row_ids.num_columns() != 1 {
+            return Err(Error::InvalidInput {
+                message: format!(
+                    "Expected a single row id column, got {}.  The table's backing \
+                     store did not honor the requested projection.",
+                    row_ids.num_columns()
+                ),
+            });
+        }
         let row_ids = row_ids
             .column(0)
             .as_primitive_opt::<UInt64Type>()
@@ -354,7 +369,8 @@ impl PermutationReader {
         let avail_rows = if let Some(permutation_table) = &self.permutation_table {
             permutation_table.count_rows(None).await? as u64
         } else {
-            self.base_table.count_rows(None).await? as u64
+            // Base-only, to agree with the base-only identity scan in `read`.
+            self.base_table.count_base_rows(None).await? as u64
         };
         Self::validate_limit_offset(self.limit, self.offset, avail_rows)?;
         Ok(())
@@ -478,10 +494,9 @@ impl PermutationReader {
                 let batch = arrow::compute::concat_batches(&schema, &batches)?;
                 Ok(batch)
             } else {
-                Ok(RecordBatch::try_new(
-                    self.output_schema(selection).await?,
-                    vec![],
-                )?)
+                // `try_new` with no columns errors on any non-empty schema; this is
+                // the same empty batch the `offsets.is_empty()` branch above builds.
+                Ok(RecordBatch::new_empty(self.output_schema(selection).await?))
             }
         }
     }

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -29,6 +29,18 @@ use lance_core::error::LanceOptionExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// One column of a caller's requested output.
+///
+/// The row id cannot be asked for in a projection, so a selection that mentions it is
+/// fetched without it and reassembled against this plan.
+#[derive(Debug, Clone)]
+enum OutputSlot {
+    /// Take this column from the fetched batch, by name.
+    Fetched(String),
+    /// Fill from the row id, under this output name.
+    RowId(String),
+}
+
 /// Reads a permutation of a source table based on row IDs stored in a separate table
 #[derive(Clone)]
 pub struct PermutationReader {
@@ -193,7 +205,7 @@ impl PermutationReader {
         selection: Select,
     ) -> Result<RecordBatch> {
         // The row id never travels in the projection; see `split_row_id_selection`.
-        let (transport_selection, row_id_aliases) = Self::split_row_id_selection(selection)?;
+        let (transport_selection, row_id_slots) = Self::split_row_id_selection(selection)?;
 
         let num_rows = row_ids.num_rows();
         // One column, positionally — the callers name it differently (`row_id` from a
@@ -286,7 +298,7 @@ impl PermutationReader {
             arrow_select::take::take_record_batch(&batch, &desired_idx_order)?
         };
 
-        Self::restore_row_ids(ordered_batch, &row_id_aliases)
+        Self::restore_row_ids(ordered_batch, row_id_slots.as_deref())
     }
 
     async fn row_ids_to_batches(
@@ -324,86 +336,137 @@ impl PermutationReader {
     ///
     /// The row id is a system column: the LanceDB server accepts it only through the
     /// `with_row_id` flag and rejects it outright in a projection. So it never goes on
-    /// the wire. This returns the projection to send plus the output names the caller
-    /// wanted the row id under, which [`Self::restore_row_ids`] puts back once the
-    /// batch is in hand — the fetch always sets `with_row_id`, so the values are there.
-    fn split_row_id_selection(selection: Select) -> Result<(Select, Vec<String>)> {
-        // An empty projection travels as `Select::Columns([])`, the one empty shape
-        // both the native scanner and the server agree on.
-        fn narrowed(columns: Vec<(String, String)>) -> Select {
+    /// the wire. This returns the projection to send plus, when the caller did ask for
+    /// the row id, the full output shape to rebuild afterwards — in the requested order
+    /// and multiplicity, which appending to the fetched batch would not preserve.
+    fn split_row_id_selection(selection: Select) -> Result<(Select, Option<Vec<OutputSlot>>)> {
+        // An empty projection travels as `Select::Columns([])`, the one empty shape both
+        // the native scanner and the server agree on.
+        fn narrowed<T>(
+            columns: Vec<(String, T)>,
+            rebuild: impl Fn(Vec<(String, T)>) -> Select,
+        ) -> Select {
             if columns.is_empty() {
                 Select::Columns(Vec::new())
             } else {
-                Select::Dynamic(columns)
+                rebuild(columns)
             }
         }
 
         match selection {
             // `_rowid` is a system column and is not included in Select::All
-            Select::All => Ok((Select::All, Vec::new())),
+            Select::All => Ok((Select::All, None)),
             Select::Columns(columns) => {
-                let (row_ids, rest): (Vec<_>, Vec<_>) =
-                    columns.into_iter().partition(|column| column == ROW_ID);
-                Ok((Select::Columns(rest), row_ids))
+                if !columns.iter().any(|column| column == ROW_ID) {
+                    return Ok((Select::Columns(columns), None));
+                }
+                let slots = columns
+                    .iter()
+                    .map(|column| {
+                        if column == ROW_ID {
+                            OutputSlot::RowId(column.clone())
+                        } else {
+                            OutputSlot::Fetched(column.clone())
+                        }
+                    })
+                    .collect();
+                let rest = columns
+                    .into_iter()
+                    .filter(|column| column != ROW_ID)
+                    .collect();
+                Ok((Select::Columns(rest), Some(slots)))
             }
             Select::Dynamic(columns) => {
-                let mut aliases = Vec::new();
-                let mut rest = Vec::new();
-                for (alias, expr) in columns {
-                    if expr == ROW_ID {
-                        aliases.push(alias);
-                    } else if alias == ROW_ID {
+                for (alias, expr) in &columns {
+                    if alias == ROW_ID && expr != ROW_ID {
                         return Err(Error::InvalidInput {
                             message: format!(
                                 "Dynamic column {} cannot be used to select _rowid",
                                 expr
                             ),
                         });
-                    } else {
-                        rest.push((alias, expr));
                     }
                 }
-                Ok((narrowed(rest), aliases))
+                if !columns.iter().any(|(_, expr)| expr == ROW_ID) {
+                    return Ok((Select::Dynamic(columns), None));
+                }
+                let slots = columns
+                    .iter()
+                    .map(|(alias, expr)| {
+                        if expr == ROW_ID {
+                            OutputSlot::RowId(alias.clone())
+                        } else {
+                            OutputSlot::Fetched(alias.clone())
+                        }
+                    })
+                    .collect();
+                let rest = columns
+                    .into_iter()
+                    .filter(|(_, expr)| expr != ROW_ID)
+                    .collect();
+                Ok((narrowed(rest, Select::Dynamic), Some(slots)))
             }
             Select::Expr(columns) => {
-                let mut aliases = Vec::new();
-                let mut rest = Vec::new();
-                for (alias, expr) in columns {
-                    match &expr {
-                        datafusion_expr::Expr::Column(column) if column.name == ROW_ID => {
-                            aliases.push(alias)
+                let is_row_id = |expr: &datafusion_expr::Expr| matches!(expr, datafusion_expr::Expr::Column(column) if column.name == ROW_ID);
+                if !columns.iter().any(|(_, expr)| is_row_id(expr)) {
+                    return Ok((Select::Expr(columns), None));
+                }
+                let slots = columns
+                    .iter()
+                    .map(|(alias, expr)| {
+                        if is_row_id(expr) {
+                            OutputSlot::RowId(alias.clone())
+                        } else {
+                            OutputSlot::Fetched(alias.clone())
                         }
-                        _ => rest.push((alias, expr)),
-                    }
-                }
-                if rest.is_empty() {
-                    Ok((Select::Columns(Vec::new()), aliases))
-                } else {
-                    Ok((Select::Expr(rest), aliases))
-                }
+                    })
+                    .collect();
+                let rest = columns
+                    .into_iter()
+                    .filter(|(_, expr)| !is_row_id(expr))
+                    .collect();
+                Ok((narrowed(rest, Select::Expr), Some(slots)))
             }
         }
     }
 
-    /// Put the row id back under the names the caller asked for, and drop it otherwise.
-    fn restore_row_ids(batch: RecordBatch, aliases: &[String]) -> Result<RecordBatch> {
-        if aliases.is_empty() {
-            // Requested only so the order could be restored; the caller never asked
-            // to see it.
-            return Ok(batch.drop_column(ROW_ID)?);
-        }
+    /// Rebuild the caller's requested output from a fetched batch plus its row ids.
+    ///
+    /// `slots` is `None` when the caller never asked for the row id, in which case it
+    /// was fetched only so the requested order could be restored and is dropped here.
+    fn restore_row_ids(batch: RecordBatch, slots: Option<&[OutputSlot]>) -> Result<RecordBatch> {
+        let Some(slots) = slots else {
+            return match batch.column_by_name(ROW_ID) {
+                Some(_) => Ok(batch.drop_column(ROW_ID)?),
+                None => Ok(batch),
+            };
+        };
+
         let row_ids = batch.column_by_name(ROW_ID).expect_ok()?.clone();
-        let mut out = batch;
-        for alias in aliases.iter().filter(|alias| *alias != ROW_ID) {
-            out = out.try_with_column(
-                arrow_schema::Field::new(alias, row_ids.data_type().clone(), true),
-                row_ids.clone(),
-            )?;
+        let schema = batch.schema();
+        let mut fields = Vec::with_capacity(slots.len());
+        let mut columns = Vec::with_capacity(slots.len());
+        for slot in slots {
+            match slot {
+                OutputSlot::Fetched(name) => {
+                    let index = schema.index_of(name)?;
+                    fields.push(schema.field(index).clone());
+                    columns.push(batch.column(index).clone());
+                }
+                OutputSlot::RowId(name) => {
+                    fields.push(arrow_schema::Field::new(
+                        name,
+                        row_ids.data_type().clone(),
+                        true,
+                    ));
+                    columns.push(row_ids.clone());
+                }
+            }
         }
-        if !aliases.iter().any(|alias| alias == ROW_ID) {
-            out = out.drop_column(ROW_ID)?;
-        }
-        Ok(out)
+        Ok(RecordBatch::try_new(
+            Arc::new(arrow_schema::Schema::new(fields)),
+            columns,
+        )?)
     }
 
     async fn validate(&self) -> Result<()> {
@@ -561,15 +624,18 @@ impl PermutationReader {
                 }
             }
             let skip = self.offset.unwrap_or(0);
+            // The row id cannot be named in a projection here either; ask by flag and
+            // rebuild the caller's shape below.
+            let (transport_selection, row_id_slots) = Self::split_row_id_selection(selection)?;
             let table = Table::from(self.base_table.clone());
-            let batches = table
+            let mut take = table
                 .take_offsets(offsets.iter().map(|o| o + skip).collect())
-                .select(selection)
-                .use_lsm(false)
-                .execute()
-                .await?
-                .try_collect::<Vec<_>>()
-                .await?;
+                .select(transport_selection)
+                .use_lsm(false);
+            if row_id_slots.is_some() {
+                take = take.with_row_id();
+            }
+            let batches = take.execute().await?.try_collect::<Vec<_>>().await?;
             let taken = batches.iter().map(|b| b.num_rows()).sum::<usize>();
             if taken != offsets.len() {
                 // Same contract `load_batch` enforces for the permutation branch: a
@@ -584,7 +650,8 @@ impl PermutationReader {
                 });
             }
             let schema = batches[0].schema();
-            Ok(arrow::compute::concat_batches(&schema, &batches)?)
+            let batch = arrow::compute::concat_batches(&schema, &batches)?;
+            Self::restore_row_ids(batch, row_id_slots.as_deref())
         }
     }
 
@@ -603,9 +670,9 @@ impl PermutationReader {
         // the schema, is unchanged, but no row is matched and none is shipped.  That
         // matters for wide or blob-bearing tables, where one row per split per epoch
         // is not free.
-        // Same split as the fetch: naming `_rowid` in the projection is rejected by
-        // the server, so it is asked for by flag and its fields appended here.
-        let (transport_selection, row_id_aliases) = Self::split_row_id_selection(selection)?;
+        // Same split as the fetch: naming `_rowid` in a projection is rejected by the
+        // server, so the schema is assembled against the caller's requested shape.
+        let (transport_selection, row_id_slots) = Self::split_row_id_selection(selection)?;
         let schema = table
             .query()
             .select(transport_selection)
@@ -614,17 +681,23 @@ impl PermutationReader {
             .use_lsm(false)
             .output_schema()
             .await?;
-        if row_id_aliases.is_empty() {
+        let Some(slots) = row_id_slots else {
             return Ok(schema);
-        }
-        let mut fields = schema.fields().to_vec();
-        for alias in &row_id_aliases {
-            fields.push(Arc::new(arrow_schema::Field::new(
-                alias,
-                arrow_schema::DataType::UInt64,
-                true,
-            )));
-        }
+        };
+        let fields = slots
+            .iter()
+            .map(|slot| match slot {
+                OutputSlot::Fetched(name) => schema
+                    .field_with_name(name)
+                    .map(|field| Arc::new(field.clone()))
+                    .map_err(Error::from),
+                OutputSlot::RowId(name) => Ok(Arc::new(arrow_schema::Field::new(
+                    name,
+                    arrow_schema::DataType::UInt64,
+                    true,
+                ))),
+            })
+            .collect::<Result<Vec<_>>>()?;
         Ok(Arc::new(arrow_schema::Schema::new(fields)))
     }
 

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -489,15 +489,21 @@ impl PermutationReader {
                 .await?
                 .try_collect::<Vec<_>>()
                 .await?;
-            if let Some(first_batch) = batches.first() {
-                let schema = first_batch.schema();
-                let batch = arrow::compute::concat_batches(&schema, &batches)?;
-                Ok(batch)
-            } else {
-                // `try_new` with no columns errors on any non-empty schema; this is
-                // the same empty batch the `offsets.is_empty()` branch above builds.
-                Ok(RecordBatch::new_empty(self.output_schema(selection).await?))
+            let taken = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+            if taken != offsets.len() {
+                // Same contract `load_batch` enforces for the permutation branch: a
+                // take that comes back short means the offsets and the table disagree,
+                // which silently drops training rows if it is allowed through.
+                return Err(Error::InvalidInput {
+                    message: format!(
+                        "Base table returned {} rows for {} offsets",
+                        taken,
+                        offsets.len()
+                    ),
+                });
             }
+            let schema = batches[0].schema();
+            Ok(arrow::compute::concat_batches(&schema, &batches)?)
         }
     }
 
@@ -506,13 +512,15 @@ impl PermutationReader {
         // `output_schema` reads the schema off a query plan, and building a plan on a
         // remote table executes the query.  Without a limit that is a full table scan
         // over HTTP for every `Permutation` constructed — once per split, per epoch — so
-        // bound it to no rows at all: the response still carries the schema, which is
-        // the only thing wanted here, and a wide or blob-bearing table does not pay to
-        // ship a row.  Native tables never execute the plan, so this costs them nothing.
+        // bound it.  Native tables never execute the plan, so this costs them nothing.
+        //
+        // One row, not zero: lance reads a limit of `Some(0)` as *no limit* rather than
+        // no rows (`Scanner`: `self.limit.unwrap_or(0) > 0` gates the limit node), so a
+        // zero here would scan the whole table — the very thing this is preventing.
         table
             .query()
             .select(selection)
-            .limit(0)
+            .limit(1)
             .use_lsm(false)
             .output_schema()
             .await

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -497,10 +497,25 @@ impl PermutationReader {
             )?;
             Self::load_batch(&self.base_table, row_ids, selection).await
         } else {
+            // Offsets are relative to this reader's own skip, the same way the
+            // permutation branch resolves them through `get_offset_map`.  Without
+            // this, `identity(t).with_skip(5)[0]` returns the row that iteration
+            // skipped — the exact shape `with_skip` exists to support.
+            for offset in offsets {
+                if *offset >= self.available_rows {
+                    return Err(Error::InvalidInput {
+                        message: format!(
+                            "Offset {} is out of range; this permutation exposes {} rows",
+                            offset, self.available_rows
+                        ),
+                    });
+                }
+            }
+            let skip = self.offset.unwrap_or(0);
             let table = Table::from(self.base_table.clone());
             let batches = table
-                .take_offsets(offsets.to_vec())
-                .select(selection.clone())
+                .take_offsets(offsets.iter().map(|o| o + skip).collect())
+                .select(selection)
                 .use_lsm(false)
                 .execute()
                 .await?
@@ -534,9 +549,15 @@ impl PermutationReader {
         // One row, not zero: lance reads a limit of `Some(0)` as *no limit* rather than
         // no rows (`Scanner`: `self.limit.unwrap_or(0) > 0` gates the limit node), so a
         // zero here would scan the whole table — the very thing this is preventing.
+        //
+        // The never-true predicate is what keeps the payload empty: the plan, and so
+        // the schema, is unchanged, but no row is matched and none is shipped.  That
+        // matters for wide or blob-bearing tables, where one row per split per epoch
+        // is not free.
         table
             .query()
             .select(selection)
+            .only_if("1 = 0")
             .limit(1)
             .use_lsm(false)
             .output_schema()
@@ -848,6 +869,43 @@ mod tests {
             .values()
             .to_vec();
         assert_eq!(idx_values, vec![0, 2, 4, 6]);
+    }
+
+    /// Offsets are relative to the reader's own skip, so indexing agrees with what
+    /// iteration yields.  They disagreed before: `with_skip(5)` then offset 0 returned
+    /// the row iteration had skipped, which is the resume case `with_skip` is for.
+    #[tokio::test]
+    async fn test_take_offsets_identity_reader_honors_skip() {
+        let base_table = lance_datagen::gen_batch()
+            .col("idx", lance_datagen::array::step::<Int32Type>())
+            .into_mem_table("tbl", RowCount::from(10), BatchCount::from(1))
+            .await;
+
+        let reader = PermutationReader::identity(base_table.base_table().clone())
+            .await
+            .unwrap()
+            .with_offset(5)
+            .await
+            .unwrap();
+        assert_eq!(reader.count_rows(), 5);
+
+        let batch = reader.take_offsets(&[0, 2], Select::All).await.unwrap();
+        assert_eq!(
+            batch.column(0).as_primitive::<Int32Type>().values(),
+            &[5, 7]
+        );
+
+        // And the first row of iteration is the row at offset 0.
+        let iterated = collect_from_stream::<Int32Type>(
+            reader.read(Select::All, Default::default()).await.unwrap(),
+            "idx",
+        )
+        .await;
+        assert_eq!(iterated.first(), Some(&5));
+
+        // Past the end of what this reader exposes, rather than silently reading on.
+        let err = reader.take_offsets(&[5], Select::All).await.unwrap_err();
+        assert!(err.to_string().contains("out of range"), "{err}");
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -506,11 +506,13 @@ impl PermutationReader {
         // `output_schema` reads the schema off a query plan, and building a plan on a
         // remote table executes the query.  Without a limit that is a full table scan
         // over HTTP for every `Permutation` constructed — once per split, per epoch — so
-        // bound it.  Native tables never execute the plan, so this costs them nothing.
+        // bound it to no rows at all: the response still carries the schema, which is
+        // the only thing wanted here, and a wide or blob-bearing table does not pay to
+        // ship a row.  Native tables never execute the plan, so this costs them nothing.
         table
             .query()
             .select(selection)
-            .limit(1)
+            .limit(0)
             .use_lsm(false)
             .output_schema()
             .await

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -192,7 +192,8 @@ impl PermutationReader {
         row_ids: RecordBatch,
         selection: Select,
     ) -> Result<RecordBatch> {
-        let has_row_id = Self::has_row_id(&selection)?;
+        // The row id never travels in the projection; see `split_row_id_selection`.
+        let (transport_selection, row_id_aliases) = Self::split_row_id_selection(selection)?;
 
         let num_rows = row_ids.num_rows();
         // One column, positionally — the callers name it differently (`row_id` from a
@@ -222,7 +223,7 @@ impl PermutationReader {
         // permutation is defined over.
         let data = Table::from(base_table.clone())
             .take_row_ids(row_ids.to_vec())
-            .select(selection)
+            .select(transport_selection)
             .with_row_id()
             .use_lsm(false)
             .execute_with_options(QueryExecutionOptions {
@@ -285,12 +286,7 @@ impl PermutationReader {
             arrow_select::take::take_record_batch(&batch, &desired_idx_order)?
         };
 
-        if has_row_id {
-            Ok(ordered_batch)
-        } else {
-            // The user didn't ask for row id, we needed it for ordering the data, but now we drop it
-            Ok(ordered_batch.drop_column(ROW_ID)?)
-        }
+        Self::restore_row_ids(ordered_batch, &row_id_aliases)
     }
 
     async fn row_ids_to_batches(
@@ -324,37 +320,90 @@ impl PermutationReader {
         Ok(Box::pin(SimpleRecordBatchStream::new(stream, schema)))
     }
 
-    fn has_row_id(selection: &Select) -> Result<bool> {
-        match selection {
-            Select::All => {
-                // _rowid is a system column and is not included in Select::All
-                Ok(false)
-            }
-            Select::Columns(columns) => Ok(columns.contains(&ROW_ID.to_string())),
-            Select::Dynamic(columns) => {
-                for column in columns {
-                    if column.0 == ROW_ID {
-                        if column.1 == ROW_ID {
-                            return Ok(true);
-                        } else {
-                            return Err(Error::InvalidInput {
-                                message: format!(
-                                    "Dynamic column {} cannot be used to select _rowid",
-                                    column.1
-                                ),
-                            });
-                        }
-                    }
-                }
-                Ok(false)
-            }
-            Select::Expr(columns) => {
-                // For Expr projections, we check if any alias is _rowid.
-                // We can't validate the expression itself (it may differ from _rowid)
-                // but we allow it through; the column will be included.
-                Ok(columns.iter().any(|(alias, _)| alias == ROW_ID))
+    /// Split `_rowid` out of a caller's selection.
+    ///
+    /// The row id is a system column: the LanceDB server accepts it only through the
+    /// `with_row_id` flag and rejects it outright in a projection. So it never goes on
+    /// the wire. This returns the projection to send plus the output names the caller
+    /// wanted the row id under, which [`Self::restore_row_ids`] puts back once the
+    /// batch is in hand — the fetch always sets `with_row_id`, so the values are there.
+    fn split_row_id_selection(selection: Select) -> Result<(Select, Vec<String>)> {
+        // An empty projection travels as `Select::Columns([])`, the one empty shape
+        // both the native scanner and the server agree on.
+        fn narrowed(columns: Vec<(String, String)>) -> Select {
+            if columns.is_empty() {
+                Select::Columns(Vec::new())
+            } else {
+                Select::Dynamic(columns)
             }
         }
+
+        match selection {
+            // `_rowid` is a system column and is not included in Select::All
+            Select::All => Ok((Select::All, Vec::new())),
+            Select::Columns(columns) => {
+                let (row_ids, rest): (Vec<_>, Vec<_>) =
+                    columns.into_iter().partition(|column| column == ROW_ID);
+                Ok((Select::Columns(rest), row_ids))
+            }
+            Select::Dynamic(columns) => {
+                let mut aliases = Vec::new();
+                let mut rest = Vec::new();
+                for (alias, expr) in columns {
+                    if expr == ROW_ID {
+                        aliases.push(alias);
+                    } else if alias == ROW_ID {
+                        return Err(Error::InvalidInput {
+                            message: format!(
+                                "Dynamic column {} cannot be used to select _rowid",
+                                expr
+                            ),
+                        });
+                    } else {
+                        rest.push((alias, expr));
+                    }
+                }
+                Ok((narrowed(rest), aliases))
+            }
+            Select::Expr(columns) => {
+                let mut aliases = Vec::new();
+                let mut rest = Vec::new();
+                for (alias, expr) in columns {
+                    match &expr {
+                        datafusion_expr::Expr::Column(column) if column.name == ROW_ID => {
+                            aliases.push(alias)
+                        }
+                        _ => rest.push((alias, expr)),
+                    }
+                }
+                if rest.is_empty() {
+                    Ok((Select::Columns(Vec::new()), aliases))
+                } else {
+                    Ok((Select::Expr(rest), aliases))
+                }
+            }
+        }
+    }
+
+    /// Put the row id back under the names the caller asked for, and drop it otherwise.
+    fn restore_row_ids(batch: RecordBatch, aliases: &[String]) -> Result<RecordBatch> {
+        if aliases.is_empty() {
+            // Requested only so the order could be restored; the caller never asked
+            // to see it.
+            return Ok(batch.drop_column(ROW_ID)?);
+        }
+        let row_ids = batch.column_by_name(ROW_ID).expect_ok()?.clone();
+        let mut out = batch;
+        for alias in aliases.iter().filter(|alias| *alias != ROW_ID) {
+            out = out.try_with_column(
+                arrow_schema::Field::new(alias, row_ids.data_type().clone(), true),
+                row_ids.clone(),
+            )?;
+        }
+        if !aliases.iter().any(|alias| alias == ROW_ID) {
+            out = out.drop_column(ROW_ID)?;
+        }
+        Ok(out)
     }
 
     async fn validate(&self) -> Result<()> {
@@ -554,14 +603,29 @@ impl PermutationReader {
         // the schema, is unchanged, but no row is matched and none is shipped.  That
         // matters for wide or blob-bearing tables, where one row per split per epoch
         // is not free.
-        table
+        // Same split as the fetch: naming `_rowid` in the projection is rejected by
+        // the server, so it is asked for by flag and its fields appended here.
+        let (transport_selection, row_id_aliases) = Self::split_row_id_selection(selection)?;
+        let schema = table
             .query()
-            .select(selection)
+            .select(transport_selection)
             .only_if("1 = 0")
             .limit(1)
             .use_lsm(false)
             .output_schema()
-            .await
+            .await?;
+        if row_id_aliases.is_empty() {
+            return Ok(schema);
+        }
+        let mut fields = schema.fields().to_vec();
+        for alias in &row_id_aliases {
+            fields.push(Arc::new(arrow_schema::Field::new(
+                alias,
+                arrow_schema::DataType::UInt64,
+                true,
+            )));
+        }
+        Ok(Arc::new(arrow_schema::Schema::new(fields)))
     }
 
     pub fn count_rows(&self) -> u64 {

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -332,6 +332,23 @@ impl PermutationReader {
         Ok(Box::pin(SimpleRecordBatchStream::new(stream, schema)))
     }
 
+    /// Whether an expression mentions the row id anywhere inside it.
+    fn references_row_id(expr: &datafusion_expr::Expr) -> bool {
+        use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+
+        let mut found = false;
+        // The closure is infallible, so the walk cannot fail.
+        let _ = expr.apply(|node| {
+            if matches!(node, datafusion_expr::Expr::Column(column) if column.name == ROW_ID) {
+                found = true;
+                Ok(TreeNodeRecursion::Stop)
+            } else {
+                Ok(TreeNodeRecursion::Continue)
+            }
+        });
+        found
+    }
+
     /// Split `_rowid` out of a caller's selection.
     ///
     /// The row id is a system column: the LanceDB server accepts it only through the
@@ -408,6 +425,21 @@ impl PermutationReader {
             }
             Select::Expr(columns) => {
                 let is_row_id = |expr: &datafusion_expr::Expr| matches!(expr, datafusion_expr::Expr::Column(column) if column.name == ROW_ID);
+                // A bare reference can be served by the flag and reassembled here.  One
+                // buried in a larger expression cannot: the store would have to evaluate
+                // `_rowid`, which is exactly what it refuses to accept.
+                for (alias, expr) in &columns {
+                    if !is_row_id(expr) && Self::references_row_id(expr) {
+                        return Err(Error::InvalidInput {
+                            message: format!(
+                                "Column {} computes over _rowid, which the table's backing \
+                                 store cannot evaluate.  Select _rowid on its own and \
+                                 compute over the result.",
+                                alias
+                            ),
+                        });
+                    }
+                }
                 if !columns.iter().any(|(_, expr)| is_row_id(expr)) {
                     return Ok((Select::Expr(columns), None));
                 }
@@ -1303,6 +1335,40 @@ mod tests {
             .await,
             vec!["doubled"]
         );
+    }
+
+    /// A bare `_rowid` expression is served by the flag, but one computed over cannot
+    /// be: the store would have to evaluate a column it refuses to accept in a
+    /// projection, so it is rejected here rather than sent and 400'd.
+    #[tokio::test]
+    async fn test_expression_over_row_id_is_rejected() {
+        use datafusion_expr::{col, lit};
+
+        let (base_table, row_ids_table, _) = setup_permutation_tables(5).await;
+        let reader = PermutationReader::try_from_tables(
+            base_table.base_table().clone(),
+            row_ids_table.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        let err = reader
+            .take_offsets(
+                &[0],
+                Select::Expr(vec![("shifted".to_string(), col(ROW_ID) + lit(1u64))]),
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("computes over _rowid"), "{err}");
+
+        // The bare form still works, under whatever alias was asked for.
+        let batch = reader
+            .take_offsets(&[0], Select::Expr(vec![("my_id".to_string(), col(ROW_ID))]))
+            .await
+            .unwrap();
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.schema().field(0).name(), "my_id");
     }
 
     /// A MemWAL write spec routes reads through the LSM scanner, which rejects

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -23,7 +23,6 @@ use arrow_array::{RecordBatch, UInt64Array};
 use arrow_schema::SchemaRef;
 use futures::{StreamExt, TryStreamExt};
 use lance::dataset::scanner::DatasetRecordBatchStream;
-use lance::io::RecordBatchStream;
 use lance_arrow::RecordBatchExt;
 use lance_core::ROW_ID;
 use lance_core::error::LanceOptionExt;
@@ -1106,12 +1105,20 @@ mod tests {
         .await
         .unwrap();
 
+        // Compare takes against the permutation's own order rather than assuming one:
+        // `build` sorts by split id, and that sort is not guaranteed to be stable.
+        let in_order = collect_from_stream::<Int32Type>(
+            reader.read(Select::All, Default::default()).await.unwrap(),
+            "idx",
+        )
+        .await;
+        assert_eq!(in_order.len(), 10);
+
         let batch = reader.take_offsets(&[3, 1], Select::All).await.unwrap();
         assert_eq!(batch.num_rows(), 2);
-        // No shuffle was configured, so permutation offsets follow storage order.
         assert_eq!(
             batch.column(0).as_primitive::<Int32Type>().values(),
-            &[3, 1]
+            &[in_order[3], in_order[1]]
         );
     }
 }

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -459,6 +459,11 @@ impl PermutationReader {
         Ok(offset_map)
     }
 
+    /// Read the rows at `offsets`, in that order.
+    ///
+    /// Offsets must be distinct: a repeated offset resolves to a single row, which
+    /// would misalign the returned batch against what the caller asked for, so it is
+    /// rejected by the row-count checks rather than returned short.
     pub async fn take_offsets(&self, offsets: &[u64], selection: Select) -> Result<RecordBatch> {
         if offsets.is_empty() {
             return Ok(RecordBatch::new_empty(self.output_schema(selection).await?));

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -21,7 +21,6 @@ use arrow::compute::concat_batches;
 use arrow::datatypes::UInt64Type;
 use arrow_array::{RecordBatch, UInt64Array};
 use arrow_schema::SchemaRef;
-use datafusion_expr::{Expr, col, lit};
 use futures::{StreamExt, TryStreamExt};
 use lance::dataset::scanner::DatasetRecordBatchStream;
 use lance::io::RecordBatchStream;
@@ -197,23 +196,20 @@ impl PermutationReader {
             .expect_ok()?
             .values();
 
-        let in_list: Vec<Expr> = row_ids.iter().map(|id| lit(*id)).collect();
-
-        let base_query = QueryRequest {
-            filter: Some(QueryFilter::Datafusion(col(ROW_ID).in_list(in_list, false))),
-            select: selection,
-            with_row_id: true,
-            ..Default::default()
-        };
-
-        let data = base_table
-            .query(
-                &AnyQuery::Query(base_query),
-                QueryExecutionOptions {
-                    max_batch_length: num_rows as u32,
-                    ..Default::default()
-                },
-            )
+        // Fetch through the public take API so this shares one request shape with
+        // `Table::take_row_ids`.  `with_row_id` brings `_rowid` back so the requested
+        // order can be restored below; `use_lsm(false)` reads the base table, since the
+        // MemWAL LSM scanner exposes `_rowaddr` rather than the stable `_rowid` a
+        // permutation is defined over.
+        let data = Table::from(base_table.clone())
+            .take_row_ids(row_ids.to_vec())
+            .select(selection)
+            .with_row_id()
+            .use_lsm(false)
+            .execute_with_options(QueryExecutionOptions {
+                max_batch_length: num_rows as u32,
+                ..Default::default()
+            })
             .await?;
         let schema = data.schema();
 
@@ -391,7 +387,12 @@ impl PermutationReader {
             self.base_table
                 .query(
                     &AnyQuery::Query(QueryRequest {
-                        select: Select::Columns(vec![ROW_ID.to_string()]),
+                        // `_rowid` is requested with the flag rather than projected, the
+                        // only shape the LanceDB server accepts.  See `load_batch` for why
+                        // the identity scan reads the base table rather than the MemWAL.
+                        select: Select::Columns(Vec::new()),
+                        with_row_id: true,
+                        use_lsm: Some(false),
                         offset: self.offset.map(|o| o as usize),
                         limit: self.limit.map(|l| l as usize),
                         ..Default::default()
@@ -468,6 +469,7 @@ impl PermutationReader {
             let batches = table
                 .take_offsets(offsets.to_vec())
                 .select(selection.clone())
+                .use_lsm(false)
                 .execute()
                 .await?
                 .try_collect::<Vec<_>>()
@@ -487,7 +489,17 @@ impl PermutationReader {
 
     pub async fn output_schema(&self, selection: Select) -> Result<SchemaRef> {
         let table = Table::from(self.base_table.clone());
-        table.query().select(selection).output_schema().await
+        // `output_schema` reads the schema off a query plan, and building a plan on a
+        // remote table executes the query.  Without a limit that is a full table scan
+        // over HTTP for every `Permutation` constructed — once per split, per epoch — so
+        // bound it.  Native tables never execute the plan, so this costs them nothing.
+        table
+            .query()
+            .select(selection)
+            .limit(1)
+            .use_lsm(false)
+            .output_schema()
+            .await
     }
 
     pub fn count_rows(&self) -> u64 {
@@ -1010,5 +1022,96 @@ mod tests {
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.schema().field(0).name(), "idx");
+    }
+
+    /// `output_schema` bounds its plan with `limit(1)` so a remote table does not run a
+    /// full scan just to report a schema. The schema itself must be unaffected, for
+    /// every selection shape.
+    #[tokio::test]
+    async fn test_output_schema_matches_selection() {
+        let (base_table, row_ids_table, _) = setup_permutation_tables(5).await;
+
+        let reader = PermutationReader::try_from_tables(
+            base_table.base_table().clone(),
+            row_ids_table.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        let names = async |selection: Select| -> Vec<String> {
+            reader
+                .output_schema(selection)
+                .await
+                .unwrap()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect()
+        };
+
+        assert_eq!(names(Select::All).await, vec!["idx", "other_col"]);
+        assert_eq!(
+            names(Select::Columns(vec!["other_col".to_string()])).await,
+            vec!["other_col"]
+        );
+        assert_eq!(
+            names(Select::Dynamic(vec![(
+                "doubled".to_string(),
+                "idx * 2".to_string()
+            )]))
+            .await,
+            vec!["doubled"]
+        );
+    }
+
+    /// A MemWAL write spec routes reads through the LSM scanner, which rejects
+    /// `with_row_id` because it exposes `_rowaddr` rather than a stable `_rowid`. The
+    /// permutation is defined over `_rowid`, so both the build and the fetch read the
+    /// base table explicitly. Without that this whole path errors.
+    #[tokio::test]
+    async fn test_permutation_over_mem_wal_table() {
+        // Aliased: `test_utils::datagen` exports a same-named trait already in scope.
+        use crate::arrow::LanceDbDatagenExt as _;
+        use crate::connect;
+        use crate::dataloader::permutation::builder::PermutationBuilder;
+        use crate::table::LsmWriteSpec;
+
+        // MemWAL needs a real dataset directory rather than an in-memory table.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = connect(temp_dir.path().to_str().unwrap())
+            .execute()
+            .await
+            .unwrap();
+        let data = lance_datagen::gen_batch()
+            .col("idx", lance_datagen::array::step::<Int32Type>())
+            .into_ldb_stream(RowCount::from(10), BatchCount::from(1));
+        let base_table = db.create_table("tbl", data).execute().await.unwrap();
+        base_table
+            .set_lsm_write_spec(LsmWriteSpec::unsharded())
+            .await
+            .unwrap();
+
+        let permutation_table = PermutationBuilder::new(base_table.clone())
+            .build()
+            .await
+            .unwrap();
+        assert_eq!(permutation_table.count_rows(None).await.unwrap(), 10);
+
+        let reader = PermutationReader::try_from_tables(
+            base_table.base_table().clone(),
+            permutation_table.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        let batch = reader.take_offsets(&[3, 1], Select::All).await.unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        // No shuffle was configured, so permutation offsets follow storage order.
+        assert_eq!(
+            batch.column(0).as_primitive::<Int32Type>().values(),
+            &[3, 1]
+        );
     }
 }

--- a/rust/lancedb/src/dataloader/permutation/split.rs
+++ b/rust/lancedb/src/dataloader/permutation/split.rs
@@ -379,8 +379,26 @@ impl Splitter {
             SplitStrategy::Sequential { sizes } | SplitStrategy::Random { sizes, .. } => {
                 Some(sizes.to_counts(num_rows).iter().sum())
             }
-            SplitStrategy::Hash { .. } | SplitStrategy::Calculated { .. } => None,
+            // A passthrough: every scanned row keeps its calculated split id.
+            SplitStrategy::Calculated { .. } => Some(num_rows),
+            // Only a discarding hash is data-dependent; without one every scanned row
+            // lands in some split.
+            SplitStrategy::Hash { discard_weight, .. } => {
+                (*discard_weight == 0).then_some(num_rows)
+            }
         }
+    }
+
+    /// Whether [`Self::apply`] reads its source to the end.
+    ///
+    /// `apply_sequential` stops as soon as the configured splits are full, so a scan
+    /// that is longer than the splits need is expected rather than an error. The
+    /// draining strategies have no such shape, so their input can be counted directly.
+    pub fn drains_source(&self) -> bool {
+        matches!(
+            self.strategy,
+            SplitStrategy::Hash { .. } | SplitStrategy::Calculated { .. }
+        )
     }
 
     /// The columns this strategy needs, in order, to compute a split id.

--- a/rust/lancedb/src/dataloader/permutation/split.rs
+++ b/rust/lancedb/src/dataloader/permutation/split.rs
@@ -11,6 +11,7 @@ use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::hash_utils::{RandomState, create_hashes};
 use futures::{StreamExt, TryStreamExt};
 use lance_arrow::SchemaExt;
+use lance_core::ROW_ID;
 
 use crate::{
     Error, Result,
@@ -223,13 +224,20 @@ impl Splitter {
         )))
     }
 
-    fn hash_split_id(batch: &RecordBatch, thresholds: &[u64], total_weight: u64) -> UInt64Array {
+    fn hash_split_id(
+        batch: &RecordBatch,
+        row_id_index: usize,
+        thresholds: &[u64],
+        total_weight: u64,
+    ) -> UInt64Array {
         let arrays = batch
             .columns()
             .iter()
-            // Don't hash the last column which should always be the row id
-            .take(batch.columns().len() - 1)
-            .cloned()
+            .enumerate()
+            // The row id identifies the row rather than describing it, so hashing it
+            // would make the split assignment depend on storage position.
+            .filter(|(i, _)| *i != row_id_index)
+            .map(|(_, col)| col.clone())
             .collect::<Vec<_>>();
         let mut hashes = vec![0; batch.num_rows()];
         let random_state = RandomState::with_seed(0);
@@ -268,7 +276,9 @@ impl Splitter {
         weights: &[u64],
         discard_weight: u64,
     ) -> Result<SendableRecordBatchStream> {
-        let row_id_index = source.schema().fields.len() - 1;
+        // By name, not by position: the row id is appended by `with_row_id`, so where
+        // it lands is up to the scanner (or the server) rather than to `project`.
+        let row_id_index = source.schema().index_of(ROW_ID)?;
         let new_schema = Arc::new(Schema::new(vec![
             source.schema().field(row_id_index).clone(),
             Field::new(SPLIT_ID_COLUMN, DataType::UInt64, false),
@@ -288,7 +298,7 @@ impl Splitter {
 
         let new_schema_clone = new_schema.clone();
         let stream = source.map_ok(move |batch| {
-            let split_ids = Self::hash_split_id(&batch, &thresholds, total_weight);
+            let split_ids = Self::hash_split_id(&batch, row_id_index, &thresholds, total_weight);
 
             if split_ids.null_count() > 0 {
                 let is_valid = split_ids.nulls().unwrap().inner();
@@ -358,10 +368,21 @@ impl Splitter {
         }
     }
 
+    /// The columns this strategy needs, in order, to compute a split id.
+    ///
+    /// The row id is not among them: the caller requests it with `with_row_id`, which
+    /// appends it after these columns.
+    pub fn projected_columns(&self) -> Vec<String> {
+        match &self.strategy {
+            SplitStrategy::Calculated { .. } => vec![SPLIT_ID_COLUMN.to_string()],
+            SplitStrategy::Hash { columns, .. } => columns.clone(),
+            _ => Vec::new(),
+        }
+    }
+
     /// Add the columns this strategy needs to compute a split id.
     ///
-    /// The row id is not projected here.  The caller requests it with `with_row_id`,
-    /// which appends it after these columns — the position [`Self::apply`] expects.
+    /// See [`Self::projected_columns`] for why the row id is not projected here.
     pub fn project(&self, query: Query) -> Query {
         match &self.strategy {
             SplitStrategy::Calculated { calculation } => query.select(Select::Dynamic(vec![(
@@ -558,7 +579,9 @@ mod tests {
     use lance_datagen::{BatchCount, ByteCount, RowCount, Seed};
     use std::sync::Arc;
 
-    const ID_COLUMN: &str = "id";
+    /// Stands in for the row id column the builder's scan appends via `with_row_id`.
+    /// Named as it really is, because `apply_hash` looks it up by name.
+    const ID_COLUMN: &str = ROW_ID;
 
     #[test]
     fn test_split_sizes_percentages_validation() {

--- a/rust/lancedb/src/dataloader/permutation/split.rs
+++ b/rust/lancedb/src/dataloader/permutation/split.rs
@@ -12,8 +12,6 @@ use datafusion_common::hash_utils::{RandomState, create_hashes};
 use futures::{StreamExt, TryStreamExt};
 use lance_arrow::SchemaExt;
 
-use lance_core::ROW_ID;
-
 use crate::{
     Error, Result,
     arrow::{SendableRecordBatchStream, SimpleRecordBatchStream},
@@ -360,17 +358,17 @@ impl Splitter {
         }
     }
 
+    /// Add the columns this strategy needs to compute a split id.
+    ///
+    /// The row id is not projected here.  The caller requests it with `with_row_id`,
+    /// which appends it after these columns — the position [`Self::apply`] expects.
     pub fn project(&self, query: Query) -> Query {
         match &self.strategy {
-            SplitStrategy::Calculated { calculation } => query.select(Select::Dynamic(vec![
-                (SPLIT_ID_COLUMN.to_string(), calculation.clone()),
-                (ROW_ID.to_string(), ROW_ID.to_string()),
-            ])),
-            SplitStrategy::Hash { columns, .. } => {
-                let mut cols = columns.clone();
-                cols.push(ROW_ID.to_string());
-                query.select(Select::Columns(cols))
-            }
+            SplitStrategy::Calculated { calculation } => query.select(Select::Dynamic(vec![(
+                SPLIT_ID_COLUMN.to_string(),
+                calculation.clone(),
+            )])),
+            SplitStrategy::Hash { columns, .. } => query.select(Select::Columns(columns.clone())),
             _ => query,
         }
     }

--- a/rust/lancedb/src/dataloader/permutation/split.rs
+++ b/rust/lancedb/src/dataloader/permutation/split.rs
@@ -368,6 +368,21 @@ impl Splitter {
         }
     }
 
+    /// How many rows the permutation must end up with, when the strategy fixes it.
+    ///
+    /// `None` when the row count depends on the data rather than the configuration,
+    /// which is the case for a hash split that discards and for a calculated split
+    /// whose expression can produce a null split id.
+    pub fn expected_row_count(&self, num_rows: u64) -> Option<u64> {
+        match &self.strategy {
+            SplitStrategy::NoSplit => Some(num_rows),
+            SplitStrategy::Sequential { sizes } | SplitStrategy::Random { sizes, .. } => {
+                Some(sizes.to_counts(num_rows).iter().sum())
+            }
+            SplitStrategy::Hash { .. } | SplitStrategy::Calculated { .. } => None,
+        }
+    }
+
     /// The columns this strategy needs, in order, to compute a split id.
     ///
     /// The row id is not among them: the caller requests it with `with_row_id`, which

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -5214,7 +5214,7 @@ mod tests {
         assert_eq!(schema.field(0).name(), "idx");
 
         let body = schema_body.lock().unwrap().clone().unwrap();
-        assert_eq!(body["k"], json!(1), "schema probe must not be an open scan");
+        assert_eq!(body["k"], json!(0), "schema probe must not fetch row data");
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -5322,12 +5322,103 @@ mod tests {
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.schema().field(0).name(), "my_id");
 
-        // The schema probe takes the same route.
-        let schema = reader
-            .output_schema(Select::Columns(vec!["idx".to_string(), ROW_ID.to_string()]))
+        // Row id first, and asked for twice: the output has to come back in the order
+        // and multiplicity requested, which appending it to the fetched batch loses.
+        let batch = reader
+            .take_offsets(
+                &[0],
+                Select::Columns(vec![
+                    ROW_ID.to_string(),
+                    "idx".to_string(),
+                    ROW_ID.to_string(),
+                ]),
+            )
             .await
             .unwrap();
-        assert!(schema.column_with_name(ROW_ID).is_some(), "{schema:?}");
+        assert_eq!(
+            batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            vec![ROW_ID, "idx", ROW_ID]
+        );
+
+        // The schema probe takes the same route, and reports the same shape.
+        let schema = reader
+            .output_schema(Select::Columns(vec![ROW_ID.to_string(), "idx".to_string()]))
+            .await
+            .unwrap();
+        assert_eq!(
+            schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            vec![ROW_ID, "idx"]
+        );
+    }
+
+    /// An identity permutation has no permutation table, so its take is a different
+    /// branch — and it was still naming `_rowid` in the projection after the fetch path
+    /// stopped doing so.
+    #[tokio::test]
+    async fn test_identity_take_never_projects_row_id() {
+        use crate::dataloader::permutation::reader::PermutationReader;
+
+        let base = Table::new_with_handler("my_table", |request: reqwest::Request| {
+            let path = request.url().path().to_string();
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+
+            if path == "/v1/table/my_table/count_rows/" {
+                return http::Response::builder()
+                    .status(200)
+                    .body(b"3".to_vec())
+                    .unwrap();
+            }
+
+            let names_row_id = match &body["columns"] {
+                serde_json::Value::Array(columns) => columns.iter().any(|column| column == ROW_ID),
+                serde_json::Value::Object(aliases) => aliases
+                    .iter()
+                    .any(|(alias, expr)| alias == ROW_ID || expr == ROW_ID),
+                _ => false,
+            };
+            if names_row_id {
+                return http::Response::builder()
+                    .status(400)
+                    .body(b"_rowid cannot be used in a select statement".to_vec())
+                    .unwrap();
+            }
+
+            let mut fields = vec![Field::new("idx", DataType::Int32, false)];
+            let mut columns: Vec<arrow_array::ArrayRef> =
+                vec![Arc::new(Int32Array::from(vec![10]))];
+            if body["with_row_id"] == json!(true) {
+                fields.push(Field::new(ROW_ID, DataType::UInt64, false));
+                columns.push(Arc::new(arrow_array::UInt64Array::from(vec![1u64])));
+            }
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(
+                    &RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap(),
+                ))
+                .unwrap()
+        });
+
+        let reader = PermutationReader::inner_new(base.base_table().clone(), None, 0)
+            .await
+            .unwrap();
+
+        let batch = reader
+            .take_offsets(&[0], Select::Columns(vec![ROW_ID.to_string()]))
+            .await
+            .unwrap();
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.schema().field(0).name(), ROW_ID);
     }
 
     /// Reading a schema builds a plan, and building a plan on a remote table executes

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -5051,6 +5051,52 @@ mod tests {
         );
     }
 
+    /// The guard fires after the destination is committed, so a persisted permutation
+    /// has to be rolled back — otherwise it is left behind under-filled and the obvious
+    /// retry, rebuilding under the same name, fails as already existing.
+    #[tokio::test]
+    async fn test_permutation_build_rolls_back_persisted_short_scan() {
+        use crate::connect;
+        use crate::dataloader::permutation::builder::PermutationBuilder;
+
+        let table = Table::new_with_handler("my_table", |request: reqwest::Request| {
+            if request.url().path() == "/v1/table/my_table/count_rows/" {
+                return http::Response::builder()
+                    .status(200)
+                    .body(b"5".to_vec())
+                    .unwrap();
+            }
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&row_id_batch(vec![10, 11, 12])))
+                .unwrap()
+        });
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let destination = connect(tmp_dir.path().to_str().unwrap())
+            .execute()
+            .await
+            .unwrap();
+
+        let err = PermutationBuilder::new(table)
+            .persist(destination.database().clone(), "perm".to_string())
+            .build()
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("expected 5"), "{err}");
+
+        assert!(
+            !destination
+                .table_names()
+                .execute()
+                .await
+                .unwrap()
+                .contains(&"perm".to_string()),
+            "a failed build must not leave its destination behind"
+        );
+    }
+
     /// The permutation fetch is a row-id take: the same `_rowid IN (...)` filter
     /// `Table::take_row_ids` sends, plus `with_row_id` so the requested order can be
     /// restored client-side.

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -5216,6 +5216,8 @@ mod tests {
         let body = schema_body.lock().unwrap().clone().unwrap();
         // One, not zero: lance reads `k: 0` as "no limit", so zero would be an open scan.
         assert_eq!(body["k"], json!(1), "schema probe must not be an open scan");
+        // ...and a never-true predicate keeps it from shipping the row it bounds to.
+        assert_eq!(body["filter"], json!("1 = 0"));
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -5214,7 +5214,8 @@ mod tests {
         assert_eq!(schema.field(0).name(), "idx");
 
         let body = schema_body.lock().unwrap().clone().unwrap();
-        assert_eq!(body["k"], json!(0), "schema probe must not fetch row data");
+        // One, not zero: lance reads `k: 0` as "no limit", so zero would be an open scan.
+        assert_eq!(body["k"], json!(1), "schema probe must not be an open scan");
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -1142,6 +1142,54 @@ impl<S: HttpSend> RemoteTable<S> {
         }
     }
 
+    async fn count_rows_impl(
+        &self,
+        filter: Option<Filter>,
+        use_lsm: Option<bool>,
+    ) -> Result<usize> {
+        let mut request = self.post_read(&format!("/v1/table/{}/count_rows/", self.identifier));
+
+        let version = self.current_version().await;
+
+        let mut body = if let Some(filter) = filter {
+            let filter_sql = match filter {
+                Filter::Sql(sql) => sql.clone(),
+                Filter::Datafusion(expr) => expr_to_sql_string(&expr)?,
+            };
+            serde_json::json!({ "predicate": filter_sql, "version": version })
+        } else {
+            serde_json::json!({ "version": version })
+        };
+        // Only forward when explicitly set; a server that predates it ignores the
+        // field and counts as it would by default.
+        if let Some(use_lsm) = use_lsm {
+            body["use_lsm"] = serde_json::Value::Bool(use_lsm);
+        }
+        self.apply_branch_body(&mut body);
+        request = request.json(&body);
+
+        let (request_id, response) = match self.send(request, true).await {
+            Ok((id, resp)) => {
+                // check_table_response now handles error-based invalidation
+                let response = self.check_table_response(&id, resp).await?;
+                (id, response)
+            }
+            Err(e) => {
+                self.handle_error_invalidation(&e);
+                return Err(e);
+            }
+        };
+
+        self.track_read_version_from_headers(response.headers());
+        let body = response.text().await.err_to_http(request_id.clone())?;
+
+        serde_json::from_str(&body).map_err(|e| Error::Http {
+            source: format!("Failed to parse row count: {}", e).into(),
+            request_id,
+            status_code: None,
+        })
+    }
+
     fn invalidate_schema_cache(&self) {
         self.schema_cache.invalidate();
     }
@@ -2106,43 +2154,17 @@ impl<S: HttpSend> BaseTable for RemoteTable<S> {
     }
 
     async fn count_rows(&self, filter: Option<Filter>) -> Result<usize> {
-        let mut request = self.post_read(&format!("/v1/table/{}/count_rows/", self.identifier));
-
-        let version = self.current_version().await;
-
-        let mut body = if let Some(filter) = filter {
-            let filter_sql = match filter {
-                Filter::Sql(sql) => sql.clone(),
-                Filter::Datafusion(expr) => expr_to_sql_string(&expr)?,
-            };
-            serde_json::json!({ "predicate": filter_sql, "version": version })
-        } else {
-            serde_json::json!({ "version": version })
-        };
-        self.apply_branch_body(&mut body);
-        request = request.json(&body);
-
-        let (request_id, response) = match self.send(request, true).await {
-            Ok((id, resp)) => {
-                // check_table_response now handles error-based invalidation
-                let response = self.check_table_response(&id, resp).await?;
-                (id, response)
-            }
-            Err(e) => {
-                self.handle_error_invalidation(&e);
-                return Err(e);
-            }
-        };
-
-        self.track_read_version_from_headers(response.headers());
-        let body = response.text().await.err_to_http(request_id.clone())?;
-
-        serde_json::from_str(&body).map_err(|e| Error::Http {
-            source: format!("Failed to parse row count: {}", e).into(),
-            request_id,
-            status_code: None,
-        })
+        self.count_rows_impl(filter, None).await
     }
+
+    /// The server rejects `count_rows` outright on a table carrying a MemWAL write
+    /// spec, because the count would silently omit every un-compacted row. Sending
+    /// `use_lsm: false` asks for the base-only count explicitly, which is what a
+    /// caller addressing rows by `_rowid` wants.
+    async fn count_base_rows(&self, filter: Option<Filter>) -> Result<usize> {
+        self.count_rows_impl(filter, Some(false)).await
+    }
+
     async fn add(&self, mut add: AddDataBuilder) -> Result<AddResult> {
         self.check_mutable().await?;
 
@@ -4943,7 +4965,9 @@ mod tests {
         use crate::dataloader::permutation::builder::PermutationBuilder;
 
         let scan_body = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
-        let captured = scan_body.clone();
+        let count_body = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let captured_scan = scan_body.clone();
+        let captured_count = count_body.clone();
 
         let table = Table::new_with_handler("my_table", move |request: reqwest::Request| {
             let path = request.url().path().to_string();
@@ -4951,6 +4975,7 @@ mod tests {
                 serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
 
             if path == "/v1/table/my_table/count_rows/" {
+                *captured_count.lock().unwrap() = Some(body);
                 return http::Response::builder()
                     .status(200)
                     .body(b"3".to_vec())
@@ -4958,7 +4983,7 @@ mod tests {
             }
 
             assert_eq!(path, "/v1/table/my_table/query/");
-            *captured.lock().unwrap() = Some(body);
+            *captured_scan.lock().unwrap() = Some(body);
             http::Response::builder()
                 .status(200)
                 .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
@@ -4973,6 +4998,28 @@ mod tests {
         assert_eq!(body["columns"], json!([]));
         assert_eq!(body["with_row_id"], json!(true));
         assert_eq!(body["use_lsm"], json!(false));
+
+        // The count has to agree with that scan. The server rejects `count_rows`
+        // outright on a MemWAL table unless it is told to count the base table.
+        let body = count_body.lock().unwrap().clone().unwrap();
+        assert_eq!(body["use_lsm"], json!(false));
+    }
+
+    /// A plain `count_rows` must not acquire the base-only flag by accident — only
+    /// the permutation's `count_base_rows` opts in.
+    #[tokio::test]
+    async fn test_count_rows_does_not_send_use_lsm() {
+        let table = Table::new_with_handler("my_table", |request: reqwest::Request| {
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+            assert_eq!(body.get("use_lsm"), None, "{body}");
+            http::Response::builder()
+                .status(200)
+                .body(b"7".to_vec())
+                .unwrap()
+        });
+
+        assert_eq!(table.count_rows(None).await.unwrap(), 7);
     }
 
     /// The permutation fetch is a row-id take: the same `_rowid IN (...)` filter

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -5022,6 +5022,35 @@ mod tests {
         assert_eq!(table.count_rows(None).await.unwrap(), 7);
     }
 
+    /// The splits are sized from `count_rows`, so a scan that returns fewer rows than
+    /// that would quietly under-fill the trailing splits and train on less data than
+    /// was asked for. It fails instead.
+    #[tokio::test]
+    async fn test_permutation_build_rejects_short_scan() {
+        use crate::dataloader::permutation::builder::PermutationBuilder;
+
+        let table = Table::new_with_handler("my_table", |request: reqwest::Request| {
+            if request.url().path() == "/v1/table/my_table/count_rows/" {
+                return http::Response::builder()
+                    .status(200)
+                    .body(b"5".to_vec())
+                    .unwrap();
+            }
+            // Two rows short of what the count promised.
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&row_id_batch(vec![10, 11, 12])))
+                .unwrap()
+        });
+
+        let err = PermutationBuilder::new(table).build().await.unwrap_err();
+        assert!(
+            err.to_string().contains("expected 5"),
+            "expected the row count guard to fire, got: {err}"
+        );
+    }
+
     /// The permutation fetch is a row-id take: the same `_rowid IN (...)` filter
     /// `Table::take_row_ids` sends, plus `with_row_id` so the requested order can be
     /// restored client-side.
@@ -5174,6 +5203,131 @@ mod tests {
             err.to_string().contains("single row id column"),
             "expected the projection guard to fire, got: {err}"
         );
+    }
+
+    /// Selecting `_rowid` must not put it in the `columns` payload: the server takes
+    /// the row id only through `with_row_id` and rejects it in a projection. The client
+    /// asks by flag and reconstructs the requested output shape itself.
+    #[tokio::test]
+    async fn test_permutation_take_never_projects_row_id() {
+        use crate::dataloader::permutation::reader::PermutationReader;
+
+        let base = Table::new_with_handler("my_table", |request: reqwest::Request| {
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+
+            // Stand in for the server, which refuses `_rowid` in a select list.
+            let names_row_id = match &body["columns"] {
+                serde_json::Value::Array(columns) => columns.iter().any(|column| column == ROW_ID),
+                serde_json::Value::Object(aliases) => aliases
+                    .iter()
+                    .any(|(alias, expr)| alias == ROW_ID || expr == ROW_ID),
+                _ => false,
+            };
+            if names_row_id {
+                return http::Response::builder()
+                    .status(400)
+                    .body(
+                        b"_rowid cannot be used in a select statement, pass `with_row_id` instead"
+                            .to_vec(),
+                    )
+                    .unwrap();
+            }
+
+            // Answer the row ids actually asked for, ascending rather than in the
+            // requested order, so the client's reordering is what is under test.
+            let filter = body["filter"].as_str().unwrap_or_default();
+            let mut row_ids = filter
+                .rsplit_once('(')
+                .map(|(_, list)| list.trim_end_matches(')'))
+                .unwrap_or_default()
+                .split(',')
+                .filter_map(|value| value.trim().parse::<u64>().ok())
+                .collect::<Vec<_>>();
+            row_ids.sort_unstable();
+
+            // Honor the projection, so an empty one really does come back with no user
+            // columns — that is the shape a `_rowid`-only selection reduces to.
+            let wants_idx = match &body["columns"] {
+                serde_json::Value::Null => true,
+                serde_json::Value::Array(columns) => columns.iter().any(|c| c == "idx"),
+                serde_json::Value::Object(aliases) => aliases.values().any(|e| e == "idx"),
+                _ => true,
+            };
+            let mut fields = Vec::new();
+            let mut columns: Vec<arrow_array::ArrayRef> = Vec::new();
+            if wants_idx {
+                fields.push(Field::new("idx", DataType::Int32, false));
+                columns.push(Arc::new(Int32Array::from(
+                    row_ids.iter().map(|id| *id as i32 * 10).collect::<Vec<_>>(),
+                )));
+            }
+            // Only when asked by flag — the schema probe does not ask, and a server
+            // would not volunteer a system column.
+            if body["with_row_id"] == json!(true) {
+                fields.push(Field::new(ROW_ID, DataType::UInt64, false));
+                columns.push(Arc::new(arrow_array::UInt64Array::from(row_ids)));
+            }
+            let data = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap();
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&data))
+                .unwrap()
+        });
+
+        let permutation = permutation_table_for(vec![7, 3, 5]).await;
+        let reader = PermutationReader::try_from_tables(
+            base.base_table().clone(),
+            permutation.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        // Asking for the row id by its own name gives it back under that name.
+        let batch = reader
+            .take_offsets(
+                &[0, 2],
+                Select::Columns(vec!["idx".to_string(), ROW_ID.to_string()]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            vec!["idx", ROW_ID]
+        );
+        assert_eq!(
+            batch
+                .column_by_name(ROW_ID)
+                .unwrap()
+                .as_primitive::<arrow::datatypes::UInt64Type>()
+                .values(),
+            &[7, 5]
+        );
+
+        // And under an alias, which is how `rename_column` leaves the selection.
+        let batch = reader
+            .take_offsets(
+                &[0],
+                Select::Dynamic(vec![("my_id".to_string(), ROW_ID.to_string())]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.schema().field(0).name(), "my_id");
+
+        // The schema probe takes the same route.
+        let schema = reader
+            .output_schema(Select::Columns(vec!["idx".to_string(), ROW_ID.to_string()]))
+            .await
+            .unwrap();
+        assert!(schema.column_with_name(ROW_ID).is_some(), "{schema:?}");
     }
 
     /// Reading a schema builds a plan, and building a plan on a remote table executes

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -5089,6 +5089,93 @@ mod tests {
         );
     }
 
+    /// An identity permutation has no permutation table, so it counts and scans the
+    /// base table directly. Both have to be base-only or they disagree — and on a
+    /// MemWAL table the server rejects a count that is not.
+    #[tokio::test]
+    async fn test_permutation_identity_counts_base_rows() {
+        use crate::dataloader::permutation::reader::PermutationReader;
+
+        let count_body = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let captured = count_body.clone();
+
+        let base = Table::new_with_handler("my_table", move |request: reqwest::Request| {
+            let path = request.url().path().to_string();
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+
+            if path == "/v1/table/my_table/count_rows/" {
+                *captured.lock().unwrap() = Some(body);
+                return http::Response::builder()
+                    .status(200)
+                    .body(b"3".to_vec())
+                    .unwrap();
+            }
+
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&row_id_batch(vec![0, 1, 2])))
+                .unwrap()
+        });
+
+        let reader = PermutationReader::inner_new(base.base_table().clone(), None, 0)
+            .await
+            .unwrap();
+        assert_eq!(reader.count_rows(), 3);
+
+        let body = count_body.lock().unwrap().clone().unwrap();
+        assert_eq!(body["use_lsm"], json!(false));
+    }
+
+    /// The identity scan asks for an empty projection plus `with_row_id`. If a store
+    /// answered that with every column, reading the row ids positionally would train
+    /// on the wrong rows — so the reader checks rather than assumes.
+    #[tokio::test]
+    async fn test_permutation_identity_rejects_unrequested_columns() {
+        use crate::dataloader::permutation::reader::PermutationReader;
+
+        let base = Table::new_with_handler("my_table", |request: reqwest::Request| {
+            if request.url().path() == "/v1/table/my_table/count_rows/" {
+                return http::Response::builder()
+                    .status(200)
+                    .body(b"2".to_vec())
+                    .unwrap();
+            }
+            // A server that read `columns: []` as "all columns" would answer like this.
+            let data = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("idx", DataType::Int32, false),
+                    Field::new(ROW_ID, DataType::UInt64, false),
+                ])),
+                vec![
+                    Arc::new(Int32Array::from(vec![50, 70])),
+                    Arc::new(arrow_array::UInt64Array::from(vec![0u64, 1])),
+                ],
+            )
+            .unwrap();
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&data))
+                .unwrap()
+        });
+
+        let reader = PermutationReader::inner_new(base.base_table().clone(), None, 0)
+            .await
+            .unwrap();
+        // `err()` rather than `unwrap_err()`: the Ok type is a stream, which is not Debug.
+        let err = reader
+            .read(Select::All, QueryExecutionOptions::default())
+            .await
+            .err()
+            .expect("expected the projection guard to fire");
+        assert!(
+            err.to_string().contains("single row id column"),
+            "expected the projection guard to fire, got: {err}"
+        );
+    }
+
     /// Reading a schema builds a plan, and building a plan on a remote table executes
     /// the query. Bounded, or every `Permutation` construction scans the whole table.
     #[tokio::test]

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -3190,6 +3190,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use chrono::{DateTime, Utc};
     use futures::{StreamExt, TryFutureExt, future::BoxFuture};
+    use lance_core::ROW_ID;
     use lance_index::scalar::inverted::query::MatchQuery;
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
     use reqwest::Body;
@@ -4901,6 +4902,185 @@ mod tests {
             .execute()
             .await
             .unwrap();
+    }
+
+    /// Build a one-column `_rowid` batch, the shape the permutation build scan expects
+    /// back from the server.
+    fn row_id_batch(row_ids: Vec<u64>) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                ROW_ID,
+                DataType::UInt64,
+                false,
+            )])),
+            vec![Arc::new(arrow_array::UInt64Array::from(row_ids))],
+        )
+        .unwrap()
+    }
+
+    /// An in-memory permutation table over `row_ids`, all in split 0.
+    async fn permutation_table_for(row_ids: Vec<u64>) -> Table {
+        let split_ids = arrow_array::UInt64Array::from(vec![0u64; row_ids.len()]);
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("row_id", DataType::UInt64, false),
+                Field::new("split_id", DataType::UInt64, false),
+            ])),
+            vec![
+                Arc::new(arrow_array::UInt64Array::from(row_ids)),
+                Arc::new(split_ids),
+            ],
+        )
+        .unwrap();
+        crate::test_utils::datagen::virtual_table("permutation", &batch).await
+    }
+
+    /// The permutation build scans row ids with the `with_row_id` flag and an empty
+    /// projection, not by naming `_rowid` in `columns` — the server accepts the former
+    /// and `use_lsm(false)` keeps it off the MemWAL, which has no stable `_rowid`.
+    #[tokio::test]
+    async fn test_permutation_build_scan_request_shape() {
+        use crate::dataloader::permutation::builder::PermutationBuilder;
+
+        let scan_body = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let captured = scan_body.clone();
+
+        let table = Table::new_with_handler("my_table", move |request: reqwest::Request| {
+            let path = request.url().path().to_string();
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+
+            if path == "/v1/table/my_table/count_rows/" {
+                return http::Response::builder()
+                    .status(200)
+                    .body("3".to_string().into_bytes())
+                    .unwrap();
+            }
+
+            assert_eq!(path, "/v1/table/my_table/query/");
+            *captured.lock().unwrap() = Some(body);
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&row_id_batch(vec![10, 11, 12])))
+                .unwrap()
+        });
+
+        let permutation = PermutationBuilder::new(table).build().await.unwrap();
+        assert_eq!(permutation.count_rows(None).await.unwrap(), 3);
+
+        let body = scan_body.lock().unwrap().clone().unwrap();
+        assert_eq!(body["columns"], json!([]));
+        assert_eq!(body["with_row_id"], json!(true));
+        assert_eq!(body["use_lsm"], json!(false));
+    }
+
+    /// The permutation fetch is a row-id take: the same `_rowid IN (...)` filter
+    /// `Table::take_row_ids` sends, plus `with_row_id` so the requested order can be
+    /// restored client-side.
+    #[tokio::test]
+    async fn test_permutation_take_request_shape() {
+        use crate::dataloader::permutation::reader::PermutationReader;
+
+        let take_body = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let captured = take_body.clone();
+
+        let base = Table::new_with_handler("my_table", move |request: reqwest::Request| {
+            assert_eq!(request.url().path(), "/v1/table/my_table/query/");
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+            *captured.lock().unwrap() = Some(body);
+
+            // Deliberately returned in the opposite order to the request, so the
+            // assertion below proves the client reorders by `_rowid`.
+            let data = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("idx", DataType::Int32, false),
+                    Field::new(ROW_ID, DataType::UInt64, false),
+                ])),
+                vec![
+                    Arc::new(Int32Array::from(vec![50, 70])),
+                    Arc::new(arrow_array::UInt64Array::from(vec![5u64, 7])),
+                ],
+            )
+            .unwrap();
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&data))
+                .unwrap()
+        });
+
+        let permutation = permutation_table_for(vec![7, 3, 5]).await;
+        let reader = PermutationReader::try_from_tables(
+            base.base_table().clone(),
+            permutation.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        // Offsets 0 and 2 of the permutation are row ids 7 and 5.
+        let batch = reader.take_offsets(&[0, 2], Select::All).await.unwrap();
+
+        let body = take_body.lock().unwrap().clone().unwrap();
+        let filter = body["filter"].as_str().expect("take must send a filter");
+        assert!(
+            filter.contains(ROW_ID) && filter.contains("IN"),
+            "expected a _rowid IN (...) filter, got: {filter}"
+        );
+        assert!(filter.contains('7') && filter.contains('5'), "{filter}");
+        assert_eq!(body["with_row_id"], json!(true));
+        assert_eq!(body["use_lsm"], json!(false));
+
+        // Reordered to the requested row ids, and `_rowid` dropped since it was not
+        // part of the selection.
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(
+            batch.column(0).as_primitive::<Int32Type>().values(),
+            &[70, 50]
+        );
+    }
+
+    /// Reading a schema builds a plan, and building a plan on a remote table executes
+    /// the query. Bounded, or every `Permutation` construction scans the whole table.
+    #[tokio::test]
+    async fn test_permutation_output_schema_is_bounded() {
+        use crate::dataloader::permutation::reader::PermutationReader;
+
+        let schema_body = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let captured = schema_body.clone();
+
+        let base = Table::new_with_handler("my_table", move |request: reqwest::Request| {
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+            *captured.lock().unwrap() = Some(body);
+            let data = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new("idx", DataType::Int32, false)])),
+                vec![Arc::new(Int32Array::from(vec![1]))],
+            )
+            .unwrap();
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&data))
+                .unwrap()
+        });
+
+        let permutation = permutation_table_for(vec![7]).await;
+        let reader = PermutationReader::try_from_tables(
+            base.base_table().clone(),
+            permutation.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        let schema = reader.output_schema(Select::All).await.unwrap();
+        assert_eq!(schema.field(0).name(), "idx");
+
+        let body = schema_body.lock().unwrap().clone().unwrap();
+        assert_eq!(body["k"], json!(1), "schema probe must not be an open scan");
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -4953,7 +4953,7 @@ mod tests {
             if path == "/v1/table/my_table/count_rows/" {
                 return http::Response::builder()
                     .status(200)
-                    .body("3".to_string().into_bytes())
+                    .body(b"3".to_vec())
                     .unwrap();
             }
 

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -562,6 +562,18 @@ pub trait BaseTable: std::fmt::Display + std::fmt::Debug + Send + Sync {
     async fn schema(&self) -> Result<SchemaRef>;
     /// Count the number of rows in this table.
     async fn count_rows(&self, filter: Option<Filter>) -> Result<usize>;
+    /// Count rows in the base table, ignoring any MemWAL.
+    ///
+    /// The default is [`Self::count_rows`], which is already base-only for tables
+    /// backed by a Lance dataset. Implementations whose plain count would include —
+    /// or refuse because of — un-compacted MemWAL data override this.
+    ///
+    /// Callers that address rows by `_rowid` need it: only base-table rows have a
+    /// stable one, so a count that disagrees with what a base-only scan returns
+    /// would silently mis-size the result (see [`crate::dataloader::permutation`]).
+    async fn count_base_rows(&self, filter: Option<Filter>) -> Result<usize> {
+        self.count_rows(filter).await
+    }
     /// Create a physical plan for the query.
     async fn create_plan(
         &self,

--- a/rust/lancedb/src/table/query.rs
+++ b/rust/lancedb/src/table/query.rs
@@ -91,12 +91,12 @@ fn requires_local_namespace_execution(query: &AnyQuery) -> bool {
     // is worse than a tuning miss: MemWAL read routing lives only in `create_plan`,
     // so a pushed-down query would return stale base-only data with no error.
     //
-    // Only `use_lsm(true)` needs to force local execution. `use_lsm(false)` asks for
-    // exactly the base-table read a pushdown performs, and when a MemWAL spec *is*
-    // installed `can_execute_namespace_query` already forces local execution on its
-    // own — so honoring it here would needlessly disable pushdown for callers that
-    // set it defensively (the permutation reader sets it on every base-table read).
-    if query.base().use_lsm == Some(true) {
+    // The permutation reader also relies on this: it sets `use_lsm(false)` on every
+    // base-table read, and the namespace request cannot express what those reads
+    // need (`k` defaults to 10, truncating a row-id take or a full row-id scan, and
+    // `Select::Dynamic` is rejected outright). Narrowing this to `Some(true)` would
+    // break the data loader on namespace-backed tables.
+    if query.base().use_lsm.is_some() {
         return true;
     }
     matches!(
@@ -693,7 +693,6 @@ mod tests {
     use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array};
     use futures::TryStreamExt;
     use lance_arrow::FixedSizeListArrayExt;
-    use snafu::location;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -893,12 +892,7 @@ mod tests {
 
         async fn query_table(&self, _request: NsQueryTableRequest) -> lance::Result<bytes::Bytes> {
             self.query_table_calls.fetch_add(1, Ordering::SeqCst);
-            // Erroring rather than panicking lets a test assert that a pushdown *was*
-            // attempted; tests that assert it was not still check the call count.
-            Err(lance::Error::NotSupported {
-                source: "CountingNamespaceClient does not serve queries".into(),
-                location: location!(),
-            })
+            panic!("approx_mode queries must not be pushed down to namespace query_table");
         }
     }
 
@@ -959,114 +953,34 @@ mod tests {
         assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 0);
     }
 
-    /// Build an in-memory table with a namespace client that counts pushdowns.
-    async fn table_with_counting_namespace(
-        name: &str,
-    ) -> (NativeTable, Arc<CountingNamespaceClient>) {
+    #[tokio::test]
+    async fn test_execute_query_use_lsm_with_namespace_pushdown_runs_locally() {
         use crate::connect;
+        use crate::table::query::execute_query;
         use arrow_array::{Int32Array, RecordBatch};
         use arrow_schema::{DataType, Field, Schema};
 
         let conn = connect("memory://").execute().await.unwrap();
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+        let vectors = Arc::new(fixed_size_list_array(
+            vec![0.0, 0.0, 10.0, 10.0, 20.0, 20.0],
+            2,
+        ));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("vector", vectors.data_type().clone(), false),
+        ]));
         let batch = RecordBatch::try_new(
             schema,
-            vec![Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef],
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3])), vectors],
         )
         .unwrap();
 
-        let table = conn.create_table(name, batch).execute().await.unwrap();
-        let namespace_client = Arc::new(CountingNamespaceClient::default());
-        let mut native_table = table.as_native().unwrap().clone();
-        native_table.namespace_client = Some(namespace_client.clone());
-        native_table
-            .pushdown_operations
-            .insert(NamespaceClientPushdownOperation::QueryTable);
-        (native_table, namespace_client)
-    }
-
-    #[tokio::test]
-    async fn test_execute_query_use_lsm_true_with_namespace_pushdown_runs_locally() {
-        use crate::table::query::execute_query;
-
-        let (native_table, namespace_client) =
-            table_with_counting_namespace("test_use_lsm_true_namespace_fallback").await;
-
-        // `use_lsm(true)` must force local execution — the namespace request has no
-        // use_lsm field, so a pushdown would silently ignore it and read the base table.
-        let query = AnyQuery::Query(QueryRequest {
-            use_lsm: Some(true),
-            ..Default::default()
-        });
-
-        // The table has no MemWAL write spec, so the local planner is what rejects it.
-        // That error is itself the proof the query never went to the namespace.
-        let err = execute_query(&native_table, &query, QueryExecutionOptions::default())
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("no MemWAL write spec"),
-            "expected the local planner's error, got: {err}"
-        );
-        assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 0);
-    }
-
-    #[tokio::test]
-    async fn test_execute_query_use_lsm_false_still_pushes_down() {
-        use crate::table::query::execute_query;
-
-        let (native_table, namespace_client) =
-            table_with_counting_namespace("test_use_lsm_false_namespace_pushdown").await;
-
-        // `use_lsm(false)` asks for exactly the base-table read a pushdown performs, so
-        // it must not disable pushdown.  Callers set it defensively — the permutation
-        // reader sets it on every base-table read — and losing pushdown would be a
-        // silent regression for namespace-backed tables.
-        let query = AnyQuery::Query(QueryRequest {
-            use_lsm: Some(false),
-            ..Default::default()
-        });
-
-        let err = execute_query(&native_table, &query, QueryExecutionOptions::default())
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("server-side query"),
-            "expected the namespace client's error, got: {err}"
-        );
-        assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn test_execute_query_use_lsm_false_with_mem_wal_spec_runs_locally() {
-        use crate::connect;
-        use crate::table::LsmWriteSpec;
-        use crate::table::query::execute_query;
-        use arrow_array::{Int32Array, RecordBatch};
-        use arrow_schema::{DataType, Field, Schema};
-
-        // MemWAL needs a real dataset directory, so this one cannot use `memory://`.
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let conn = connect(tmp_dir.path().to_str().unwrap())
-            .execute()
-            .await
-            .unwrap();
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef],
-        )
-        .unwrap();
         let table = conn
-            .create_table("test_use_lsm_false_with_spec", batch)
+            .create_table("test_use_lsm_namespace_fallback", batch)
             .execute()
             .await
             .unwrap();
-        table
-            .set_lsm_write_spec(LsmWriteSpec::unsharded())
-            .await
-            .unwrap();
-
         let namespace_client = Arc::new(CountingNamespaceClient::default());
         let mut native_table = table.as_native().unwrap().clone();
         native_table.namespace_client = Some(namespace_client.clone());
@@ -1074,10 +988,17 @@ mod tests {
             .pushdown_operations
             .insert(NamespaceClientPushdownOperation::QueryTable);
 
-        // With a spec installed, `can_execute_namespace_query` forces local execution on
-        // its own, so `use_lsm(false)` still reads the base table locally.
-        let query = AnyQuery::Query(QueryRequest {
-            use_lsm: Some(false),
+        // `use_lsm` set (even to false) must force local execution — the namespace
+        // request has no use_lsm field, so a pushdown would silently ignore it.
+        let query_vector = Arc::new(Float32Array::from(vec![0.0, 0.0]));
+        let query = AnyQuery::VectorQuery(VectorQueryRequest {
+            base: QueryRequest {
+                limit: Some(1),
+                use_lsm: Some(false),
+                ..Default::default()
+            },
+            column: Some("vector".to_string()),
+            query_vector: vec![query_vector as ArrayRef],
             ..Default::default()
         });
 
@@ -1087,7 +1008,7 @@ mod tests {
         let batches = stream.try_collect::<Vec<_>>().await.unwrap();
         let count: usize = batches.iter().map(|b| b.num_rows()).sum();
 
-        assert_eq!(count, 3);
+        assert_eq!(count, 1);
         assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 0);
     }
 

--- a/rust/lancedb/src/table/query.rs
+++ b/rust/lancedb/src/table/query.rs
@@ -90,7 +90,13 @@ fn requires_local_namespace_execution(query: &AnyQuery) -> bool {
     // pushing these down would silently ignore the user's setting. For use_lsm that
     // is worse than a tuning miss: MemWAL read routing lives only in `create_plan`,
     // so a pushed-down query would return stale base-only data with no error.
-    if query.base().use_lsm.is_some() {
+    //
+    // Only `use_lsm(true)` needs to force local execution. `use_lsm(false)` asks for
+    // exactly the base-table read a pushdown performs, and when a MemWAL spec *is*
+    // installed `can_execute_namespace_query` already forces local execution on its
+    // own — so honoring it here would needlessly disable pushdown for callers that
+    // set it defensively (the permutation reader sets it on every base-table read).
+    if query.base().use_lsm == Some(true) {
         return true;
     }
     matches!(
@@ -687,6 +693,7 @@ mod tests {
     use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array};
     use futures::TryStreamExt;
     use lance_arrow::FixedSizeListArrayExt;
+    use snafu::location;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -886,7 +893,12 @@ mod tests {
 
         async fn query_table(&self, _request: NsQueryTableRequest) -> lance::Result<bytes::Bytes> {
             self.query_table_calls.fetch_add(1, Ordering::SeqCst);
-            panic!("approx_mode queries must not be pushed down to namespace query_table");
+            // Erroring rather than panicking lets a test assert that a pushdown *was*
+            // attempted; tests that assert it was not still check the call count.
+            Err(lance::Error::NotSupported {
+                source: "CountingNamespaceClient does not serve queries".into(),
+                location: location!(),
+            })
         }
     }
 
@@ -947,34 +959,114 @@ mod tests {
         assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 0);
     }
 
-    #[tokio::test]
-    async fn test_execute_query_use_lsm_with_namespace_pushdown_runs_locally() {
+    /// Build an in-memory table with a namespace client that counts pushdowns.
+    async fn table_with_counting_namespace(
+        name: &str,
+    ) -> (NativeTable, Arc<CountingNamespaceClient>) {
         use crate::connect;
-        use crate::table::query::execute_query;
         use arrow_array::{Int32Array, RecordBatch};
         use arrow_schema::{DataType, Field, Schema};
 
         let conn = connect("memory://").execute().await.unwrap();
-
-        let vectors = Arc::new(fixed_size_list_array(
-            vec![0.0, 0.0, 10.0, 10.0, 20.0, 20.0],
-            2,
-        ));
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("vector", vectors.data_type().clone(), false),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let batch = RecordBatch::try_new(
             schema,
-            vec![Arc::new(Int32Array::from(vec![1, 2, 3])), vectors],
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef],
         )
         .unwrap();
 
-        let table = conn
-            .create_table("test_use_lsm_namespace_fallback", batch)
+        let table = conn.create_table(name, batch).execute().await.unwrap();
+        let namespace_client = Arc::new(CountingNamespaceClient::default());
+        let mut native_table = table.as_native().unwrap().clone();
+        native_table.namespace_client = Some(namespace_client.clone());
+        native_table
+            .pushdown_operations
+            .insert(NamespaceClientPushdownOperation::QueryTable);
+        (native_table, namespace_client)
+    }
+
+    #[tokio::test]
+    async fn test_execute_query_use_lsm_true_with_namespace_pushdown_runs_locally() {
+        use crate::table::query::execute_query;
+
+        let (native_table, namespace_client) =
+            table_with_counting_namespace("test_use_lsm_true_namespace_fallback").await;
+
+        // `use_lsm(true)` must force local execution — the namespace request has no
+        // use_lsm field, so a pushdown would silently ignore it and read the base table.
+        let query = AnyQuery::Query(QueryRequest {
+            use_lsm: Some(true),
+            ..Default::default()
+        });
+
+        // The table has no MemWAL write spec, so the local planner is what rejects it.
+        // That error is itself the proof the query never went to the namespace.
+        let err = execute_query(&native_table, &query, QueryExecutionOptions::default())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no MemWAL write spec"),
+            "expected the local planner's error, got: {err}"
+        );
+        assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_execute_query_use_lsm_false_still_pushes_down() {
+        use crate::table::query::execute_query;
+
+        let (native_table, namespace_client) =
+            table_with_counting_namespace("test_use_lsm_false_namespace_pushdown").await;
+
+        // `use_lsm(false)` asks for exactly the base-table read a pushdown performs, so
+        // it must not disable pushdown.  Callers set it defensively — the permutation
+        // reader sets it on every base-table read — and losing pushdown would be a
+        // silent regression for namespace-backed tables.
+        let query = AnyQuery::Query(QueryRequest {
+            use_lsm: Some(false),
+            ..Default::default()
+        });
+
+        let err = execute_query(&native_table, &query, QueryExecutionOptions::default())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("server-side query"),
+            "expected the namespace client's error, got: {err}"
+        );
+        assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_execute_query_use_lsm_false_with_mem_wal_spec_runs_locally() {
+        use crate::connect;
+        use crate::table::LsmWriteSpec;
+        use crate::table::query::execute_query;
+        use arrow_array::{Int32Array, RecordBatch};
+        use arrow_schema::{DataType, Field, Schema};
+
+        // MemWAL needs a real dataset directory, so this one cannot use `memory://`.
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let conn = connect(tmp_dir.path().to_str().unwrap())
             .execute()
             .await
             .unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("test_use_lsm_false_with_spec", batch)
+            .execute()
+            .await
+            .unwrap();
+        table
+            .set_lsm_write_spec(LsmWriteSpec::unsharded())
+            .await
+            .unwrap();
+
         let namespace_client = Arc::new(CountingNamespaceClient::default());
         let mut native_table = table.as_native().unwrap().clone();
         native_table.namespace_client = Some(namespace_client.clone());
@@ -982,17 +1074,10 @@ mod tests {
             .pushdown_operations
             .insert(NamespaceClientPushdownOperation::QueryTable);
 
-        // `use_lsm` set (even to false) must force local execution — the namespace
-        // request has no use_lsm field, so a pushdown would silently ignore it.
-        let query_vector = Arc::new(Float32Array::from(vec![0.0, 0.0]));
-        let query = AnyQuery::VectorQuery(VectorQueryRequest {
-            base: QueryRequest {
-                limit: Some(1),
-                use_lsm: Some(false),
-                ..Default::default()
-            },
-            column: Some("vector".to_string()),
-            query_vector: vec![query_vector as ArrayRef],
+        // With a spec installed, `can_execute_namespace_query` forces local execution on
+        // its own, so `use_lsm(false)` still reads the base table locally.
+        let query = AnyQuery::Query(QueryRequest {
+            use_lsm: Some(false),
             ..Default::default()
         });
 
@@ -1002,7 +1087,7 @@ mod tests {
         let batches = stream.try_collect::<Vec<_>>().await.unwrap();
         let count: usize = batches.iter().map(|b| b.num_rows()).sum();
 
-        assert_eq!(count, 1);
+        assert_eq!(count, 3);
         assert_eq!(namespace_client.query_table_calls.load(Ordering::SeqCst), 0);
     }
 


### PR DESCRIPTION
`StreamingDataset`, `PermutationBuilder`, and `Permutation` now work against a `RemoteTable` (LanceDB Cloud and Enterprise). Rows are addressed by `_rowid` exactly as `Table::take_row_ids` does — a supported enterprise query path — so the loader's fetch was already the take path; it just was never allowed to run.

```python
db = lancedb.connect("db://my-db", api_key=..., host_override=...)
ds = StreamingDataset(db.open_table("training"), world_size=8, rank=r)
```

Three things had to change beyond removing the guard in `PermutationBuilder.__init__`.

### Ask for the row id one way

The build scanned `Select::Columns(["_rowid"])` while the fetch used the `with_row_id` flag. Only the flag is accepted for remote tables — the view layer rejects `_rowid` in a select list outright — and `include_row_id` appends it last, which `Splitter` already assumes. `Splitter::project` no longer needs to know about `_rowid` at all.

### Bound the schema probe

`PermutationReader::output_schema` reads the schema off a query plan, and building a plan on a remote table *executes* the query (`create_plan` → `execute_query`). With no limit that is `k = isize::MAX`, so asking a remote table for its output schema pulled the whole table over HTTP and discarded it — once per assigned split, on every epoch, since `StreamingDataset.__iter__` constructs a `Permutation` per split.

### Read the base table

Both the native LSM scanner and the server reject `with_row_id` on a MemWAL table, because the LSM scanner exposes `_rowaddr` rather than a stable `_rowid`. `load_batch` sets `with_row_id`, so **the data loader is broken today on any MemWAL-enabled table, local or remote.** A permutation is defined over `_rowid`, so it now sets `use_lsm(false)` on every base-table read. Consequence worth knowing: rows still in an uncompacted MemWAL are not part of the permutation.

That forced one adjacent fix — `use_lsm(false)` had to stop disabling namespace pushdown. It asks for exactly the base-table read a pushdown performs, and a table that *does* carry a MemWAL spec already forces local execution in `can_execute_namespace_query`, so only `use_lsm(true)` needs to.

### Tests

Mocked-endpoint tests pin the wire shapes (build scan sends `columns: []` + `with_row_id` + `use_lsm: false`; the take sends `_rowid IN (...)`; the schema probe sends `k: 1`), plus a permutation over a MemWAL table, the hash and calculated split projections, and end-to-end `StreamingDataset` and `permutation_builder` runs against a mock server in Python.