### PR TITLE
fix(python): return None from unit jobs

### DIFF
--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -3947,7 +3947,7 @@ def test_refresh_column_async_returns_job(tmp_path):
 
     job = table.refresh_column_async("doubled")
     assert job.id is None  # in-process jobs have no server id
-    job.wait()
+    assert job.wait() is None
     assert job.status() == "finished"
     assert sorted(table.to_arrow()["doubled"].to_pylist()) == [2, 4]
 
@@ -3963,6 +3963,6 @@ async def test_refresh_column_async_job_async_table(tmp_path):
     await table.add_columns(computed={"tripled": "x * 3"})
 
     job = await table.refresh_column_async("tripled")
-    await job.wait()
+    assert await job.wait() is None
     assert await job.status() == "finished"
     assert (await table.to_arrow())["tripled"].to_pylist() == [9]

--- a/python/src/job.rs
+++ b/python/src/job.rs
@@ -93,7 +93,7 @@ impl Job {
         let inner = self_.inner.clone();
         future_into_py(self_.py(), async move {
             inner.wait().await.infer_error()?;
-            Ok(())
+            Ok(None::<()>)
         })
     }
 


### PR DESCRIPTION
## Problem

Generic job result propagation exposed the PyO3 representation of Rust's unit value as `()` in Python. Unit jobs therefore returned an empty tuple instead of `None`, breaking the documented `Job.wait()` contract and the Python doctest workflow.

## Behavior

Unit job completion now converts explicitly to Python `None`. Typed job results continue to pass through unchanged, with synchronous and asynchronous regression coverage.
