### PR TITLE
fix(python): preserve valid embeddings when an OpenAI batch is rejected

### DIFF
--- a/python/python/lancedb/embeddings/openai.py
+++ b/python/python/lancedb/embeddings/openai.py
@@ -98,24 +98,35 @@ class OpenAIEmbeddings(TextEmbeddingFunction):
                 valid_indices.append(idx)
 
         # TODO retry, rate limit, token limit
-        try:
+        def embed_batch(texts_batch, indices_batch):
             kwargs = {
-                "input": valid_texts,
+                "input": texts_batch,
                 "model": self.name,
             }
             if self.name != "text-embedding-ada-002":
                 kwargs["dimensions"] = self.dim
 
             rs = self._openai_client.embeddings.create(**kwargs)
-            valid_embeddings = {
-                idx: v.embedding for v, idx in zip(rs.data, valid_indices)
-            }
+            return {idx: v.embedding for v, idx in zip(rs.data, indices_batch)}
+
+        def embed_one_or_log(idx, text):
+            # Retry a single rejected input
+            try:
+                return embed_batch([text], [idx])
+            except openai.BadRequestError:
+                logging.exception("Bad request for input at index %d: %r", idx, text)
+                return {}
+
+        try:
+            valid_embeddings = embed_batch(valid_texts, valid_indices)
         except openai.AuthenticationError:
             logging.error("Authentication failed: Invalid API key provided")
             raise
         except openai.BadRequestError:
-            logging.exception("Bad request: %s", texts)
-            return [None] * len(texts)
+            # Retry each input individually
+            valid_embeddings = {}
+            for idx, text in zip(valid_indices, valid_texts):
+                valid_embeddings.update(embed_one_or_log(idx, text))
         except Exception:
             logging.exception("OpenAI embeddings error")
             raise

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -6,11 +6,9 @@ import pickle
 from typing import List, Optional, Union
 from unittest.mock import MagicMock, patch
 
-import httpx
 import lance
 import lancedb
 import numpy as np
-import openai
 import pyarrow as pa
 import pytest
 import pandas as pd
@@ -600,20 +598,27 @@ def test_openai_no_retry_on_401(mock_sleep):
 
 def test_openai_bad_request_partial_batch_recovery():
     # Regression test for issue #1677
+
+    # Fake exception types, avoids requiring the optional openai/httpx deps
+    class FakeBadRequestError(Exception):
+        pass
+
+    class FakeAuthenticationError(Exception):
+        pass
+
+    fake_openai_module = MagicMock()
+    fake_openai_module.BadRequestError = FakeBadRequestError
+    fake_openai_module.AuthenticationError = FakeAuthenticationError
+
     registry = get_registry()
     model = registry.get("openai").create(name="text-embedding-ada-002")
-
-    def make_bad_request_error():
-        request = httpx.Request("POST", "https://api.openai.com/v1/embeddings")
-        response = httpx.Response(400, request=request, json={"error": {}})
-        return openai.BadRequestError("bad request", response=response, body=None)
 
     def fake_create(input, model=None, **kwargs):
         # Full batch always rejected
         if len(input) > 1:
-            raise make_bad_request_error()
+            raise FakeBadRequestError("bad request")
         if input[0] == "bad text":
-            raise make_bad_request_error()
+            raise FakeBadRequestError("bad request")
         embedding = MagicMock()
         embedding.embedding = [0.1, 0.2, 0.3]
         result = MagicMock()
@@ -623,7 +628,13 @@ def test_openai_bad_request_partial_batch_recovery():
     mock_client = MagicMock()
     mock_client.embeddings.create.side_effect = fake_create
 
-    with patch.object(type(model), "_openai_client", new_callable=lambda: mock_client):
+    with (
+        patch(
+            "lancedb.embeddings.openai.attempt_import_or_raise",
+            return_value=fake_openai_module,
+        ),
+        patch.object(type(model), "_openai_client", new_callable=lambda: mock_client),
+    ):
         embeddings = model.generate_embeddings(["good text", "bad text"])
 
     assert embeddings[0] == [0.1, 0.2, 0.3]

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -6,9 +6,11 @@ import pickle
 from typing import List, Optional, Union
 from unittest.mock import MagicMock, patch
 
+import httpx
 import lance
 import lancedb
 import numpy as np
+import openai
 import pyarrow as pa
 import pytest
 import pandas as pd
@@ -594,6 +596,38 @@ def test_openai_no_retry_on_401(mock_sleep):
     assert mock_func.call_count == 1
     # Verify that sleep was never called (no retries)
     assert mock_sleep.call_count == 0
+
+
+def test_openai_bad_request_partial_batch_recovery():
+    # Regression test for issue #1677
+    registry = get_registry()
+    model = registry.get("openai").create(name="text-embedding-ada-002")
+
+    def make_bad_request_error():
+        request = httpx.Request("POST", "https://api.openai.com/v1/embeddings")
+        response = httpx.Response(400, request=request, json={"error": {}})
+        return openai.BadRequestError("bad request", response=response, body=None)
+
+    def fake_create(input, model=None, **kwargs):
+        # Full batch always rejected
+        if len(input) > 1:
+            raise make_bad_request_error()
+        if input[0] == "bad text":
+            raise make_bad_request_error()
+        embedding = MagicMock()
+        embedding.embedding = [0.1, 0.2, 0.3]
+        result = MagicMock()
+        result.data = [embedding]
+        return result
+
+    mock_client = MagicMock()
+    mock_client.embeddings.create.side_effect = fake_create
+
+    with patch.object(type(model), "_openai_client", new_callable=lambda: mock_client):
+        embeddings = model.generate_embeddings(["good text", "bad text"])
+
+    assert embeddings[0] == [0.1, 0.2, 0.3]
+    assert embeddings[1] is None
 
 
 def test_ollama_embeddings_pickle():


### PR DESCRIPTION
Retries individual inputs one at a time when the OpenAI API rejects a batch with BadRequestError, instead of discarding the whole batch.
Valid inputs now still get embeddings; only the actually-bad input resolves to None, and the log names the exact failing input.

Fixes #1677 