### PR TITLE
fix: preserve file URI authority for Windows UNC database paths

### DIFF
--- a/python/python/lancedb/db.py
+++ b/python/python/lancedb/db.py
@@ -748,20 +748,12 @@ class LanceDBConnection(DBConnection):
         if not isinstance(uri, Path):
             scheme = get_uri_scheme(uri)
         is_local = isinstance(uri, Path) or scheme == "file"
-        if is_local:
+        # A `file:` URI is forwarded untouched, matching `connect_async`. Stripping
+        # the scheme textually would drop the authority, so a Windows UNC URI like
+        # `file://server/share/db` would become the cwd-relative `server/share/db`.
+        is_file_uri = isinstance(uri, str) and uri.lower().startswith("file:")
+        if is_local and not is_file_uri:
             if isinstance(uri, str):
-                # Strip file:// or file:/ scheme if present
-                # file:///path becomes file:/path after URL normalization
-                if uri.startswith("file://"):
-                    uri = uri[7:]  # Remove "file://"
-                elif uri.startswith("file:/"):
-                    uri = uri[5:]  # Remove "file:"
-
-                if sys.platform == "win32":
-                    # On Windows, a path like /C:/path should become C:/path
-                    if len(uri) >= 3 and uri[0] == "/" and uri[2] == ":":
-                        uri = uri[1:]
-
                 uri = Path(uri)
             uri = uri.expanduser().absolute()
             Path(uri).mkdir(parents=True, exist_ok=True)

--- a/python/python/tests/test_db.py
+++ b/python/python/tests/test_db.py
@@ -89,6 +89,61 @@ def test_sync_debugger_inspection_does_not_use_background_loop(tmp_path, monkeyp
     assert repr(table) == f"LanceTable(name='test', _conn={db!r})"
 
 
+def test_connect_preserves_file_uri_authority(monkeypatch):
+    uri = "file://server/share/database"
+    received = []
+
+    async def fake_connect(passed_uri, *_args):
+        received.append(passed_uri)
+        return SimpleNamespace(uri=passed_uri)
+
+    monkeypatch.setattr("lancedb.db.lancedb_connect", fake_connect)
+    db = lancedb.connect(uri)
+
+    assert received == [uri]
+    assert db.uri == uri
+
+
+@pytest.mark.asyncio
+async def test_connect_async_preserves_file_uri_authority(monkeypatch):
+    uri = "file://server/share/database"
+    received = []
+
+    async def fake_connect(passed_uri, *_args):
+        received.append(passed_uri)
+        return SimpleNamespace(uri=passed_uri)
+
+    monkeypatch.setattr(lancedb, "lancedb_connect", fake_connect)
+    db = await lancedb.connect_async(uri)
+
+    assert received == [uri]
+    assert db.uri == uri
+
+
+def test_connect_file_uri_lifecycle(tmp_path):
+    uri = (tmp_path / "sync").as_uri()
+    db = lancedb.connect(uri)
+
+    db.create_table("test", data=[{"id": 1}])
+    assert db.list_tables().tables == ["test"]
+    assert db.open_table("test").count_rows() == 1
+    db.drop_table("test")
+    assert db.list_tables().tables == []
+
+
+@pytest.mark.asyncio
+async def test_connect_async_file_uri_lifecycle(tmp_path):
+    uri = (tmp_path / "async").as_uri()
+    db = await lancedb.connect_async(uri)
+
+    await db.create_table("test", data=[{"id": 1}])
+    assert (await db.list_tables()).tables == ["test"]
+    table = await db.open_table("test")
+    assert await table.count_rows() == 1
+    await db.drop_table("test")
+    assert (await db.list_tables()).tables == []
+
+
 def test_read_consistency_interval_does_not_use_background_loop(tmp_path, monkeypatch):
     from lancedb.background_loop import LOOP
     from lancedb.db import LanceDBConnection

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -662,20 +662,22 @@ impl ListingDatabase {
 
     /// Try to create a local directory to store the lancedb dataset
     fn try_create_dir(path: &str) -> core::result::Result<(), std::io::Error> {
-        // Strip file:// or file:/ scheme if present to get the actual filesystem path
-        // Note: file:///path becomes file:/path after url.to_string(), so we need to handle both
-        let fs_path = if let Some(stripped) = path.strip_prefix("file://") {
-            // file:///path or file://host/path format
-            stripped
-        } else if let Some(stripped) = path.strip_prefix("file:") {
-            // file:/path format (from url.to_string() on file:///path)
-            // The path after "file:" should already start with "/" for absolute paths
-            stripped
-        } else {
-            path
+        // Stripping the scheme textually loses the URL authority, so
+        // `file://server/share/db` becomes the cwd-relative `server/share/db`
+        // instead of the UNC path `\\server\share\db`. `to_file_path` keeps the
+        // authority, and also handles the `file:/C:/...` form that
+        // `Url::to_string` produces on Windows.
+        let filesystem_path = match url::Url::parse(path) {
+            Ok(url) if url.scheme() == "file" => url.to_file_path().map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Unable to convert URL '{url}' to a local path"),
+                )
+            })?,
+            _ => Path::new(path).to_path_buf(),
         };
 
-        let path = Path::new(fs_path);
+        let path = filesystem_path.as_path();
         if !path.try_exists()? {
             create_dir_all(path)?;
         }
@@ -1485,6 +1487,107 @@ mod tests {
     use tempfile::tempdir;
     use tokio::sync::Barrier;
     use tokio::time::timeout;
+
+    #[test]
+    fn try_create_dir_resolves_absolute_file_uris() {
+        let tempdir = tempdir().unwrap();
+        let target = tempdir.path().join("db");
+        let uri = url::Url::from_directory_path(&target).unwrap().to_string();
+
+        ListingDatabase::try_create_dir(&uri).unwrap();
+
+        assert!(target.is_dir());
+    }
+
+    #[test]
+    fn try_create_dir_does_not_drop_a_file_uri_authority() {
+        // `file://host/share/database` is a UNC path, not the relative path
+        // `host/share/database`. Creating the latter would silently place the
+        // database somewhere else entirely. The `.invalid` host keeps the
+        // Windows share lookup from reaching the network.
+        let relative = Path::new("server.invalid").join("share").join("database");
+
+        assert!(ListingDatabase::try_create_dir("file://server.invalid/share/database").is_err());
+        assert!(!relative.exists());
+    }
+
+    /// Regression for #2623: a database opened through a UNC authority must keep
+    /// that authority for every later operation, including reopening a table.
+    ///
+    /// Deliberately not skipped when the administrative share is missing: a
+    /// silent skip is what let this bug survive. It uses the machine's real
+    /// network name because `url` treats `localhost` as an empty authority,
+    /// which would turn `file://localhost/C$/…` back into a drive-relative URI.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn test_reopen_table_through_a_unc_authority() {
+        use std::path::{Component, Prefix};
+
+        let tempdir = tempdir().unwrap();
+        let drive = match tempdir.path().components().next() {
+            Some(Component::Prefix(prefix)) => match prefix.kind() {
+                Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => drive,
+                other => panic!("expected a drive-backed temporary directory, got {other:?}"),
+            },
+            other => panic!("expected an absolute Windows temporary directory, got {other:?}"),
+        };
+        let drive_root = PathBuf::from(format!("{}:\\", drive as char));
+        let relative = tempdir.path().strip_prefix(&drive_root).unwrap();
+        let computer_name =
+            std::env::var("COMPUTERNAME").expect("COMPUTERNAME is required to build a UNC path");
+        let unc_path = PathBuf::from(format!(r"\\{}\{}$", computer_name, drive as char))
+            .join(relative)
+            .join("db");
+        let uri = url::Url::from_directory_path(&unc_path)
+            .unwrap()
+            .to_string();
+
+        let request = ConnectRequest {
+            uri,
+            #[cfg(feature = "remote")]
+            client_config: Default::default(),
+            options: Default::default(),
+            namespace_client_properties: Default::default(),
+            manifest_enabled: false,
+            read_consistency_interval: None,
+            session: None,
+        };
+        let db = ListingDatabase::connect_with_options(&request)
+            .await
+            .unwrap();
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let table = db
+            .create_table(CreateTableRequest {
+                name: "unc_reopen".to_string(),
+                namespace_path: vec![],
+                data: Box::new(
+                    RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
+                        .unwrap(),
+                ) as Box<dyn Scannable>,
+                mode: CreateTableMode::Create,
+                write_options: Default::default(),
+                location: None,
+                namespace_client: None,
+            })
+            .await
+            .unwrap();
+        drop(table);
+
+        let reopened = db
+            .open_table(OpenTableRequest {
+                name: "unc_reopen".to_string(),
+                namespace_path: vec![],
+                index_cache_size: None,
+                lance_read_params: None,
+                location: None,
+                namespace_client: None,
+                managed_versioning: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(reopened.count_rows(None).await.unwrap(), 3);
+    }
 
     async fn setup_database() -> (tempfile::TempDir, ListingDatabase) {
         let tempdir = tempdir().unwrap();
@@ -2847,18 +2950,14 @@ mod tests {
     /// as `path=<base table>` + `query=/_mem_wal/...`, causing
     /// `Dataset::write` to find the base table dataset and falsely
     /// report `Dataset already exists`.
-    ///
-    /// Skipped on Windows: `try_create_dir` does not understand
-    /// `file:///C:/…` paths so `connect_with_options` fails before
-    /// even reaching the URL-mutation logic. The pure URL-mutation
-    /// invariant is covered by
-    /// `test_capture_query_treats_empty_as_none` above, which runs
-    /// on all platforms.
-    #[cfg(not(windows))]
     #[tokio::test]
     async fn test_table_uri_url_path_has_no_trailing_question_mark() {
         let tempdir = tempdir().unwrap();
-        let uri = format!("file://{}", tempdir.path().to_str().unwrap());
+        let uri = url::Url::from_directory_path(tempdir.path())
+            .unwrap()
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let request = ConnectRequest {
             uri: uri.clone(),


### PR DESCRIPTION
Opening a database on a Windows UNC path failed with `Unable to convert URL "file:///DataBase/lancedb/..." to filesystem path` — the server name had gone missing from the path.

The underlying cause in Lance was fixed by [`fix(io): preserve Windows UNC share roots` (lance-format/lance#8378)](https://github.com/lance-format/lance/pull/8378), which we already pick up via `v11.0.0-beta.18`. But LanceDB mangles the URI before Lance ever sees it, in two places that strip the `file:` scheme with string slicing. That throws away the URL authority, so a UNC URI like `file://server/share/db` turns into the working-directory-relative `server/share/db`:

- `LanceDBConnection.__init__` in the Python sync path, which then hands Rust a path that no longer names the share. `connect_async` never did this, so the two paths disagreed.
- `ListingDatabase::try_create_dir`, which creates the database directory in the wrong place. This also affects plain drive letters: it is why `test_table_uri_url_path_has_no_trailing_question_mark` was skipped on Windows, since `file:///C:/…` failed there before the test reached what it was checking.

The sync connection now forwards `file:` URIs untouched, matching `connect_async`, and `try_create_dir` resolves them with `Url::to_file_path`, which keeps the authority and also understands the `file:/C:/...` form that `Url::to_string` produces. The Windows skip is removed, and a Windows-only regression test opens a database through the machine's own administrative share and reopens a table from it. That test deliberately fails rather than skipping when the share is unavailable — a self-skipping test is what let this survive.

Replaces #3798, which fixed the same issue by reimplementing the Lance-side rooted object store inside LanceDB.

Fixes #2623

## Not included

The clone rewrite from #3798 (`CloneCommitHandler`, hand-rolled `shallow_clone` via `CommitBuilder`) is left out. Its cross-database clone test passes unchanged on `main`, so there is no behavior to fix there.

## Testing

The Windows UNC test cannot run locally — CI's `windows-2022` and `windows-11-arm` jobs are its first real exercise. If those runners turn out not to expose an administrative share, the test needs to create a real share instead; that is the one thing worth watching on this PR.
