### PR TITLE
chore: enforce shared workspace dependencies via cargo-deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lance-testing = { "version" = "=11.0.0-beta.15", "tag" = "v11.0.0-beta.15", "git
 lance-datafusion = { "version" = "=11.0.0-beta.15", "tag" = "v11.0.0-beta.15", "git" = "https://github.com/lance-format/lance.git" }
 lance-encoding = { "version" = "=11.0.0-beta.15", "tag" = "v11.0.0-beta.15", "git" = "https://github.com/lance-format/lance.git" }
 lance-arrow = { "version" = "=11.0.0-beta.15", "tag" = "v11.0.0-beta.15", "git" = "https://github.com/lance-format/lance.git" }
+lancedb = { path = "rust/lancedb", default-features = false }
 ahash = "0.8"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false }
@@ -39,6 +40,7 @@ arrow-schema = "58.0.0"
 arrow-select = "58.0.0"
 arrow-cast = "58.0.0"
 async-trait = "0"
+bytes = "1"
 datafusion = { version = "54.0.0", default-features = false }
 datafusion-catalog = "54.0.0"
 datafusion-common = { version = "54.0.0", default-features = false }
@@ -65,7 +67,12 @@ url = "2"
 num-traits = "0.2"
 regex = "1.10"
 semver = "1.0.25"
-chrono = "0.4"
+serde = "1"
+serde_json = "1"
+tempfile = "3.5.0"
+tokio = { version = "1.23", features = ["rt-multi-thread", "sync"] }
+uuid = { version = "1.7.0", features = ["v4"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [profile.ci]
 debug = "line-tables-only"

--- a/deny.toml
+++ b/deny.toml
@@ -177,6 +177,11 @@ multiple-versions = "warn"
 # Wildcard version requirements (`foo = "*"`) are a footgun — they let any
 # future release in without review. Ban them outright.
 wildcards = "deny"
+# Lint every dependency declared by a workspace member against the shared
+# `[workspace.dependencies]` table: any crate used by more than one member must
+# go through `workspace = true`, and entries nothing uses are an error. This
+# keeps versions from drifting between the core crate and the bindings.
+workspace-dependencies = { duplicates = "deny", unused = "deny" }
 # Internal workspace crates reference each other via `path = "..."`, which
 # cargo-deny sees as a wildcard version. That's fine for private workspace
 # members (not published to crates.io), so allow it specifically for paths.

--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -16,12 +16,12 @@ crate-type = ["cdylib"]
 async-trait.workspace = true
 arrow-ipc.workspace = true
 arrow-array.workspace = true
-arrow-buffer = "58.0.0"
+arrow-buffer.workspace = true
 half.workspace = true
 arrow-schema.workspace = true
 env_logger.workspace = true
 futures.workspace = true
-lancedb = { path = "../rust/lancedb", default-features = false }
+lancedb.workspace = true
 lance-namespace.workspace = true
 napi = { version = "3.8.3", default-features = false, features = [
     "napi9",
@@ -29,8 +29,8 @@ napi = { version = "3.8.3", default-features = false, features = [
     "chrono_date",
     "serde-json",
 ] }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-serde_json = "1"
+chrono.workspace = true
+serde_json.workspace = true
 napi-derive = "3.5.2"
 # Prevent dynamic linking of lzma, which comes from datafusion
 lzma-sys = { version = "0.1", features = ["static"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,10 +15,10 @@ name = "_lancedb"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "58.0.0", features = ["pyarrow"] }
-async-trait = "0.1"
-bytes = "1"
-lancedb = { path = "../rust/lancedb", default-features = false }
+arrow = { workspace = true, features = ["pyarrow"] }
+async-trait.workspace = true
+bytes.workspace = true
+lancedb.workspace = true
 datafusion-common.workspace = true
 lance-core.workspace = true
 lance-namespace.workspace = true
@@ -27,17 +27,17 @@ lance-io.workspace = true
 env_logger.workspace = true
 log.workspace = true
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310", "chrono"] }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono.workspace = true
 pyo3-async-runtimes = { version = "0.28", features = [
     "attributes",
     "tokio-runtime",
 ] }
-pin-project = "1.1.5"
+pin-project.workspace = true
 futures.workspace = true
-serde = "1"
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 snafu.workspace = true
-tokio = { version = "1.40", features = ["sync", "rt-multi-thread"] }
+tokio.workspace = true
 libc = "0.2"
 
 [build-dependencies]

--- a/rust/lancedb/Cargo.toml
+++ b/rust/lancedb/Cargo.toml
@@ -51,20 +51,20 @@ metrics = { workspace = true, optional = true }
 metrics-util = { workspace = true, optional = true }
 moka = { workspace = true }
 pin-project = { workspace = true }
-tokio = { version = "1.23", features = ["rt-multi-thread", "sync"] }
+tokio = { workspace = true }
 log.workspace = true
-async-trait = "0"
-bytes = "1"
+async-trait = { workspace = true }
+bytes = { workspace = true }
 futures.workspace = true
 num-traits.workspace = true
 url.workspace = true
 rand.workspace = true
 regex.workspace = true
-serde = { version = "^1" }
-serde_json = { version = "1" }
+serde = { workspace = true }
+serde_json = { workspace = true }
 async-openai = { version = "0.20.0", optional = true }
 serde_with = { version = "3.8.1" }
-tempfile = "3.5.0"
+tempfile = { workspace = true }
 aws-sdk-bedrockruntime = { version = "1.27.0", optional = true }
 # For remote feature
 reqwest = { version = "0.12.0", default-features = false, features = [
@@ -79,7 +79,7 @@ reqwest = { version = "0.12.0", default-features = false, features = [
 ], optional = true }
 http = { version = "1", optional = true } # Matching what is in reqwest
 urlencoding = { version = "2", optional = true }
-uuid = { version = "1.7.0", features = ["v4", "v5"] }
+uuid = { workspace = true, features = ["v5"] }
 polars-arrow = { version = ">=0.37,<0.40.0", optional = true }
 polars = { version = ">=0.37,<0.40.0", optional = true }
 hf-hub = { version = "0.4.1", optional = true, default-features = false, features = [
@@ -96,11 +96,11 @@ semver = { workspace = true }
 [dev-dependencies]
 anyhow = "1"
 lance-testing = { workspace = true }
-tempfile = "3.5.0"
+tempfile = { workspace = true }
 random_word = { version = "0.4.3", features = ["en"] }
 roaring = "0.11.4"
-tokio = { version = "1.23", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "test-util"] }
-uuid = { version = "1.7.0", features = ["v4"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "test-util"] }
+uuid = { workspace = true }
 walkdir = "2"
 aws-sdk-dynamodb = { version = "1.55.0" }
 aws-sdk-s3 = { version = "1.55.0" }


### PR DESCRIPTION
`cargo deny` did not check crate-level dependency declarations against `[workspace.dependencies]`, so a crate used by both the core crate and the bindings could be declared independently in each one and drift. For example `tokio` was pinned at `1.23` in `rust/lancedb` and `1.40` in `python`, and `pin-project` at `1.0.7` in the workspace table but `1.1.5` in `python`.

This PR turns on cargo-deny's `bans.workspace-dependencies` lint, which fails when a dependency is used by more than one member without going through `workspace = true`, and when a `[workspace.dependencies]` entry is used by nobody.

Enabling it surfaced 12 violations. Fixing them means adding `bytes`, `lancedb`, `serde`, `serde_json`, `tempfile`, `tokio`, and `uuid` to `[workspace.dependencies]`, and pointing the `arrow`, `arrow-buffer`, `async-trait`, `chrono`, and `pin-project` declarations at the entries that already existed. `Cargo.lock` is unchanged, so resolution is the same as before.

The shared `chrono` entry now carries `default-features = false, features = ["clock"]`, matching what `nodejs` and `python` already asked for — cargo ignores a member's `default-features = false` unless the workspace entry sets it too. On the targets we build, `clock` covers everything `rust/lancedb` was getting from chrono's defaults.
