### PR TITLE
feat(node): retry embedding calls with exponential backoff

### DIFF
--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -535,4 +535,66 @@ describe("embedding functions", () => {
       [...parsed.values()].map(({ vectorColumn }) => vectorColumn).sort(),
     ).toEqual(["vector_a", "vector_b"]);
   });
+
+  describe("rate limit retries", () => {
+    class MockRateLimitedEmbeddingFunction extends EmbeddingFunction<string> {
+      callCount = 0;
+      #failTimes: number;
+      #maxRetries: number;
+
+      constructor(options: { failTimes?: number; maxRetries?: number } = {}) {
+        super();
+        this.#failTimes = options.failTimes ?? 0;
+        this.#maxRetries = options.maxRetries ?? 7;
+      }
+      override maxRetries(): number {
+        return this.#maxRetries;
+      }
+      ndims() {
+        return 3;
+      }
+      embeddingDataType(): Float {
+        return new Float32();
+      }
+      async computeQueryEmbeddings(_data: string) {
+        return [1, 2, 3];
+      }
+      async computeSourceEmbeddings(data: string[]) {
+        this.callCount++;
+        if (this.callCount <= this.#failTimes) {
+          throw new Error("Rate limit exceeded. Please try again later.");
+        }
+        return Array.from({ length: data.length }).fill([
+          1, 2, 3,
+        ]) as number[][];
+      }
+    }
+
+    it("retries a transient failure and succeeds", async () => {
+      const func = new MockRateLimitedEmbeddingFunction({
+        failTimes: 1,
+        maxRetries: 2,
+      });
+      const db = await connect(tmpDir.name);
+      const table = await db.createTable("test", [{ id: 1, text: "hello" }], {
+        embeddingFunction: { function: func, sourceColumn: "text" },
+      });
+      expect(await table.countRows()).toBe(1);
+      expect(func.callCount).toBe(2);
+    });
+
+    it("does not retry when maxRetries is 0", async () => {
+      const func = new MockRateLimitedEmbeddingFunction({
+        failTimes: 1,
+        maxRetries: 0,
+      });
+      const db = await connect(tmpDir.name);
+      await expect(
+        db.createTable("test", [{ id: 1, text: "hello" }], {
+          embeddingFunction: { function: func, sourceColumn: "text" },
+        }),
+      ).rejects.toThrow();
+      expect(func.callCount).toBe(1);
+    });
+  });
 });

--- a/nodejs/__test__/embedding.test.ts
+++ b/nodejs/__test__/embedding.test.ts
@@ -596,5 +596,153 @@ describe("embedding functions", () => {
       ).rejects.toThrow();
       expect(func.callCount).toBe(1);
     });
+
+    describe("computeSourceEmbeddingsWithRetry / computeQueryEmbeddingsWithRetry", () => {
+      class ConfigurableRetryEmbeddingFunction extends EmbeddingFunction<string> {
+        sourceCallCount = 0;
+        queryCallCount = 0;
+        #failTimes: number;
+        #maxRetries: number;
+        #makeError: () => Error;
+        #isRetryableOverride?: (error: unknown) => boolean;
+
+        constructor(
+          options: {
+            failTimes?: number;
+            maxRetries?: number;
+            makeError?: () => Error;
+            isRetryable?: (error: unknown) => boolean;
+          } = {},
+        ) {
+          super();
+          this.#failTimes = options.failTimes ?? 0;
+          this.#maxRetries = options.maxRetries ?? 7;
+          this.#makeError =
+            options.makeError ?? (() => new Error("Rate limit exceeded"));
+          this.#isRetryableOverride = options.isRetryable;
+        }
+        override maxRetries(): number {
+          return this.#maxRetries;
+        }
+        override isRetryableError(error: unknown): boolean {
+          return this.#isRetryableOverride
+            ? this.#isRetryableOverride(error)
+            : super.isRetryableError(error);
+        }
+        ndims() {
+          return 3;
+        }
+        embeddingDataType(): Float {
+          return new Float32();
+        }
+        async computeSourceEmbeddings(data: string[]) {
+          this.sourceCallCount++;
+          if (this.sourceCallCount <= this.#failTimes) {
+            throw this.#makeError();
+          }
+          return Array.from({ length: data.length }).fill([
+            1, 2, 3,
+          ]) as number[][];
+        }
+        async computeQueryEmbeddings(_data: string) {
+          this.queryCallCount++;
+          if (this.queryCallCount <= this.#failTimes) {
+            throw this.#makeError();
+          }
+          return [1, 2, 3];
+        }
+      }
+
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      // Advance the fake clock far enough to flush every pending (and
+      // recursively re-scheduled) backoff timer, so the retry loop runs to
+      // completion without the test waiting on real delays.
+      async function flushRetries<T>(promise: Promise<T>): Promise<T> {
+        await jest.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+        return promise;
+      }
+
+      it("computeSourceEmbeddingsWithRetry retries a transient failure and succeeds", async () => {
+        const func = new ConfigurableRetryEmbeddingFunction({
+          failTimes: 3,
+          maxRetries: 7,
+        });
+        await expect(
+          flushRetries(func.computeSourceEmbeddingsWithRetry(["hello"])),
+        ).resolves.toEqual([[1, 2, 3]]);
+        expect(func.sourceCallCount).toBe(4);
+      });
+
+      it("computeQueryEmbeddingsWithRetry retries a transient failure and succeeds", async () => {
+        const func = new ConfigurableRetryEmbeddingFunction({
+          failTimes: 3,
+          maxRetries: 7,
+        });
+        await expect(
+          flushRetries(func.computeQueryEmbeddingsWithRetry("hello")),
+        ).resolves.toEqual([1, 2, 3]);
+        expect(func.queryCallCount).toBe(4);
+      });
+
+      it("does not retry an authentication error and preserves it", async () => {
+        class AuthenticationError extends Error {
+          constructor(message: string) {
+            super(message);
+            this.name = "AuthenticationError";
+          }
+        }
+        const func = new ConfigurableRetryEmbeddingFunction({
+          failTimes: Number.POSITIVE_INFINITY,
+          maxRetries: 7,
+          makeError: () => new AuthenticationError("Invalid API key"),
+        });
+        await expect(
+          func.computeSourceEmbeddingsWithRetry(["hello"]),
+        ).rejects.toThrow(AuthenticationError);
+        expect(func.sourceCallCount).toBe(1);
+      });
+
+      it("does not retry a 401 status error and preserves it", async () => {
+        const func = new ConfigurableRetryEmbeddingFunction({
+          failTimes: Number.POSITIVE_INFINITY,
+          maxRetries: 7,
+          makeError: () =>
+            Object.assign(new Error("Unauthorized"), { status: 401 }),
+        });
+        await expect(
+          func.computeQueryEmbeddingsWithRetry("hello"),
+        ).rejects.toMatchObject({ status: 401 });
+        expect(func.queryCallCount).toBe(1);
+      });
+
+      it("preserves the original error once retries are exhausted", async () => {
+        const func = new ConfigurableRetryEmbeddingFunction({
+          failTimes: Number.POSITIVE_INFINITY,
+          maxRetries: 2,
+        });
+        await expect(
+          flushRetries(func.computeSourceEmbeddingsWithRetry(["hello"])),
+        ).rejects.toThrow("Rate limit exceeded");
+        expect(func.sourceCallCount).toBe(3);
+      });
+
+      it("allows overriding retry eligibility", async () => {
+        const func = new ConfigurableRetryEmbeddingFunction({
+          failTimes: Number.POSITIVE_INFINITY,
+          maxRetries: 7,
+          isRetryable: () => false,
+        });
+        await expect(
+          func.computeSourceEmbeddingsWithRetry(["hello"]),
+        ).rejects.toThrow("Rate limit exceeded");
+        expect(func.sourceCallCount).toBe(1);
+      });
+    });
   });
 });

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -962,7 +962,7 @@ async function applyEmbeddingsFromMetadata(
     const values = sourceColumn.toArray();
 
     const vectors =
-      await functionEntry.function.computeSourceEmbeddings(values);
+      await functionEntry.function.computeSourceEmbeddingsWithRetry(values);
     if (vectors.length !== values.length) {
       throw new Error(
         "Embedding function did not return an embedding for each input element",
@@ -1095,7 +1095,7 @@ async function applyEmbeddings<T>(
       );
     }
     const values = sourceColumn.toArray();
-    const vectors = await embeddings.function.computeSourceEmbeddings(
+    const vectors = await embeddings.function.computeSourceEmbeddingsWithRetry(
       values as T[],
     );
     if (vectors.length !== values.length) {

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -16,6 +16,7 @@ import {
 } from "../arrow";
 import { sanitizeType } from "../sanitize";
 import { getRegistry } from "./registry";
+import { retryWithExponentialBackoff } from "./retry";
 
 /**
  * Options for a given embedding function
@@ -221,6 +222,15 @@ export abstract class EmbeddingFunction<
     return undefined;
   }
 
+  /**
+   * Maximum number of retries for transient errors (e.g. rate limiting) when
+   * computing embeddings. Override to change the default, or return 0 to
+   * disable retries.
+   */
+  maxRetries(): number {
+    return 7;
+  }
+
   /** The datatype of the embeddings */
   abstract embeddingDataType(): Float;
 
@@ -238,6 +248,30 @@ export abstract class EmbeddingFunction<
     return this.computeSourceEmbeddings([data]).then(
       (embeddings) => embeddings[0],
     );
+  }
+
+  /**
+   * Compute the embeddings for the source column, retrying with exponential
+   * backoff on failure. See {@link maxRetries}.
+   */
+  computeSourceEmbeddingsWithRetry(
+    data: T[],
+  ): Promise<number[][] | Float32Array[] | Float64Array[]> {
+    return retryWithExponentialBackoff(
+      (data: T[]) => this.computeSourceEmbeddings(data),
+      { maxRetries: this.maxRetries() },
+    )(data);
+  }
+
+  /**
+   * Compute the embeddings for a single query, retrying with exponential
+   * backoff on failure. See {@link maxRetries}.
+   */
+  computeQueryEmbeddingsWithRetry(data: T): Promise<Awaited<IntoVector>> {
+    return retryWithExponentialBackoff(
+      (data: T) => this.computeQueryEmbeddings(data),
+      { maxRetries: this.maxRetries() },
+    )(data);
   }
 }
 

--- a/nodejs/lancedb/embedding/embedding_function.ts
+++ b/nodejs/lancedb/embedding/embedding_function.ts
@@ -16,7 +16,7 @@ import {
 } from "../arrow";
 import { sanitizeType } from "../sanitize";
 import { getRegistry } from "./registry";
-import { retryWithExponentialBackoff } from "./retry";
+import { isPermanentError, retryWithExponentialBackoff } from "./retry";
 
 /**
  * Options for a given embedding function
@@ -231,6 +231,16 @@ export abstract class EmbeddingFunction<
     return 7;
   }
 
+  /**
+   * Whether an error from `computeSourceEmbeddings`/`computeQueryEmbeddings`
+   * should be retried. Defaults to rejecting known permanent failures (e.g.
+   * an invalid API key) so those fail immediately instead of retrying for
+   * hours. See {@link isPermanentError}. Override to change this policy.
+   */
+  isRetryableError(error: unknown): boolean {
+    return !isPermanentError(error);
+  }
+
   /** The datatype of the embeddings */
   abstract embeddingDataType(): Float;
 
@@ -259,7 +269,10 @@ export abstract class EmbeddingFunction<
   ): Promise<number[][] | Float32Array[] | Float64Array[]> {
     return retryWithExponentialBackoff(
       (data: T[]) => this.computeSourceEmbeddings(data),
-      { maxRetries: this.maxRetries() },
+      {
+        maxRetries: this.maxRetries(),
+        isRetryable: (error) => this.isRetryableError(error),
+      },
     )(data);
   }
 
@@ -270,7 +283,10 @@ export abstract class EmbeddingFunction<
   computeQueryEmbeddingsWithRetry(data: T): Promise<Awaited<IntoVector>> {
     return retryWithExponentialBackoff(
       (data: T) => this.computeQueryEmbeddings(data),
-      { maxRetries: this.maxRetries() },
+      {
+        maxRetries: this.maxRetries(),
+        isRetryable: (error) => this.isRetryableError(error),
+      },
     )(data);
   }
 }

--- a/nodejs/lancedb/embedding/retry.ts
+++ b/nodejs/lancedb/embedding/retry.ts
@@ -2,11 +2,36 @@
 // SPDX-FileCopyrightText: Copyright The LanceDB Authors
 
 /**
+ * Returns true for errors that are known to be permanent (retrying them
+ * cannot succeed), such as an invalid API key. Matches the check the Python
+ * SDK added in #2995: an error named `AuthenticationError` (e.g. OpenAI's
+ * SDK), or one carrying a 401/403 HTTP status.
+ */
+export function isPermanentError(error: unknown): boolean {
+  if (error instanceof Error && error.name === "AuthenticationError") {
+    return true;
+  }
+  const status =
+    (error as {
+      status?: unknown;
+      // biome-ignore lint/style/useNamingConvention: mirrors the snake_case some SDKs use
+      status_code?: unknown;
+      statusCode?: unknown;
+    }) ?? {};
+  const code = status.status ?? status.status_code ?? status.statusCode;
+  return code === 401 || code === 403;
+}
+
+/**
  * Wrap an async function so it retries with exponential backoff on failure.
  *
  * There is no reliable, cross-provider way to distinguish a rate limit error
  * from any other failure, so (matching the Python SDK) this retries on any
- * thrown error up to `maxRetries` times.
+ * thrown error by default, except for errors `isRetryable` identifies as
+ * permanent (see {@link isPermanentError}) — those are thrown immediately.
+ *
+ * The original error is always what's thrown, whether retries are disabled,
+ * the error is non-retryable, or retries are exhausted — it is never wrapped.
  */
 export function retryWithExponentialBackoff<
   // biome-ignore lint/suspicious/noExplicitAny: wraps arbitrary embedding function methods
@@ -18,6 +43,7 @@ export function retryWithExponentialBackoff<
     initialDelayMs?: number;
     exponentialBase?: number;
     jitter?: boolean;
+    isRetryable?: (error: unknown) => boolean;
   } = {},
 ): F {
   const {
@@ -25,6 +51,7 @@ export function retryWithExponentialBackoff<
     initialDelayMs = 1000,
     exponentialBase = 2,
     jitter = true,
+    isRetryable = (error: unknown) => !isPermanentError(error),
   } = options;
 
   return (async (...args: Parameters<F>) => {
@@ -35,13 +62,10 @@ export function retryWithExponentialBackoff<
       try {
         return await func(...args);
       } catch (e) {
-        numRetries++;
-        if (numRetries > maxRetries) {
-          throw new Error(
-            `Maximum number of retries (${maxRetries}) exceeded.`,
-            { cause: e },
-          );
+        if (numRetries >= maxRetries || !isRetryable(e)) {
+          throw e;
         }
+        numRetries++;
         delay *= exponentialBase * (1 + (jitter ? Math.random() : 0));
         await new Promise((resolve) => setTimeout(resolve, delay));
       }

--- a/nodejs/lancedb/embedding/retry.ts
+++ b/nodejs/lancedb/embedding/retry.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+/**
+ * Wrap an async function so it retries with exponential backoff on failure.
+ *
+ * There is no reliable, cross-provider way to distinguish a rate limit error
+ * from any other failure, so (matching the Python SDK) this retries on any
+ * thrown error up to `maxRetries` times.
+ */
+export function retryWithExponentialBackoff<
+  // biome-ignore lint/suspicious/noExplicitAny: wraps arbitrary embedding function methods
+  F extends (...args: any[]) => Promise<any>,
+>(
+  func: F,
+  options: {
+    maxRetries?: number;
+    initialDelayMs?: number;
+    exponentialBase?: number;
+    jitter?: boolean;
+  } = {},
+): F {
+  const {
+    maxRetries = 7,
+    initialDelayMs = 1000,
+    exponentialBase = 2,
+    jitter = true,
+  } = options;
+
+  return (async (...args: Parameters<F>) => {
+    let delay = initialDelayMs;
+    let numRetries = 0;
+
+    while (true) {
+      try {
+        return await func(...args);
+      } catch (e) {
+        numRetries++;
+        if (numRetries > maxRetries) {
+          throw new Error(
+            `Maximum number of retries (${maxRetries}) exceeded.`,
+            { cause: e },
+          );
+        }
+        delay *= exponentialBase * (1 + (jitter ? Math.random() : 0));
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }) as F;
+}

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -1197,7 +1197,9 @@ export class LocalTable extends Table {
             new Error("No embedding functions are defined in the table"),
           );
         }
-        return await embeddingFunc.function.computeQueryEmbeddings(query);
+        return await embeddingFunc.function.computeQueryEmbeddingsWithRetry(
+          query,
+        );
       },
     );
 


### PR DESCRIPTION
Closes #2343

Node SDK's `computeSourceEmbeddings`/`computeQueryEmbeddings` had no retry logic, so a transient failure (e.g. a provider rate limit) during ingest or query would fail the whole call. This mirrors the existing Python SDK behavior (#614).

## Changes
- Add `retryWithExponentialBackoff` helper (`nodejs/lancedb/embedding/retry.ts`) — retries on any thrown error (no reliable cross-provider way to distinguish rate-limit errors from others, matching the Python SDK's approach), with exponential backoff + jitter.
- Add `computeSourceEmbeddingsWithRetry` / `computeQueryEmbeddingsWithRetry` on `EmbeddingFunction`, wrapping the existing methods. Add an overridable `maxRetries()` (default 7, matching the Python SDK default; return 0 to disable retries).
- Switch the ingest (`arrow.ts`) and query (`table.ts`) embedding call sites to use the retrying variants.

## Test plan
- Added two tests in `embedding.test.ts`: one confirms a transient failure is retried and the call eventually succeeds, the other confirms `maxRetries: 0` disables retries and fails immediately.
- `pnpm biome check` passes on all changed files.
- `tsc --noEmit` shows the same two pre-existing errors as on `main` (unrelated to this change, caused by `native.d.ts` not being present in this environment).
- Could not run the Jest suite locally — the native addon fails to link in debug mode on this Apple Silicon machine (`ld: b(l) ARM64 branch out of range`), a known napi-rs/rustc debug-binary-size issue unrelated to this diff (repros identically on unmodified `main`). Should build fine in CI/release mode.