### PR TITLE
feat: support remote tables in the data loader

### DIFF
--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -41,21 +41,21 @@ class PermutationBuilder:
     The permutation is stored in memory and will be lost when the program exits.
     """
 
-    def __init__(self, table: LanceTable):
+    def __init__(self, table: Table):
         """
         Creates a new permutation builder for the given table.
 
         By default, the permutation builder will create a single split that contains all
         rows in the same order as the base table.
+
+        Both local tables and remote tables (LanceDB Cloud and Enterprise) are
+        supported.  Against a remote table the permutation is built by reading every
+        row id over HTTP, so expect the build to cost roughly 8 bytes per row of
+        transfer, and note that it reads the base table only: rows still sitting in a
+        MemWAL that have not been compacted are not part of the permutation, because
+        the LSM scanner does not expose the stable ``_rowid`` a permutation is
+        defined over.
         """
-        if not hasattr(table, "_inner"):
-            raise TypeError(
-                f"PermutationBuilder requires a local LanceTable, "
-                f"got {type(table).__name__}. "
-                "The permutation API is not supported on remote tables. "
-                "Remote tables connect to LanceDB Cloud or Enterprise and do not have "
-                "direct access to the underlying Lance dataset needed for permutations."
-            )
         self._async = async_permutation_builder(table)
 
     def split_random(
@@ -231,7 +231,14 @@ class PermutationBuilder:
         return LOOP.run(do_execute())
 
 
-def permutation_builder(table: LanceTable) -> PermutationBuilder:
+def permutation_builder(table: Table) -> PermutationBuilder:
+    """
+    Creates a new permutation builder for the given table.
+
+    Accepts both local tables and remote tables (LanceDB Cloud and Enterprise); see
+    [PermutationBuilder][lancedb.permutation.PermutationBuilder] for what building a
+    permutation over a remote table costs.
+    """
     return PermutationBuilder(table)
 
 
@@ -248,8 +255,8 @@ class Permutations:
 
     Attributes
     ----------
-    base_table: LanceTable
-        The base table that the permutations are based on.
+    base_table: Table
+        The base table that the permutations are based on.  May be a remote table.
     permutation_table: LanceTable
         The permutation table that defines the splits.
     split_names: list[str]
@@ -282,7 +289,7 @@ class Permutations:
     {'train': 0, 'test': 1}
     """
 
-    def __init__(self, base_table: LanceTable, permutation_table: LanceTable):
+    def __init__(self, base_table: Table, permutation_table: LanceTable):
         self.base_table = base_table
         self.permutation_table = permutation_table
 

--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -48,13 +48,8 @@ class PermutationBuilder:
         By default, the permutation builder will create a single split that contains all
         rows in the same order as the base table.
 
-        Both local tables and remote tables (LanceDB Cloud and Enterprise) are
-        supported.  Against a remote table the permutation is built by reading every
-        row id over HTTP, so expect the build to cost roughly 8 bytes per row of
-        transfer, and note that it reads the base table only: rows still sitting in a
-        MemWAL that have not been compacted are not part of the permutation, because
-        the LSM scanner does not expose the stable ``_rowid`` a permutation is
-        defined over.
+        Rows sitting in an LSM that have not been flushed to the base table have no
+        row id yet, so they are not part of the permutation.
         """
         self._async = async_permutation_builder(table)
 
@@ -232,13 +227,6 @@ class PermutationBuilder:
 
 
 def permutation_builder(table: Table) -> PermutationBuilder:
-    """
-    Creates a new permutation builder for the given table.
-
-    Accepts both local tables and remote tables (LanceDB Cloud and Enterprise); see
-    [PermutationBuilder][lancedb.permutation.PermutationBuilder] for what building a
-    permutation over a remote table costs.
-    """
     return PermutationBuilder(table)
 
 
@@ -256,7 +244,7 @@ class Permutations:
     Attributes
     ----------
     base_table: Table
-        The base table that the permutations are based on.  May be a remote table.
+        The base table that the permutations are based on.
     permutation_table: LanceTable
         The permutation table that defines the splits.
     split_names: list[str]

--- a/python/python/lancedb/streaming.py
+++ b/python/python/lancedb/streaming.py
@@ -75,16 +75,7 @@ class StreamingDataset(IterableDataset):
     Parameters
     ----------
     table:
-        LanceDB table to stream from.  Local tables and remote tables (LanceDB Cloud
-        and Enterprise) are both supported.
-
-        Against a remote table every fetch is one HTTP request taking
-        ``read_batch_size`` rows by row id, so ``prefetch_batches`` is what hides the
-        round trip: raise it if ``prefetch_queue_depth`` keeps touching zero.
-        Construction is more expensive too — the permutation is built by reading every
-        row id over HTTP, roughly 8 bytes per row, once per rank.  Rows that are still
-        in an uncompacted MemWAL are not included; see
-        [PermutationBuilder][lancedb.permutation.PermutationBuilder].
+        LanceDB table to stream from.
     num_splits:
         Number of fixed splits to partition the table into.  Must be divisible
         by ``world_size``.  When used with DataLoader workers it must also be

--- a/python/python/lancedb/streaming.py
+++ b/python/python/lancedb/streaming.py
@@ -75,7 +75,16 @@ class StreamingDataset(IterableDataset):
     Parameters
     ----------
     table:
-        LanceDB table to stream from.
+        LanceDB table to stream from.  Local tables and remote tables (LanceDB Cloud
+        and Enterprise) are both supported.
+
+        Against a remote table every fetch is one HTTP request taking
+        ``read_batch_size`` rows by row id, so ``prefetch_batches`` is what hides the
+        round trip: raise it if ``prefetch_queue_depth`` keeps touching zero.
+        Construction is more expensive too — the permutation is built by reading every
+        row id over HTTP, roughly 8 bytes per row, once per rank.  Rows that are still
+        in an uncompacted MemWAL are not included; see
+        [PermutationBuilder][lancedb.permutation.PermutationBuilder].
     num_splits:
         Number of fixed splits to partition the table into.  Must be divisible
         by ``world_size``.  When used with DataLoader workers it must also be

--- a/python/python/tests/test_elastic_dataloader.py
+++ b/python/python/tests/test_elastic_dataloader.py
@@ -37,6 +37,11 @@ from unittest.mock import patch
 import lancedb
 import pyarrow as pa
 import pytest
+from utils import (
+    MockPermutationServer,
+    assert_server_safe_row_id_requests,
+    mock_remote_table,
+)
 
 torch = pytest.importorskip("torch")
 streaming = pytest.importorskip("lancedb.streaming")
@@ -2118,3 +2123,29 @@ def test_doc_example_checkpoint(lance_table):
     assert sorted(consumed + remaining_original) == list(range(NUM_ROWS)), (
         "Consumed + remaining must cover every row exactly once"
     )
+
+
+# ---------------------------------------------------------------------------
+# Remote tables (LanceDB Cloud / Enterprise)
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_dataset_over_remote_table():
+    """StreamingDataset reads a remote table, with server-safe requests.
+
+    The permutation API used to reject RemoteTable outright, so this is the whole
+    feature end to end: build a permutation over a remote table, then fetch batches
+    from it by row id.
+    """
+    server = MockPermutationServer()
+
+    with mock_remote_table(server) as table:
+        ds = StreamingDataset(table, num_splits=2, shuffle_seed=SHUFFLE_SEED)
+        ids = [row["id"] for row in ds]
+
+    assert sorted(ids) == list(range(server.num_rows)), (
+        "Every row of the remote table must be yielded exactly once"
+    )
+    assert len(server.scans) == 1, "the permutation is built with one row-id scan"
+    assert server.takes, "rows must be fetched with row-id takes"
+    assert_server_safe_row_id_requests(server)

--- a/python/python/tests/test_permutation.py
+++ b/python/python/tests/test_permutation.py
@@ -8,6 +8,11 @@ import pytest
 from lancedb import DBConnection, Table, connect
 from lancedb.background_loop import LOOP
 from lancedb.permutation import Permutation, Permutations, permutation_builder
+from utils import (
+    MockPermutationServer,
+    assert_server_safe_row_id_requests,
+    mock_remote_table,
+)
 
 
 def test_split_random_ratios(mem_db):
@@ -1214,3 +1219,37 @@ def test_remove_rowid_after_select(some_permutation: Permutation):
     perm_without_rowid = perm_with_rowid.remove_columns(["_rowid"])
     assert "_rowid" not in perm_without_rowid.column_names
     assert perm_without_rowid.column_names == ["id"]
+
+
+def test_permutation_over_remote_table():
+    """The permutation API accepts a remote table (LanceDB Cloud / Enterprise).
+
+    It used to reject one outright, which meant a remote table could not be used for
+    training at all.  Rows are addressed by `_rowid` here exactly as `take_row_ids`
+    does, so this also pins the request shapes sent to the server.
+    """
+    server = MockPermutationServer()
+
+    with mock_remote_table(server) as table:
+        permutation_tbl = permutation_builder(table).split_sequential(fixed=2).execute()
+        assert permutation_tbl.count_rows() == server.num_rows
+
+        permutation = Permutation.from_tables(table, permutation_tbl, 0)
+        assert permutation.num_rows == server.num_rows // 2
+
+        # Compare against the permutation's own order rather than assuming one: the
+        # builder sorts by split id, and that sort is not guaranteed to be stable.
+        rows = permutation_tbl.search(None).to_arrow().to_pydict()
+        split0 = [
+            row_id
+            for row_id, split in zip(rows["row_id"], rows["split_id"])
+            if not split
+        ]
+        # The mock table's `id` equals its `_rowid`. Offsets are resolved to row ids
+        # client-side, then taken back in the order asked for.
+        assert permutation.take_offsets([2, 0]) == [
+            {"id": split0[2]},
+            {"id": split0[0]},
+        ]
+
+    assert_server_safe_row_id_requests(server)

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -199,7 +199,9 @@ def assert_server_safe_row_id_requests(server):
     `.get`, not `[...]`: a dropped field should read as the assertion message these
     are written for, not as a KeyError.
     """
-    for body in server.query_bodies:
+    # Base-table reads only; the schema probe reads no rows, so it has no reason to
+    # say anything about the LSM.
+    for body in server.scans + server.takes:
         assert body.get("use_lsm") is False, body
     for body in server.takes:
         # The fetch needs the row id back to restore the requested order.

--- a/python/python/tests/utils.py
+++ b/python/python/tests/utils.py
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
+import contextlib
+import http.server
+import json
+import re
+import threading
+
+import lancedb
+import pyarrow as pa
 import pytest
+
+ARROW_FILE_CONTENT_TYPE = "application/vnd.apache.arrow.file"
 
 
 def exception_output(e_info: pytest.ExceptionInfo):
@@ -9,3 +19,207 @@ def exception_output(e_info: pytest.ExceptionInfo):
     # skip traceback part, since it's not worth checking in tests
     lines = traceback.format_exception_only(e_info.type, e_info.value)
     return "".join(lines).strip()
+
+
+def parse_in_list(filter_sql: str) -> list[int]:
+    """Pull the integers out of a `<col> IN (a, b, c)` predicate.
+
+    Scoped to the parenthesised list rather than scanning the whole predicate, so a
+    cast or a type name in the rendered SQL cannot contribute phantom values.
+    """
+    match = re.search(r"\bIN\s*\(([^)]*)\)", filter_sql, re.IGNORECASE)
+    assert match is not None, f"expected an IN list, got: {filter_sql}"
+    return [int(m) for m in re.findall(r"-?\d+", match.group(1))]
+
+
+def is_row_id_take(body) -> bool:
+    """True when a query body fetches specific rows by row id."""
+    return "_rowid" in (body.get("filter") or "")
+
+
+def arrow_file_bytes(table: pa.Table) -> bytes:
+    """Serialize to the Arrow IPC *file* framing the /query/ route answers with."""
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_file(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue().to_pybytes()
+
+
+class MockPermutationServer:
+    """A stand-in LanceDB server hosting one table whose ``id`` equals its ``_rowid``.
+
+    Serves the three routes the permutation API and the streaming data loader touch
+    (``describe``, ``count_rows``, ``query``) and records every ``/query/`` body, so a
+    test can assert on the request shapes sent to the server — the part that has to
+    stay compatible rather than merely round-trip locally.
+    """
+
+    def __init__(self, name="remote_data", num_rows=8):
+        self.name = name
+        self.num_rows = num_rows
+        self.query_bodies = []
+
+    def __call__(self, request):
+        path = request.path
+        if path == f"/v1/table/{self.name}/describe/":
+            return self._json(
+                request,
+                {
+                    "version": 1,
+                    "schema": {
+                        "fields": [
+                            {"name": "id", "type": {"type": "int64"}, "nullable": False}
+                        ]
+                    },
+                },
+            )
+        if path == f"/v1/table/{self.name}/count_rows/":
+            self._read_body(request)
+            return self._json(request, self.num_rows)
+        if path == f"/v1/table/{self.name}/query/":
+            return self._query(request, self._read_body(request))
+
+        # Drain before answering, so an unexpected route cannot desync a
+        # keep-alive connection.
+        self._read_body(request)
+        request.send_response(404)
+        request.end_headers()
+
+    @property
+    def scans(self):
+        """Bodies of the permutation build scan: the row id column, nothing else."""
+        return [b for b in self.query_bodies if b.get("columns") == ["_rowid"]]
+
+    @property
+    def takes(self):
+        """Bodies of the row-id takes the loader fetches batches with.
+
+        Keyed on `_rowid` rather than "has a filter": the schema probe carries a
+        never-true predicate so it ships no rows, and it is not a take.
+        """
+        return [b for b in self.query_bodies if is_row_id_take(b)]
+
+    @staticmethod
+    def _read_body(request):
+        content_len = int(request.headers.get("Content-Length") or 0)
+        return json.loads(request.rfile.read(content_len)) if content_len else {}
+
+    @staticmethod
+    def _json(request, payload):
+        request.send_response(200)
+        request.send_header("Content-Type", "application/json")
+        request.end_headers()
+        request.wfile.write(json.dumps(payload).encode())
+
+    @staticmethod
+    def _arrow(request, table):
+        body = arrow_file_bytes(table)
+        request.send_response(200)
+        request.send_header("Content-Type", ARROW_FILE_CONTENT_TYPE)
+        request.send_header("Content-Length", str(len(body)))
+        request.end_headers()
+        request.wfile.write(body)
+
+    def _query(self, request, body):
+        self.query_bodies.append(body)
+
+        if is_row_id_take(body):
+            # A row-id take. Answer in ascending row-id order regardless of the order
+            # asked for, so tests prove the client restores the requested order.
+            row_ids = sorted(parse_in_list(body["filter"]))
+            return self._arrow(
+                request,
+                pa.table(
+                    {
+                        "id": pa.array(row_ids, pa.int64()),
+                        "_rowid": pa.array(row_ids, pa.uint64()),
+                    }
+                ),
+            )
+
+        if body.get("columns") == ["_rowid"]:
+            # The permutation build scan: row ids and nothing else.
+            return self._arrow(
+                request,
+                pa.table({"_rowid": pa.array(range(self.num_rows), pa.uint64())}),
+            )
+
+        # The schema probe: bounded and filtered to nothing, so it carries the schema
+        # and no rows.
+        return self._arrow(request, pa.table({"id": pa.array([], pa.int64())}))
+
+
+def _make_handler(serve):
+    class MockLanceDBHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            serve(self)
+
+        def do_POST(self):
+            serve(self)
+
+        def log_message(self, *args):
+            pass  # keep pytest output readable
+
+    return MockLanceDBHandler
+
+
+@contextlib.contextmanager
+def mock_remote_table(server):
+    """Run ``server`` on a local port and yield an open remote table against it.
+
+    Threading, because the loader fans out ``num_splits * prefetch_batches`` fetch
+    threads; a single-threaded server would serialize them in the accept backlog and
+    hide the prefetch overlap being exercised.
+    """
+    with http.server.ThreadingHTTPServer(
+        ("localhost", 0), _make_handler(server)
+    ) as srv:
+        thread = threading.Thread(target=srv.serve_forever)
+        thread.start()
+        try:
+            db = lancedb.connect(
+                "db://dev",
+                api_key="fake",
+                host_override=f"http://localhost:{srv.server_address[1]}",
+                client_config={"timeout_config": {"connect_timeout": 5}},
+            )
+            yield db.open_table(server.name)
+        finally:
+            srv.shutdown()
+            thread.join()
+
+
+def assert_server_safe_row_id_requests(server):
+    """Assert every base-table read the loader issues is pinned to the base table.
+
+    A permutation addresses rows by stable ``_rowid``, which the MemWAL LSM scanner
+    does not expose — and which it rejects ``with_row_id`` reads for — so each read
+    has to say ``use_lsm: false`` explicitly.
+
+    `.get`, not `[...]`: a dropped field should read as the assertion message these
+    are written for, not as a KeyError.
+    """
+    for body in server.query_bodies:
+        assert body.get("use_lsm") is False, body
+    for body in server.takes:
+        # The fetch needs the row id back to restore the requested order.
+        assert body.get("with_row_id") is True, body
+        assert "_rowid" in body["filter"], body
+
+    # A filterless query with no effective bound asks the server for the whole table.
+    # Only the one-off permutation scan may do that — notably not the schema probe,
+    # which is built once per split per epoch. Takes carry their own bound in the
+    # `IN` list, so their k is irrelevant.
+    #
+    # `k == 0` counts as unbounded: lance reads a zero limit as "no limit" rather than
+    # "no rows", so a probe sending 0 is an open scan wearing a small number.
+    def is_unbounded(body):
+        if is_row_id_take(body):
+            return False
+        k = body.get("k")
+        return k is None or k == 0 or k > server.num_rows
+
+    unbounded = [b for b in server.query_bodies if is_unbounded(b)]
+    assert unbounded == server.scans, (
+        f"only the permutation scan may be unbounded, got {unbounded}"
+    )

--- a/python/src/permutation.rs
+++ b/python/src/permutation.rs
@@ -268,7 +268,9 @@ impl PyPermutationReader {
                     .await
                     .infer_error()?
             } else {
-                PermutationReader::identity(base_table).await
+                PermutationReader::identity(base_table)
+                    .await
+                    .infer_error()?
             };
             Ok(Self::from_reader(reader))
         })

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -242,6 +242,13 @@ impl PermutationBuilder {
         // First pass, apply filter and load row ids.  A permutation addresses rows by
         // stable `_rowid`, which the MemWAL LSM scanner does not expose, so it always
         // reads the base table.
+        //
+        // This scan's row order is load-bearing: `Shuffler` permutes positions rather
+        // than values, so the permutation is a function of (scan order, seed).  Every
+        // rank builds its own permutation and they have to agree, or splits overlap and
+        // rows are trained twice or not at all.  Locally that holds because a scan
+        // reads fragments in manifest order; remotely it depends on the server
+        // returning a stable order for the same table version.
         let mut rows = self
             .base_table
             .query()

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -239,16 +239,12 @@ impl PermutationBuilder {
 
     /// Builds the permutation table and stores it in the given database.
     pub async fn build(self) -> Result<Table> {
-        // First pass, apply filter and load row ids.  A permutation addresses rows by
-        // stable `_rowid`, which the MemWAL LSM scanner does not expose, so it always
-        // reads the base table.
+        // First pass, apply filter and load row ids.  Rows still in the LSM have not
+        // been flushed to the base table and so have no row id yet; they cannot be part
+        // of a permutation.
         //
-        // This scan's row order is load-bearing: `Shuffler` permutes positions rather
-        // than values, so the permutation is a function of (scan order, seed).  Every
-        // rank builds its own permutation and they have to agree, or splits overlap and
-        // rows are trained twice or not at all.  Locally that holds because a scan
-        // reads fragments in manifest order; remotely it depends on the server
-        // returning a stable order for the same table version.
+        // `Shuffler` permutes positions, so every rank must scan the rows in the same
+        // order to build the same permutation.
         let mut rows = self
             .base_table
             .query()

--- a/rust/lancedb/src/dataloader/permutation/builder.rs
+++ b/rust/lancedb/src/dataloader/permutation/builder.rs
@@ -21,6 +21,7 @@ use crate::{
         util::{TemporaryDirectory, rename_column},
     },
     query::{ExecutableQuery, QueryBase, Select},
+    table::Filter,
 };
 
 pub const SRC_ROW_ID_COL: &str = "row_id";
@@ -238,8 +239,14 @@ impl PermutationBuilder {
 
     /// Builds the permutation table and stores it in the given database.
     pub async fn build(self) -> Result<Table> {
-        // First pass, apply filter and load row ids
-        let mut rows = self.base_table.query().select(Select::columns(&[ROW_ID]));
+        // First pass, apply filter and load row ids.  A permutation addresses rows by
+        // stable `_rowid`, which the MemWAL LSM scanner does not expose, so it always
+        // reads the base table.
+        let mut rows = self
+            .base_table
+            .query()
+            .select(Select::columns(&[ROW_ID]))
+            .use_lsm(false);
 
         if let Some(filter) = &self.config.filter {
             rows = rows.only_if(filter);
@@ -256,9 +263,12 @@ impl PermutationBuilder {
         // split id)
         rows = splitter.project(rows);
 
+        // Base-only, to agree with the scan above.  On a remote MemWAL table a plain
+        // `count_rows` is rejected outright rather than merely disagreeing.
         let num_rows = self
             .base_table
-            .count_rows(self.config.filter.clone())
+            .base_table()
+            .count_base_rows(self.config.filter.clone().map(Filter::Sql))
             .await? as u64;
 
         // Apply splits

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -499,14 +499,11 @@ impl PermutationReader {
     pub async fn output_schema(&self, selection: Select) -> Result<SchemaRef> {
         let table = Table::from(self.base_table.clone());
         // limit(1) because some table types may require executing the
-        // query to determine the output schema.  use_lsm(false) because a
-        // Permutation's selection is a dynamic projection, which the LSM
-        // scanner rejects.
+        // query to determine the output schema
         table
             .query()
             .select(selection)
             .limit(1)
-            .use_lsm(false)
             .output_schema()
             .await
     }
@@ -1035,62 +1032,5 @@ mod tests {
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.schema().field(0).name(), "idx");
-    }
-
-    /// `Permutation` keeps its selection as a dynamic projection, which the LSM scanner
-    /// rejects — so schema lookups have to read the base table like every other
-    /// permutation read does, or `Permutation.schema` fails on a MemWAL table.
-    #[tokio::test]
-    async fn test_output_schema_dynamic_selection_on_mem_wal_table() {
-        use crate::connect;
-        use crate::dataloader::permutation::builder::PermutationBuilder;
-        use crate::table::LsmWriteSpec;
-        use arrow_array::{Int32Array, RecordBatchIterator};
-
-        // MemWAL needs a real dataset directory rather than an in-memory table, and a
-        // primary key column that is not nullable.
-        let temp_dir = tempfile::tempdir().unwrap();
-        let db = connect(temp_dir.path().to_str().unwrap())
-            .execute()
-            .await
-            .unwrap();
-        let schema = Arc::new(Schema::new(vec![Field::new("idx", DataType::Int32, false)]));
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(Int32Array::from(vec![0, 1, 2, 3]))],
-        )
-        .unwrap();
-        let reader: Box<dyn arrow_array::RecordBatchReader + Send> =
-            Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema.clone()));
-        let base_table = db.create_table("tbl", reader).execute().await.unwrap();
-        base_table
-            .set_unenforced_primary_key(["idx"])
-            .await
-            .unwrap();
-        base_table
-            .set_lsm_write_spec(LsmWriteSpec::unsharded())
-            .await
-            .unwrap();
-
-        let permutation_table = PermutationBuilder::new(base_table.clone())
-            .build()
-            .await
-            .unwrap();
-        let reader = PermutationReader::try_from_tables(
-            base_table.base_table().clone(),
-            permutation_table.base_table().clone(),
-            0,
-        )
-        .await
-        .unwrap();
-
-        let schema = reader
-            .output_schema(Select::Dynamic(vec![(
-                "idx".to_string(),
-                "idx".to_string(),
-            )]))
-            .await
-            .unwrap();
-        assert_eq!(schema.field(0).name(), "idx");
     }
 }

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -99,9 +99,7 @@ impl PermutationReader {
 
     /// A reader over the base table in storage order, with no permutation.
     ///
-    /// Fallible: construction counts the base table, which for a remote table is an
-    /// HTTP round trip, so a transient network or auth failure must surface as an
-    /// error rather than a panic across a binding boundary.
+    /// Fallible because construction counts the base table, which can fail.
     pub async fn identity(base_table: Arc<dyn BaseTable>) -> Result<Self> {
         Self::inner_new(base_table, None, 0).await
     }
@@ -209,8 +207,8 @@ impl PermutationReader {
             filter: Some(QueryFilter::Datafusion(col(ROW_ID).in_list(in_list, false))),
             select: selection,
             with_row_id: true,
-            // The permutation is defined over stable `_rowid`s, which the MemWAL LSM
-            // scanner does not expose — and which it rejects `with_row_id` for.
+            // Rows still in the LSM have no row id, so they cannot match a row id
+            // take and are not part of the data loader's view of the table.
             use_lsm: Some(false),
             ..Default::default()
         };
@@ -402,7 +400,7 @@ impl PermutationReader {
                 .query(
                     &AnyQuery::Query(QueryRequest {
                         select: Select::Columns(vec![ROW_ID.to_string()]),
-                        // See `load_batch`: the permutation reads the base table.
+                        // See `load_batch`: rows still in the LSM have no row id.
                         use_lsm: Some(false),
                         offset: self.offset.map(|o| o as usize),
                         limit: self.limit.map(|l| l as usize),
@@ -500,19 +498,12 @@ impl PermutationReader {
 
     pub async fn output_schema(&self, selection: Select) -> Result<SchemaRef> {
         let table = Table::from(self.base_table.clone());
-        // `output_schema` reads the schema off a query plan, and building a plan on a
-        // remote table executes the query.  Unbounded that is a full table scan over
-        // HTTP for every `Permutation` constructed — once per split, per epoch.
-        //
-        // One row, not zero: lance reads a limit of `Some(0)` as *no limit* rather than
-        // no rows (`Scanner`: `self.limit.unwrap_or(0) > 0` gates the limit node), so a
-        // zero here would scan the whole table.  Native tables never execute the plan,
-        // so the bound costs them nothing.
+        // limit(1) because some table types may require executing the
+        // query to determine the output schema
         table
             .query()
             .select(selection)
             .limit(1)
-            .use_lsm(false)
             .output_schema()
             .await
     }

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -499,11 +499,14 @@ impl PermutationReader {
     pub async fn output_schema(&self, selection: Select) -> Result<SchemaRef> {
         let table = Table::from(self.base_table.clone());
         // limit(1) because some table types may require executing the
-        // query to determine the output schema
+        // query to determine the output schema.  use_lsm(false) because a
+        // Permutation's selection is a dynamic projection, which the LSM
+        // scanner rejects.
         table
             .query()
             .select(selection)
             .limit(1)
+            .use_lsm(false)
             .output_schema()
             .await
     }
@@ -1032,5 +1035,62 @@ mod tests {
         assert_eq!(batch.num_rows(), 0);
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.schema().field(0).name(), "idx");
+    }
+
+    /// `Permutation` keeps its selection as a dynamic projection, which the LSM scanner
+    /// rejects — so schema lookups have to read the base table like every other
+    /// permutation read does, or `Permutation.schema` fails on a MemWAL table.
+    #[tokio::test]
+    async fn test_output_schema_dynamic_selection_on_mem_wal_table() {
+        use crate::connect;
+        use crate::dataloader::permutation::builder::PermutationBuilder;
+        use crate::table::LsmWriteSpec;
+        use arrow_array::{Int32Array, RecordBatchIterator};
+
+        // MemWAL needs a real dataset directory rather than an in-memory table, and a
+        // primary key column that is not nullable.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = connect(temp_dir.path().to_str().unwrap())
+            .execute()
+            .await
+            .unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("idx", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![0, 1, 2, 3]))],
+        )
+        .unwrap();
+        let reader: Box<dyn arrow_array::RecordBatchReader + Send> =
+            Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema.clone()));
+        let base_table = db.create_table("tbl", reader).execute().await.unwrap();
+        base_table
+            .set_unenforced_primary_key(["idx"])
+            .await
+            .unwrap();
+        base_table
+            .set_lsm_write_spec(LsmWriteSpec::unsharded())
+            .await
+            .unwrap();
+
+        let permutation_table = PermutationBuilder::new(base_table.clone())
+            .build()
+            .await
+            .unwrap();
+        let reader = PermutationReader::try_from_tables(
+            base_table.base_table().clone(),
+            permutation_table.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        let schema = reader
+            .output_schema(Select::Dynamic(vec![(
+                "idx".to_string(),
+                "idx".to_string(),
+            )]))
+            .await
+            .unwrap();
+        assert_eq!(schema.field(0).name(), "idx");
     }
 }

--- a/rust/lancedb/src/dataloader/permutation/reader.rs
+++ b/rust/lancedb/src/dataloader/permutation/reader.rs
@@ -97,8 +97,13 @@ impl PermutationReader {
         Self::inner_new(base_table, Some(permutation_table), split).await
     }
 
-    pub async fn identity(base_table: Arc<dyn BaseTable>) -> Self {
-        Self::inner_new(base_table, None, 0).await.unwrap()
+    /// A reader over the base table in storage order, with no permutation.
+    ///
+    /// Fallible: construction counts the base table, which for a remote table is an
+    /// HTTP round trip, so a transient network or auth failure must surface as an
+    /// error rather than a panic across a binding boundary.
+    pub async fn identity(base_table: Arc<dyn BaseTable>) -> Result<Self> {
+        Self::inner_new(base_table, None, 0).await
     }
 
     /// Validates the limit and offset and returns the number of rows that will be read
@@ -153,7 +158,8 @@ impl PermutationReader {
                 ))))
                 .await? as u64
         } else {
-            self.base_table.count_rows(None).await? as u64
+            // Base-only, to agree with the base-only identity scan in `read`.
+            self.base_table.count_base_rows(None).await? as u64
         };
         Self::validate_limit_offset(limit, offset, available_rows)
     }
@@ -203,6 +209,9 @@ impl PermutationReader {
             filter: Some(QueryFilter::Datafusion(col(ROW_ID).in_list(in_list, false))),
             select: selection,
             with_row_id: true,
+            // The permutation is defined over stable `_rowid`s, which the MemWAL LSM
+            // scanner does not expose — and which it rejects `with_row_id` for.
+            use_lsm: Some(false),
             ..Default::default()
         };
 
@@ -359,7 +368,8 @@ impl PermutationReader {
         let avail_rows = if let Some(permutation_table) = &self.permutation_table {
             permutation_table.count_rows(None).await? as u64
         } else {
-            self.base_table.count_rows(None).await? as u64
+            // Base-only, to agree with the base-only identity scan in `read`.
+            self.base_table.count_base_rows(None).await? as u64
         };
         Self::validate_limit_offset(self.limit, self.offset, avail_rows)?;
         Ok(())
@@ -392,6 +402,8 @@ impl PermutationReader {
                 .query(
                     &AnyQuery::Query(QueryRequest {
                         select: Select::Columns(vec![ROW_ID.to_string()]),
+                        // See `load_batch`: the permutation reads the base table.
+                        use_lsm: Some(false),
                         offset: self.offset.map(|o| o as usize),
                         limit: self.limit.map(|l| l as usize),
                         ..Default::default()
@@ -468,6 +480,7 @@ impl PermutationReader {
             let batches = table
                 .take_offsets(offsets.to_vec())
                 .select(selection.clone())
+                .use_lsm(false)
                 .execute()
                 .await?
                 .try_collect::<Vec<_>>()
@@ -487,7 +500,21 @@ impl PermutationReader {
 
     pub async fn output_schema(&self, selection: Select) -> Result<SchemaRef> {
         let table = Table::from(self.base_table.clone());
-        table.query().select(selection).output_schema().await
+        // `output_schema` reads the schema off a query plan, and building a plan on a
+        // remote table executes the query.  Unbounded that is a full table scan over
+        // HTTP for every `Permutation` constructed — once per split, per epoch.
+        //
+        // One row, not zero: lance reads a limit of `Some(0)` as *no limit* rather than
+        // no rows (`Scanner`: `self.limit.unwrap_or(0) > 0` gates the limit node), so a
+        // zero here would scan the whole table.  Native tables never execute the plan,
+        // so the bound costs them nothing.
+        table
+            .query()
+            .select(selection)
+            .limit(1)
+            .use_lsm(false)
+            .output_schema()
+            .await
     }
 
     pub fn count_rows(&self) -> u64 {
@@ -779,7 +806,9 @@ mod tests {
             .into_mem_table("tbl", RowCount::from(10), BatchCount::from(1))
             .await;
 
-        let reader = PermutationReader::identity(base_table.base_table().clone()).await;
+        let reader = PermutationReader::identity(base_table.base_table().clone())
+            .await
+            .unwrap();
 
         // With no permutation table, take_offsets uses the base table directly
         let offsets = vec![0, 2, 4, 6];
@@ -961,7 +990,9 @@ mod tests {
             .into_mem_table("tbl", RowCount::from(10), BatchCount::from(1))
             .await;
 
-        let reader = PermutationReader::identity(base_table.base_table().clone()).await;
+        let reader = PermutationReader::identity(base_table.base_table().clone())
+            .await
+            .unwrap();
 
         let batch = reader.take_offsets(&[], Select::All).await.unwrap();
 

--- a/rust/lancedb/src/remote/table.rs
+++ b/rust/lancedb/src/remote/table.rs
@@ -1142,6 +1142,54 @@ impl<S: HttpSend> RemoteTable<S> {
         }
     }
 
+    async fn count_rows_impl(
+        &self,
+        filter: Option<Filter>,
+        use_lsm: Option<bool>,
+    ) -> Result<usize> {
+        let mut request = self.post_read(&format!("/v1/table/{}/count_rows/", self.identifier));
+
+        let version = self.current_version().await;
+
+        let mut body = if let Some(filter) = filter {
+            let filter_sql = match filter {
+                Filter::Sql(sql) => sql.clone(),
+                Filter::Datafusion(expr) => expr_to_sql_string(&expr)?,
+            };
+            serde_json::json!({ "predicate": filter_sql, "version": version })
+        } else {
+            serde_json::json!({ "version": version })
+        };
+        // Only forward when explicitly set; a server that predates the field ignores
+        // it and counts as it would by default.
+        if let Some(use_lsm) = use_lsm {
+            body["use_lsm"] = serde_json::Value::Bool(use_lsm);
+        }
+        self.apply_branch_body(&mut body);
+        request = request.json(&body);
+
+        let (request_id, response) = match self.send(request, true).await {
+            Ok((id, resp)) => {
+                // check_table_response now handles error-based invalidation
+                let response = self.check_table_response(&id, resp).await?;
+                (id, response)
+            }
+            Err(e) => {
+                self.handle_error_invalidation(&e);
+                return Err(e);
+            }
+        };
+
+        self.track_read_version_from_headers(response.headers());
+        let body = response.text().await.err_to_http(request_id.clone())?;
+
+        serde_json::from_str(&body).map_err(|e| Error::Http {
+            source: format!("Failed to parse row count: {}", e).into(),
+            request_id,
+            status_code: None,
+        })
+    }
+
     fn invalidate_schema_cache(&self) {
         self.schema_cache.invalidate();
     }
@@ -2106,42 +2154,15 @@ impl<S: HttpSend> BaseTable for RemoteTable<S> {
     }
 
     async fn count_rows(&self, filter: Option<Filter>) -> Result<usize> {
-        let mut request = self.post_read(&format!("/v1/table/{}/count_rows/", self.identifier));
+        self.count_rows_impl(filter, None).await
+    }
 
-        let version = self.current_version().await;
-
-        let mut body = if let Some(filter) = filter {
-            let filter_sql = match filter {
-                Filter::Sql(sql) => sql.clone(),
-                Filter::Datafusion(expr) => expr_to_sql_string(&expr)?,
-            };
-            serde_json::json!({ "predicate": filter_sql, "version": version })
-        } else {
-            serde_json::json!({ "version": version })
-        };
-        self.apply_branch_body(&mut body);
-        request = request.json(&body);
-
-        let (request_id, response) = match self.send(request, true).await {
-            Ok((id, resp)) => {
-                // check_table_response now handles error-based invalidation
-                let response = self.check_table_response(&id, resp).await?;
-                (id, response)
-            }
-            Err(e) => {
-                self.handle_error_invalidation(&e);
-                return Err(e);
-            }
-        };
-
-        self.track_read_version_from_headers(response.headers());
-        let body = response.text().await.err_to_http(request_id.clone())?;
-
-        serde_json::from_str(&body).map_err(|e| Error::Http {
-            source: format!("Failed to parse row count: {}", e).into(),
-            request_id,
-            status_code: None,
-        })
+    /// The server rejects `count_rows` outright on a table carrying a MemWAL write
+    /// spec, because the count would silently omit every un-compacted row.  Sending
+    /// `use_lsm: false` asks for the base-only count explicitly, which is what a
+    /// caller addressing rows by `_rowid` needs.
+    async fn count_base_rows(&self, filter: Option<Filter>) -> Result<usize> {
+        self.count_rows_impl(filter, Some(false)).await
     }
     async fn add(&self, mut add: AddDataBuilder) -> Result<AddResult> {
         self.check_mutable().await?;
@@ -4901,6 +4922,98 @@ mod tests {
             .execute()
             .await
             .unwrap();
+    }
+
+    /// The permutation reads the base table: a plain `count_rows` is rejected outright
+    /// by the server on a table with a MemWAL write spec, so the base-only variant has
+    /// to say so explicitly.
+    #[tokio::test]
+    async fn test_count_base_rows_asks_for_the_base_table() {
+        let captured = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let seen = captured.clone();
+        let table = Table::new_with_handler("my_table", move |request: reqwest::Request| {
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+            *seen.lock().unwrap() = Some(body);
+            http::Response::builder().status(200).body("7").unwrap()
+        });
+
+        assert_eq!(table.base_table().count_base_rows(None).await.unwrap(), 7);
+        assert_eq!(
+            captured.lock().unwrap().clone().unwrap()["use_lsm"],
+            json!(false)
+        );
+
+        // A plain count must not pick the flag up by accident.
+        let captured = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let seen = captured.clone();
+        let table = Table::new_with_handler("my_table", move |request: reqwest::Request| {
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+            *seen.lock().unwrap() = Some(body);
+            http::Response::builder().status(200).body("7").unwrap()
+        });
+        assert_eq!(table.count_rows(None).await.unwrap(), 7);
+        assert_eq!(
+            captured.lock().unwrap().clone().unwrap().get("use_lsm"),
+            None
+        );
+    }
+
+    /// Reading a schema builds a plan, and building a plan on a remote table executes
+    /// the query. Bounded, or every `Permutation` construction — one per split, per
+    /// epoch — scans the whole table.
+    #[tokio::test]
+    async fn test_permutation_output_schema_is_bounded() {
+        use crate::dataloader::permutation::reader::PermutationReader;
+
+        let captured = Arc::new(std::sync::Mutex::new(None::<serde_json::Value>));
+        let seen = captured.clone();
+        let base = Table::new_with_handler("my_table", move |request: reqwest::Request| {
+            let body: serde_json::Value =
+                serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+            *seen.lock().unwrap() = Some(body);
+            let data = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new("idx", DataType::Int32, false)])),
+                vec![Arc::new(Int32Array::from(vec![1]))],
+            )
+            .unwrap();
+            http::Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, ARROW_FILE_CONTENT_TYPE)
+                .body(write_ipc_file(&data))
+                .unwrap()
+        });
+
+        let split_ids = arrow_array::UInt64Array::from(vec![0u64]);
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("row_id", DataType::UInt64, false),
+                Field::new("split_id", DataType::UInt64, false),
+            ])),
+            vec![
+                Arc::new(arrow_array::UInt64Array::from(vec![7u64])),
+                Arc::new(split_ids),
+            ],
+        )
+        .unwrap();
+        let permutation = crate::test_utils::datagen::virtual_table("permutation", &batch).await;
+
+        let reader = PermutationReader::try_from_tables(
+            base.base_table().clone(),
+            permutation.base_table().clone(),
+            0,
+        )
+        .await
+        .unwrap();
+
+        let schema = reader.output_schema(Select::All).await.unwrap();
+        assert_eq!(schema.field(0).name(), "idx");
+        assert_eq!(
+            captured.lock().unwrap().clone().unwrap()["k"],
+            json!(1),
+            "the schema probe must not be an open scan"
+        );
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -562,6 +562,18 @@ pub trait BaseTable: std::fmt::Display + std::fmt::Debug + Send + Sync {
     async fn schema(&self) -> Result<SchemaRef>;
     /// Count the number of rows in this table.
     async fn count_rows(&self, filter: Option<Filter>) -> Result<usize>;
+    /// Count rows in the base table, ignoring any MemWAL.
+    ///
+    /// The default is [`Self::count_rows`], which is already base-only for tables
+    /// backed by a Lance dataset. Implementations whose plain count would include —
+    /// or refuse because of — un-compacted MemWAL data override this.
+    ///
+    /// Callers that address rows by `_rowid` need it: only base-table rows have a
+    /// stable one, so a count that disagrees with what a base-only scan returns
+    /// would mis-size the result (see [`crate::dataloader::permutation`]).
+    async fn count_base_rows(&self, filter: Option<Filter>) -> Result<usize> {
+        self.count_rows(filter).await
+    }
     /// Create a physical plan for the query.
     async fn create_plan(
         &self,


### PR DESCRIPTION
`StreamingDataset`, `PermutationBuilder`, and `Permutation` now work against a `RemoteTable` (LanceDB Cloud and Enterprise), which unblocks benchmarking the loader against the enterprise cluster cache.

```python
db = lancedb.connect("db://my-db", api_key=..., host_override=...)
ds = StreamingDataset(db.open_table("training"), world_size=8, rank=r)
```

Rows are addressed by `_rowid` exactly as before — `PermutationReader::load_batch` already built the same `_rowid IN (...)` filter `Table::take_row_ids` sends, so the loader's fetch was always the take path. It just was never allowed to run.

### What changes

**The Python guard.** `PermutationBuilder.__init__` rejected anything without `_inner`, so a `RemoteTable` raised `TypeError` before reaching the PyO3 layer — which already unwraps one via `_table._inner`.

**A bounded schema probe.** `PermutationReader::output_schema` reads the schema off a query plan, and building a plan on a remote table *executes* the query (`create_plan` → `execute_query`). With no limit that is `k = isize::MAX`, so asking a remote table for its output schema pulled the whole table over HTTP and discarded it — once per assigned split, on every epoch, since `StreamingDataset.__iter__` constructs a `Permutation` per split. Now bounded at one row. Native tables never execute the plan, so it costs them nothing.

One row rather than zero, deliberately: lance gates its limit node on `self.limit.unwrap_or(0) > 0`, so `Some(0)` means *no limit*.

**Base-table reads for MemWAL.** A permutation is an addressing of rows by stable `_rowid`, and the LSM scanner exposes `_rowaddr` instead — both backends reject `with_row_id` on a table with a MemWAL write spec. Since `load_batch` needs `_rowid` back to restore the requested order, the loader errors on any such table today, locally too. Every base-table read now sets `use_lsm(false)`.

`count_rows` had no way to say that, and the server rejects the call outright on a WAL table (its own comment: *"lancedb's `count_rows` has no `use_lsm` to mirror"*), so `BaseTable` gains `count_base_rows` — default delegates to `count_rows`, so no implementor changes, and `RemoteTable` overrides it. Consequence, stated in the docstrings: rows in an uncompacted MemWAL are not part of the permutation.

**Fallible identity construction.** `PermutationReader::identity` resolved `inner_new` with `unwrap`. That was near-total against a local dataset, but construction counts the base table — an HTTP round trip for a remote one — so a transient network or auth failure became a panic across the PyO3 boundary.

### Tests

Mocked-endpoint tests pin the wire shapes (base-only count sends `use_lsm: false`, a plain count does not; the schema probe sends `k: 1`), plus end-to-end `permutation_builder` and `StreamingDataset` runs against a mock server in Python — the former torch-free, so it runs wherever the suite does.