### PR TITLE
fix(python): skip the unrunnable FunctionVersion doctest example

### DIFF
--- a/python/python/lancedb/functions.py
+++ b/python/python/lancedb/functions.py
@@ -281,7 +281,7 @@ class FunctionVersion(_RemoteValue):
         Examples
         --------
         >>> from lancedb import col
-        >>> application = function(
+        >>> application = function(  # doctest: +SKIP
         ...     title=col("title"),
         ...     body=col("body"),
         ... ).rename(columns={


### PR DESCRIPTION
The example binds an undefined `function`; only its last line was skipped, so the doctest suite fails on main and on every PR.