### PR TITLE
fix(python): set LsmWriteSpec module metadata

### DIFF
--- a/ci/check_breaking_changes.py
+++ b/ci/check_breaking_changes.py
@@ -2,6 +2,7 @@
 Check whether there are any breaking changes in the PRs between the base and head commits.
 If there are, assert that we have incremented the minor version.
 """
+
 import argparse
 import os
 from packaging.version import parse
@@ -27,7 +28,7 @@ if __name__ == "__main__":
     else:
         print("No breaking changes found.")
         exit(0)
-    
+
     last_stable_version = parse(args.last_stable_version)
     current_version = parse(args.current_version)
     if current_version.minor <= last_stable_version.minor:

--- a/ci/check_lance_release.py
+++ b/ci/check_lance_release.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Determine whether a newer Lance tag exists and expose results for CI."""
+
 from __future__ import annotations
 
 import argparse
@@ -36,8 +37,16 @@ class SemVer:
     prerelease: Tuple[Union[int, str], ...]
 
     def __lt__(self, other: "SemVer") -> bool:  # pragma: no cover - simple comparison
-        if (self.major, self.minor, self.patch) != (other.major, other.minor, other.patch):
-            return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
+        if (self.major, self.minor, self.patch) != (
+            other.major,
+            other.minor,
+            other.patch,
+        ):
+            return (self.major, self.minor, self.patch) < (
+                other.major,
+                other.minor,
+                other.patch,
+            )
         if self.prerelease == other.prerelease:
             return False
         if not self.prerelease:
@@ -142,7 +151,9 @@ def read_current_version(repo_root: Path) -> str:
         deps = data["workspace"]["dependencies"]
         entry = deps["lance"]
     except KeyError as exc:  # pragma: no cover - configuration guard
-        raise RuntimeError("Failed to locate workspace.dependencies.lance in Cargo.toml") from exc
+        raise RuntimeError(
+            "Failed to locate workspace.dependencies.lance in Cargo.toml"
+        ) from exc
 
     if isinstance(entry, str):
         raw_version = entry

--- a/ci/mock_openai.py
+++ b/ci/mock_openai.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The LanceDB Authors
 """A zero-dependency mock OpenAI embeddings API endpoint for testing purposes."""
+
 import argparse
 import json
 import http.server
@@ -22,11 +23,13 @@ class MockOpenAIRequestHandler(http.server.BaseHTTPRequestHandler):
 
         data = []
         for i in range(num_inputs):
-            data.append({
-                "object": "embedding",
-                "embedding": [0.1] * 1536,
-                "index": i,
-            })
+            data.append(
+                {
+                    "object": "embedding",
+                    "embedding": [0.1] * 1536,
+                    "index": i,
+                }
+            )
 
         response = {
             "object": "list",
@@ -35,7 +38,7 @@ class MockOpenAIRequestHandler(http.server.BaseHTTPRequestHandler):
             "usage": {
                 "prompt_tokens": 0,
                 "total_tokens": 0,
-            }
+            },
         }
 
         self.send_response(200)

--- a/ci/semver_sort.py
+++ b/ci/semver_sort.py
@@ -7,6 +7,7 @@ from packaging.version import parse, InvalidVersion
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser()
     parser.add_argument("prefix", default="v")
     args = parser.parse_args()

--- a/ci/set_lance_version.py
+++ b/ci/set_lance_version.py
@@ -22,7 +22,7 @@ def run_command(command: str) -> str:
 def get_latest_stable_version() -> str:
     version_line = run_command("cargo info lance | grep '^version:'")
     # Example output: "version: 0.35.0 (latest 0.37.0)"
-    match = re.search(r'\(latest ([0-9.]+)\)', version_line)
+    match = re.search(r"\(latest ([0-9.]+)\)", version_line)
     if match:
         return match.group(1)
     # Fallback: use the first version after 'version:'
@@ -69,7 +69,7 @@ def extract_default_features(line: str) -> bool:
     """
     import re
 
-    match = re.search(r'default-features\s*=\s*false', line)
+    match = re.search(r"default-features\s*=\s*false", line)
     return match is not None
 
 
@@ -104,7 +104,7 @@ def dict_to_toml_line(package_name: str, config: dict) -> str:
             # This shouldn't happen with our current usage
             parts.append(f'"{key}" = {json.dumps(value)}')
 
-    return f'{package_name} = {{ {", ".join(parts)} }}\n'
+    return f"{package_name} = {{ {', '.join(parts)} }}\n"
 
 
 def update_cargo_toml(line_updater):

--- a/ci/validate_stable_lance.py
+++ b/ci/validate_stable_lance.py
@@ -12,7 +12,7 @@ with open("Cargo.toml", "rb") as f:
             elif isinstance(dep, dict):
                 # Version doesn't have the beta tag in it, so we instead look
                 # at the git tag.
-                version = dep.get('tag', dep.get('version'))
+                version = dep.get("tag", dep.get("version"))
             else:
                 raise ValueError("Unexpected type for dependency: " + str(dep))
 

--- a/plugins/lancedb/skills/lancedb/scripts/check_materialization.py
+++ b/plugins/lancedb/skills/lancedb/scripts/check_materialization.py
@@ -64,7 +64,9 @@ def scan_python(path: Path, text: str) -> list[Finding]:
 
 def statement_around(text: str, start: int, end: int) -> str:
     before = max(text.rfind(";", 0, start), text.rfind("\n\n", 0, start))
-    after_candidates = [pos for pos in (text.find(";", end), text.find("\n\n", end)) if pos != -1]
+    after_candidates = [
+        pos for pos in (text.find(";", end), text.find("\n\n", end)) if pos != -1
+    ]
     after = min(after_candidates) if after_candidates else len(text)
     return text[before + 1 : after].strip()
 

--- a/python/python/tests/test_lsm_write_spec.py
+++ b/python/python/tests/test_lsm_write_spec.py
@@ -21,6 +21,11 @@ SCHEMA = pa.schema(
 )
 
 
+def test_lsm_write_spec_module_metadata():
+    assert lancedb.LsmWriteSpec is LsmWriteSpec
+    assert LsmWriteSpec.__module__ == "lancedb._lancedb"
+
+
 def _batch(ids, vs):
     return pa.RecordBatch.from_arrays(
         [pa.array(ids, type=pa.utf8()), pa.array(vs, type=pa.int32())],

--- a/python/src/table.rs
+++ b/python/src/table.rs
@@ -262,7 +262,7 @@ fn fmt_maintained(maintained: &Option<Vec<String>>) -> String {
 /// classmethods, then optionally chain `with_maintained_indexes(...)` and
 /// `with_writer_config_defaults(...)`. A fresh spec maintains every index the
 /// MemWAL supports, resolved on install.
-#[pyclass(from_py_object)]
+#[pyclass(module = "lancedb._lancedb", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct LsmWriteSpec {
     inner: lancedb::table::LsmWriteSpec,


### PR DESCRIPTION
PyO3 exposed `LsmWriteSpec` with its default `builtins` module, causing mkdocstrings to resolve the public `lancedb.LsmWriteSpec` re-export as `builtins.LsmWriteSpec` and fail the documentation build. Declare the native extension module and pin the public re-export with a regression test.

This also applies the repository's current Ruff formatter to seven previously unformatted Python scripts.
