### PR TITLE
fix(python): avoid truncating table_names() at default limit

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -258,7 +258,7 @@ class DBConnection(EnforceOverrides):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:
@@ -272,8 +272,9 @@ class DBConnection(EnforceOverrides):
         page_token: str, optional
             The token to use for pagination. If not present, start from the beginning.
             Typically, this token is last table name from the previous page.
-        limit: int, default 10
-            The size of the page to return.
+        limit: int, optional
+            The size of the page to return. If not present, all table names are
+            returned.
 
         Returns
         -------
@@ -962,7 +963,7 @@ class LanceDBConnection(DBConnection):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:
@@ -977,8 +978,9 @@ class LanceDBConnection(DBConnection):
             The namespace to list tables in.
         page_token: str, optional
             The token to use for pagination.
-        limit: int, default 10
-            The maximum number of tables to return.
+        limit: int, optional
+            The maximum number of tables to return. If not present, all table
+            names are returned.
 
         Returns
         -------

--- a/python/python/lancedb/namespace.py
+++ b/python/python/lancedb/namespace.py
@@ -504,7 +504,7 @@ class LanceNamespaceDBConnection(DBConnection):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:

--- a/python/python/lancedb/remote/db.py
+++ b/python/python/lancedb/remote/db.py
@@ -345,7 +345,7 @@ class RemoteDBConnection(DBConnection):
     def table_names(
         self,
         page_token: Optional[str] = None,
-        limit: int = 10,
+        limit: Optional[int] = None,
         *,
         namespace_path: Optional[List[str]] = None,
     ) -> Iterable[str]:
@@ -361,8 +361,9 @@ class RemoteDBConnection(DBConnection):
             Empty list represents root namespace.
         page_token: str
             The last token to start the new page.
-        limit: int, default 10
-            The maximum number of tables to return for each page.
+        limit: int, optional
+            The maximum number of tables to return for each page. If not present,
+            all table names are returned.
 
         Returns
         -------

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -234,6 +234,16 @@ def test_table_names(tmp_db: lancedb.DBConnection):
     assert len(result) == 3
 
 
+def test_table_names_does_not_truncate_by_default(tmp_db: lancedb.DBConnection):
+    for idx in range(12):
+        tmp_db.create_table(f"table_{idx:02d}", data=[{"id": idx}])
+
+    result = tmp_db.table_names()
+
+    assert len(result) == 12
+    assert result == [f"table_{idx:02d}" for idx in range(12)]
+
+
 def test_db_contains_and_len_include_all_table_name_pages(tmp_db: lancedb.DBConnection):
     for idx in range(20):
         tmp_db.create_table(f"table_{idx}", data=[{"id": idx}])

--- a/python/python/tests/test_namespace.py
+++ b/python/python/tests/test_namespace.py
@@ -358,6 +358,23 @@ class TestNamespaceConnection:
         result = list(db.table_names(namespace_path=["test_ns"]))
         assert "test_table" in result
 
+    def test_table_names_does_not_truncate_by_default(self):
+        """Namespace-backed sync table_names() should not stop at 10 results."""
+        db = lancedb.connect_namespace("dir", {"root": self.temp_dir})
+        db.create_namespace(["test_ns"])
+
+        schema = pa.schema([pa.field("id", pa.int64())])
+        for idx in range(12):
+            db.create_table(
+                f"table_{idx:02d}",
+                schema=schema,
+                namespace_path=["test_ns"],
+            )
+
+        table_names = list(db.table_names(namespace_path=["test_ns"]))
+
+        assert table_names == [f"table_{idx:02d}" for idx in range(12)]
+
     def test_table_operations(self):
         """Test various table operations through namespace."""
         db = lancedb.connect_namespace("dir", {"root": self.temp_dir})


### PR DESCRIPTION
## Summary
Fix sync `table_names()` so it does not truncate results at the default limit of 10.

## Changes
- change sync `table_names()` default limit from `10` to `None`
- keep remote sync behavior consistent
- add a regression test covering more than 10 tables

Closes #3914