### PR TITLE
docs: add comments about metadata conventions

### DIFF
--- a/docs/src/js/classes/Table.md
+++ b/docs/src/js/classes/Table.md
@@ -1292,6 +1292,17 @@ abstract updateFieldMetadata(updates): Promise<UpdateFieldMetadataResult>
 
 Update per-field (column) metadata.
 
+The following keys are treated specially, by convention, and should be
+used when appropriate:
+
+- `lancedb:description`: for a human-readable description of a field.
+- `lancedb:tag:(tag_name)`: for a user-defined key-value tag.
+- `lancedb:logical_column`: for a column grouping; e.g. `feature_v1` and
+  `feature_v2` might be in the same logical_column.
+- `lancedb:status`: for status options (`production`, `candidate`,
+  `deprecated`, `archived`) to designate the current life cycle state of
+  this column.
+
 #### Parameters
 
 * **updates**: [`FieldMetadataUpdate`](../interfaces/FieldMetadataUpdate.md)[]

--- a/docs/src/js/classes/Table.md
+++ b/docs/src/js/classes/Table.md
@@ -1296,9 +1296,10 @@ The following keys are treated specially, by convention, and should be
 used when appropriate:
 
 - `lancedb:description`: for a human-readable description of a field.
-- `lancedb:tag:(tag_name)`: for a user-defined key-value tag.
-- `lancedb:logical_column`: for a column grouping; e.g. `feature_v1` and
-  `feature_v2` might be in the same logical_column.
+- `lancedb:tag:<name>`: for a user-defined key-value tag, where the suffix
+  names the tag category; e.g. `lancedb:tag:model: "clip"`.
+- `lancedb:logical-column`: for a column grouping; e.g. `feature_v1` and
+  `feature_v2` might be in the same logical column.
 - `lancedb:status`: for status options (`production`, `candidate`,
   `deprecated`, `archived`) to designate the current life cycle state of
   this column.

--- a/docs/src/js/interfaces/FieldMetadataUpdate.md
+++ b/docs/src/js/interfaces/FieldMetadataUpdate.md
@@ -17,7 +17,8 @@ metadata: Record<string, null | string>;
 ```
 
 Metadata key/value pairs. Merged into the field's existing metadata by
-default; a value of `null` deletes that key.
+default; a value of `null` deletes that key. See
+[Table.updateFieldMetadata](../classes/Table.md#updatefieldmetadata) for the conventional `lancedb:*` keys.
 
 ***
 

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -628,6 +628,17 @@ export abstract class Table {
 
   /**
    * Update per-field (column) metadata.
+   *
+   * The following keys are treated specially, by convention, and should be
+   * used when appropriate:
+   *
+   * - `lancedb:description`: for a human-readable description of a field.
+   * - `lancedb:tag:(tag_name)`: for a user-defined key-value tag.
+   * - `lancedb:logical_column`: for a column grouping; e.g. `feature_v1` and
+   *   `feature_v2` might be in the same logical_column.
+   * - `lancedb:status`: for status options (`production`, `candidate`,
+   *   `deprecated`, `archived`) to designate the current life cycle state of
+   *   this column.
    * @param {FieldMetadataUpdate[]} updates One or more per-field updates. Each
    * update's metadata is merged into the field's existing metadata by default;
    * a value of `null` deletes that key, and `replace: true` swaps the whole map.
@@ -1538,7 +1549,8 @@ export interface FieldMetadataUpdate {
   path: string;
   /**
    * Metadata key/value pairs. Merged into the field's existing metadata by
-   * default; a value of `null` deletes that key.
+   * default; a value of `null` deletes that key. See
+   * {@link Table.updateFieldMetadata} for the conventional `lancedb:*` keys.
    */
   metadata: Record<string, string | null>;
   /** If true, replace the field's entire metadata map instead of merging. */

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -633,9 +633,10 @@ export abstract class Table {
    * used when appropriate:
    *
    * - `lancedb:description`: for a human-readable description of a field.
-   * - `lancedb:tag:(tag_name)`: for a user-defined key-value tag.
-   * - `lancedb:logical_column`: for a column grouping; e.g. `feature_v1` and
-   *   `feature_v2` might be in the same logical_column.
+   * - `lancedb:tag:<name>`: for a user-defined key-value tag, where the suffix
+   *   names the tag category; e.g. `lancedb:tag:model: "clip"`.
+   * - `lancedb:logical-column`: for a column grouping; e.g. `feature_v1` and
+   *   `feature_v2` might be in the same logical column.
    * - `lancedb:status`: for status options (`production`, `candidate`,
    *   `deprecated`, `archived`) to designate the current life cycle state of
    *   this column.

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2120,11 +2120,23 @@ class Table(ABC):
         ----------
         updates : dict
             One or more dicts, each with:
+
             - "path": str — dot-path to the field (e.g. "embedding" or "a.b.c").
             - "metadata": dict[str, str | None] — keys to set; a value of ``None``
               deletes that key.
             - "replace": bool, optional — replace the field's whole metadata map
               instead of merging (default False).
+
+            The following keys are treated specially, by convention, and should
+            be used when appropriate:
+
+            - "lancedb:description": for a human-readable description of a field.
+            - "lancedb:tag:(tag_name)" for a user-defined key-value tag.
+            - "lancedb:logical_column" for a column grouping; e.g. "feature_v1"
+                and "feature_v2" might be in the same logical_column.
+            - "lancedb:status" for status options ("production", "candidate",
+                "deprecated", "archived") to designate the current life cycle
+                state of this column.
 
         Returns
         -------

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -2131,9 +2131,10 @@ class Table(ABC):
             be used when appropriate:
 
             - "lancedb:description": for a human-readable description of a field.
-            - "lancedb:tag:(tag_name)" for a user-defined key-value tag.
-            - "lancedb:logical_column" for a column grouping; e.g. "feature_v1"
-                and "feature_v2" might be in the same logical_column.
+            - ``"lancedb:tag:<name>"`` for a user-defined key-value tag, where the
+                suffix names the tag category; e.g. "lancedb:tag:model": "clip".
+            - "lancedb:logical-column" for a column grouping; e.g. "feature_v1"
+                and "feature_v2" might be in the same logical column.
             - "lancedb:status" for status options ("production", "candidate",
                 "deprecated", "archived") to designate the current life cycle
                 state of this column.

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1752,7 +1752,22 @@ impl Table {
         self.inner.alter_columns(alterations).await
     }
 
-    /// Update per-field metadata (merges by default).
+    /// Update per-field (column) metadata.
+    ///
+    /// Each [`FieldMetadataUpdate`] is merged into the field's existing metadata
+    /// by default; use [`FieldMetadataUpdate::remove`] to delete a key, or
+    /// [`FieldMetadataUpdate::replace`] to swap the field's entire metadata map.
+    ///
+    /// The following keys are treated specially, by convention, and should be
+    /// used when appropriate:
+    ///
+    /// - `lancedb:description`: for a human-readable description of a field.
+    /// - `lancedb:tag:(tag_name)`: for a user-defined key-value tag.
+    /// - `lancedb:logical_column`: for a column grouping; e.g. `feature_v1` and
+    ///   `feature_v2` might be in the same logical_column.
+    /// - `lancedb:status`: for status options (`production`, `candidate`,
+    ///   `deprecated`, `archived`) to designate the current life cycle state of
+    ///   this column.
     pub async fn update_field_metadata(
         &self,
         updates: &[FieldMetadataUpdate],

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -1762,9 +1762,10 @@ impl Table {
     /// used when appropriate:
     ///
     /// - `lancedb:description`: for a human-readable description of a field.
-    /// - `lancedb:tag:(tag_name)`: for a user-defined key-value tag.
-    /// - `lancedb:logical_column`: for a column grouping; e.g. `feature_v1` and
-    ///   `feature_v2` might be in the same logical_column.
+    /// - `lancedb:tag:<name>`: for a user-defined key-value tag, where the suffix
+    ///   names the tag category; e.g. `lancedb:tag:model: "clip"`.
+    /// - `lancedb:logical-column`: for a column grouping; e.g. `feature_v1` and
+    ///   `feature_v2` might be in the same logical column.
     /// - `lancedb:status`: for status options (`production`, `candidate`,
     ///   `deprecated`, `archived`) to designate the current life cycle state of
     ///   this column.

--- a/rust/lancedb/src/table/schema_evolution.rs
+++ b/rust/lancedb/src/table/schema_evolution.rs
@@ -55,7 +55,9 @@ pub struct DropColumnsResult {
 pub struct FieldMetadataUpdate {
     /// Dot-separated path to the field (e.g. `"embedding"` or `"address.zip"`).
     pub path: String,
-    /// Keys to set (`Some`) or delete (`None`).
+    /// Keys to set (`Some`) or delete (`None`). See
+    /// [`Table::update_field_metadata`](crate::Table::update_field_metadata) for
+    /// the conventional `lancedb:*` keys.
     pub metadata: HashMap<String, Option<String>>,
     /// If `true`, replace the field's entire metadata map instead of merging.
     pub replace: bool,


### PR DESCRIPTION
In LanceDB Enterprise, we've adopted these conventions to give some "canonical" metadata paths. This lets us display them in a certain way in the UI or let agents standardize on them, to assume they'll find info in a certain place. This PR (only comments/docs) just documents those choices.