### PR TITLE
build: avoid fat LTO in local Cargo profiles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,18 @@ debug = true
 codegen-units = 16
 lto = "thin"
 
+[profile.release-no-lto]
+inherits = "release"
+debug = true
+lto = false
+# Prioritize compile time when LTO is not relevant to the measurement.
+codegen-units = 16
+
+[profile.bench]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
 [target.'cfg(all())']
 rustflags = [
     "-Wclippy::all",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ Common commands:
 * Run specific test: `cargo test --quiet --features remote -p <package_name> --test <test_name>`
 * Lint: `cargo clippy --quiet --features remote --tests --examples`
 * Format Rust: `cargo fmt --all`
+* Use repository-defined Cargo profiles instead of ad hoc LTO overrides.
+* Use `release-with-debug` for benchmarks and profiling so optimized builds keep debug symbols without a rebuild.
+* Use `release-no-lto` only for local debugging, IO-bound benchmarks, or compile-time-sensitive performance investigation where LTO would not affect the measured bottleneck.
 * Format Python: `ruff format .`
 * Lint Python: `ruff check .`
 * Bootstrap Python dev env: `cd python && uv run --extra tests --extra dev maturin develop --extras tests,dev`

--- a/rust/lancedb/examples/bench_open_missing_table.rs
+++ b/rust/lancedb/examples/bench_open_missing_table.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
-// Release benchmark for opening a missing table as sibling-table cardinality grows.
+// Benchmark for opening a missing table as sibling-table cardinality grows.
 //
 // The fixture uses real `.lance` directories and marker files. Fixture creation is
 // outside the timed section. Defaults intentionally cover 1k, 10k, and 100k siblings
 // with 10 warmups and 100 distinct missing-table opens per scale:
 //
 // ```text
-// cargo run --release -p lancedb --example bench_open_missing_table
+// cargo run --profile release-no-lto -p lancedb --example bench_open_missing_table
 // ```
 //
 // `BENCH_SIBLINGS`, `BENCH_WARMUPS`, and `BENCH_TRIALS` override those defaults.

--- a/rust/lancedb/examples/bench_streaming_dataloader.rs
+++ b/rust/lancedb/examples/bench_streaming_dataloader.rs
@@ -5,10 +5,10 @@
 //! streaming dataloader.
 //!
 //! Normal sweep:
-//!   cargo run --release --example bench_streaming_dataloader
+//!   cargo run --profile release-with-debug --example bench_streaming_dataloader
 //!
 //! Flamegraph (self-contained, no perf/dtrace needed):
-//!   BENCH_PROFILE=1 BENCH_CHUNK=64 cargo run --release \
+//!   BENCH_PROFILE=1 BENCH_CHUNK=64 cargo run --profile release-with-debug \
 //!       --example bench_streaming_dataloader
 //!   # writes flamegraph.svg in the current directory
 //!


### PR DESCRIPTION
Local benchmarks currently inherit the release profile's fat LTO and single codegen unit, making local iteration pay release-artifact build costs.

Provide repository-defined profiles for no-LTO local work and cheaper benchmark builds, and document when each profile is appropriate. Release artifacts continue to use fat LTO.
