### PR TITLE
fix(python): use canonical remote function endpoints

### DIFF
--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -162,7 +162,7 @@ def _mock_remote_function_catalog():
             body = json.loads(self.rfile.read(length) or b"{}")
             state["requests"].append((self.path, body))
             status = 200
-            if self.path == "/v1/function/create":
+            if self.path == "/v1/functions/create":
                 state["version"] = {
                     "name": body["name"],
                     "version": "fv_exact",
@@ -187,7 +187,7 @@ def _mock_remote_function_catalog():
                     "job_state": "DONE",
                     "result": state["version"],
                 }
-            elif self.path == "/v1/function/describe":
+            elif self.path == "/v1/functions/get":
                 assert body == {
                     "name": "normalize_score",
                     "version": "fv_exact",
@@ -249,6 +249,6 @@ def test_blocking_remote_registration_returns_function_version():
     assert created.name == "normalize_score"
     assert created.version == "fv_exact"
     assert [path for path, _ in state["requests"]] == [
-        "/v1/function/create",
+        "/v1/functions/create",
         "/v1/jobs/describe",
     ]

--- a/rust/lancedb/src/remote/db.rs
+++ b/rust/lancedb/src/remote/db.rs
@@ -494,7 +494,7 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
         &self,
         request: FunctionRegistrationRequest,
     ) -> Result<Job<FunctionVersion>> {
-        let req = self.client.post("/v1/function/create").json(&request);
+        let req = self.client.post("/v1/functions/create").json(&request);
         let (request_id, response) = self.client.send(req).await?;
         let response = self.client.check_response(&request_id, response).await?;
         let status = response.status();
@@ -513,7 +513,7 @@ impl<S: HttpSend> Database for RemoteDatabase<S> {
     async fn get_function(&self, name: &str, version: &str) -> Result<FunctionVersion> {
         let req = self
             .client
-            .post("/v1/function/describe")
+            .post("/v1/functions/get")
             .json(&serde_json::json!({
                 "name": name,
                 "version": version,
@@ -2489,7 +2489,7 @@ mod tests {
             include_str!("../../tests/fixtures/first_class_functions/v1/remote_function_job.json");
         let expected: serde_json::Value = serde_json::from_str(REQUEST).unwrap();
         let conn = Connection::new_with_handler(move |request| match request.url().path() {
-            "/v1/function/create" => {
+            "/v1/functions/create" => {
                 assert_eq!(request.method(), &reqwest::Method::POST);
                 let body: serde_json::Value =
                     serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
@@ -2520,7 +2520,7 @@ mod tests {
         );
         let conn = Connection::new_with_handler(|request| {
             assert_eq!(request.method(), &reqwest::Method::POST);
-            assert_eq!(request.url().path(), "/v1/function/describe");
+            assert_eq!(request.url().path(), "/v1/functions/get");
             let body: serde_json::Value =
                 serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
             assert_eq!(


### PR DESCRIPTION
Remote Function catalog requests used singular endpoints that are not exposed by Phalanx. Route registration to `POST /v1/functions/create` and exact-version lookup to `POST /v1/functions/get`, while preserving the existing typed Job submission and wait behavior.
