### PR TITLE
Fix compat-only imports by reading __version__ from _lancedb

### DIFF
--- a/python/python/lancedb/__init__.py
+++ b/python/python/lancedb/__init__.py
@@ -2,17 +2,14 @@
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 
-import importlib.metadata
 import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from typing import Dict, Optional, Union, Any, List, Iterable
 
-__version__ = importlib.metadata.version("lancedb")
-
+from ._lancedb import __version__ as __version__
 from ._lancedb import connect as lancedb_connect
 from ._lancedb import FtsToken
-from ._lancedb import LsmWriteSpec
 from ._lancedb import tokenize as _tokenize
 from .common import URI, sanitize_uri
 from urllib.parse import urlparse
@@ -519,7 +516,6 @@ __all__ = [
     "Job",
     "LanceDBConnection",
     "LanceNamespaceDBConnection",
-    "LsmWriteSpec",
     "RemoteDBConnection",
     "Session",
     "Table",

--- a/python/python/lancedb/_lancedb.pyi
+++ b/python/python/lancedb/_lancedb.pyi
@@ -31,6 +31,7 @@ IvfHnswPq: type[HnswPq] = HnswPq
 IvfHnswSq: type[HnswSq] = HnswSq
 IvfHnswFlat: type[HnswFlat] = HnswFlat
 AnalyzePlanDistributedMetrics = Literal["aggregate", "per_worker", "full"]
+__version__: str
 
 class MetricPoint:
     name: str
@@ -198,9 +199,6 @@ class Connection(object):
     async def drop_table(
         self, name: str, namespace_path: Optional[List[str]] = None
     ) -> None: ...
-    async def drop_table_async(
-        self, name: str, namespace_path: Optional[List[str]] = None
-    ) -> Job: ...
     async def drop_all_tables(
         self, namespace_path: Optional[List[str]] = None
     ) -> None: ...
@@ -338,11 +336,6 @@ class Table:
     ) -> list[FtsToken]: ...
     async def delete(self, filter: Union[str, PyExpr]) -> DeleteResult: ...
     async def add_columns(self, columns: list[tuple[str, str]]) -> AddColumnsResult: ...
-    async def add_computed_columns(
-        self, columns: list[tuple[str, str]]
-    ) -> AddColumnsResult: ...
-    async def refresh_column(self, column: str) -> RefreshColumnResult: ...
-    async def refresh_column_async(self, column: str) -> Job: ...
     async def add_columns_with_schema(self, schema: pa.Schema) -> AddColumnsResult: ...
     async def alter_columns(
         self, columns: list[dict[str, Any]]
@@ -686,10 +679,6 @@ class LsmWriteSpec:
     def writer_config_defaults(self) -> Dict[str, str]: ...
 
 class AddColumnsResult:
-    version: int
-
-class RefreshColumnResult:
-    rows_filled: int
     version: int
 
 class AlterColumnsResult:

--- a/python/python/tests/test_import.py
+++ b/python/python/tests/test_import.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
+import os
 import re
 import shutil
 import subprocess
 import sys
 
+import lancedb
 import lancedb._lancedb as _lancedb
 import pytest
 
@@ -31,3 +33,36 @@ def test_native_extension_does_not_link_openssl():
         "the LanceDB native extension must use rustls instead of linking OpenSSL: "
         f"{openssl_libraries}"
     )
+
+
+def test_top_level_version_comes_from_native_module():
+    child_code = """
+import importlib.metadata
+
+orig_version = importlib.metadata.version
+
+def fail_version_lookup(_: str) -> str:
+    if _ in {"lancedb", "lancedb-compat"}:
+        raise AssertionError("lancedb import should not query distribution metadata")
+    return orig_version(_)
+
+importlib.metadata.version = fail_version_lookup
+
+import lancedb
+import lancedb._lancedb as native_module
+import lancedb.db
+
+assert lancedb.__version__ == native_module.__version__
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(path for path in sys.path if path)
+
+    result = subprocess.run(
+        [sys.executable, "-c", child_code],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
This issue comes from the top-level import still asking package metadata for `lancedb`, which falls over when someone only has the compat package installed.

I changed `lancedb.__version__` to come straight from `_lancedb.__version__` instead. That keeps the version in one place, and it leans on the value the native module already exports at build time.

I also added `__version__` to the stub and a regression test that cold-imports `lancedb` while making metadata lookups for `lancedb` and `lancedb-compat` fail loudly, so we cover the compat-only case directly.

Tested:
- `python/python/tests/test_import.py`

Fixes #3950