### PR TITLE
fix: write-protect legacy virtual_column computed columns

### DIFF
--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -2785,7 +2785,7 @@ impl NativeTable {
         namespace_client: Option<Arc<dyn LanceNamespace>>,
         pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
     ) -> Result<Self> {
-        computed_columns::ensure_no_foreign_declarations(batches.arrow_schema().fields())?;
+        computed_columns::ensure_publishable_schema(&batches.arrow_schema())?;
         // Default params uses format v1.
         let params = params.unwrap_or(WriteParams {
             ..Default::default()
@@ -2885,6 +2885,7 @@ impl NativeTable {
         pushdown_operations: HashSet<NamespaceClientPushdownOperation>,
         session: Option<Arc<lance::session::Session>>,
     ) -> Result<Self> {
+        computed_columns::ensure_publishable_schema(&batches.arrow_schema())?;
         // Build table_id from namespace + name for the storage options provider
         let mut table_id = namespace.clone();
         table_id.push(name.to_string());
@@ -2963,6 +2964,38 @@ impl NativeTable {
     ) -> Result<()> {
         self.dataset.ensure_mutable()?;
         let mut dataset = (*self.dataset.get().await?).clone();
+        // A column join writes onto existing rows, so it is a write path like
+        // any other: no refresh-owned values, no fabricated declarations.
+        let table_schema = arrow_schema::Schema::from(dataset.schema());
+        let right_schema = batches.schema();
+        computed_columns::ensure_not_written(
+            &table_schema,
+            right_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .filter(|name| *name != right_on),
+        )?;
+        // Wider than ensure_no_foreign_declarations, which it subsumes: a
+        // legacy marker must not ride in either.
+        if let Some(field) = right_schema.fields().iter().find(|field| {
+            field
+                .metadata()
+                .keys()
+                .any(|key| computed_columns::is_write_protection_key(key))
+        }) {
+            return Err(Error::InvalidInput {
+                message: format!(
+                    "merged column '{}' carries computed-column declaration metadata; \
+                     declarations cannot be introduced through a column join",
+                    field.name()
+                ),
+            });
+        }
+        computed_columns::ensure_no_foreign_binding_envelope(
+            right_schema.metadata(),
+            "a column join's schema metadata",
+        )?;
         dataset.merge(batches, left_on, right_on).await?;
         self.dataset.update(dataset);
         Ok(())
@@ -3052,6 +3085,41 @@ impl NativeTable {
     ) -> Result<()> {
         self.dataset.ensure_mutable()?;
         let mut dataset = (*self.dataset.get().await?).clone();
+        // The immutable binding envelope must ride through verbatim; only an
+        // invalid one may be dropped. Judge the map lance will actually apply.
+        let upsert_values: HashMap<String, String> = upsert_values.into_iter().collect();
+        let current = dataset
+            .schema()
+            .metadata
+            .get(computed_columns::FUNCTION_BINDINGS_META_KEY)
+            .cloned();
+        let incoming = upsert_values.get(computed_columns::FUNCTION_BINDINGS_META_KEY);
+        match (&current, incoming) {
+            (_, Some(value)) if Some(value) != current.as_ref() => {
+                return Err(Error::InvalidInput {
+                    message: format!(
+                        "'{}' cannot be introduced or rewritten through schema-metadata \
+                         replacement: Function bindings are written only by declaration \
+                         planning",
+                        computed_columns::FUNCTION_BINDINGS_META_KEY
+                    ),
+                });
+            }
+            (Some(_), None) => {
+                let schema = arrow_schema::Schema::from(dataset.schema());
+                if computed_columns::function_bindings(&schema).is_ok() {
+                    return Err(Error::InvalidInput {
+                        message: format!(
+                            "replacing schema metadata must preserve '{}' verbatim: it \
+                             holds the table's immutable Function bindings",
+                            computed_columns::FUNCTION_BINDINGS_META_KEY
+                        ),
+                    });
+                }
+                // Invalid envelope: dropping it is the repair path.
+            }
+            _ => {}
+        }
         // TODO: update this when we implement metadata APIs
         #[allow(deprecated)]
         dataset.replace_schema_metadata(upsert_values).await?;
@@ -3073,6 +3141,47 @@ impl NativeTable {
     ) -> Result<()> {
         self.dataset.ensure_mutable()?;
         let mut dataset = (*self.dataset.get().await?).clone();
+        // Deprecated, but a replacement here would still erase a protection
+        // marker. Resolved by field id, matching this API's addressing.
+        let schema = arrow_schema::Schema::from(dataset.schema());
+        let protected = computed_columns::write_protected_columns(&schema);
+        let mut protected_ids = std::collections::HashSet::new();
+        for field in dataset.schema().fields.iter() {
+            if protected.iter().any(|name| name == &field.name) {
+                fn collect(
+                    field: &lance::datatypes::Field,
+                    out: &mut std::collections::HashSet<u32>,
+                ) {
+                    out.insert(field.id as u32);
+                    for child in &field.children {
+                        collect(child, out);
+                    }
+                }
+                collect(field, &mut protected_ids);
+            }
+        }
+        let new_values: Vec<(u32, HashMap<String, String>)> = new_values.into_iter().collect();
+        if let Some((id, _)) = new_values.iter().find(|(id, _)| protected_ids.contains(id)) {
+            return Err(Error::InvalidInput {
+                message: format!(
+                    "replacing metadata of field id {id} would erase a computed-column \
+                     declaration; drop the column and declare it again"
+                ),
+            });
+        }
+        // And the inverse: a fabricated marker would wedge the table.
+        if let Some((id, _)) = new_values.iter().find(|(_, metadata)| {
+            metadata
+                .keys()
+                .any(|key| computed_columns::is_write_protection_key(key))
+        }) {
+            return Err(Error::InvalidInput {
+                message: format!(
+                    "metadata for field id {id} contains computed-column declaration keys; \
+                     declarations cannot be introduced through metadata replacement"
+                ),
+            });
+        }
         dataset.replace_field_metadata(new_values).await?;
         self.dataset.update(dataset);
         Ok(())
@@ -3267,12 +3376,26 @@ impl BaseTable for NativeTable {
 
         let table_schema = Schema::from(&ds.schema().clone());
         computed_columns::ensure_supported_function_metadata(&table_schema)?;
-        computed_columns::ensure_not_written(
-            &table_schema,
-            add.data.schema().fields().iter().map(|f| f.name().as_str()),
-        )?;
-        if matches!(add.mode, AddDataMode::Overwrite) {
-            computed_columns::ensure_no_foreign_declarations(add.data.schema().fields())?;
+        // Value-aware, not name-based: appends pad computed columns with nulls.
+        let protected = computed_columns::write_protected_columns(&table_schema);
+        if !protected.is_empty() {
+            add.data = Box::new(computed_columns::WriteGuardedScannable::new(
+                add.data, protected,
+            ));
+        }
+        // Explicit lance_write_params outrank the builder mode, so the
+        // effective mode decides whether this write publishes its schema.
+        let effective_overwrite = match add
+            .write_options
+            .lance_write_params
+            .as_ref()
+            .map(|params| params.mode)
+        {
+            Some(mode) => !matches!(mode, WriteMode::Append),
+            None => matches!(add.mode, AddDataMode::Overwrite),
+        };
+        if effective_overwrite {
+            computed_columns::ensure_publishable_schema(&add.data.schema())?;
         }
 
         let num_partitions = if let Some(parallelism) = add.write_parallelism {
@@ -4946,6 +5069,218 @@ mod tests {
             manifest.config.get("test_key2"),
             Some(&"test_val2_update".to_string())
         );
+    }
+
+    /// The envelope declaration planning would write.
+    fn valid_envelope() -> String {
+        computed_columns::function_bindings_metadata(&[]).unwrap()
+    }
+
+    /// Write `value` as the binding envelope straight onto the dataset, below
+    /// the guard, as declaration planning does.
+    async fn plant_envelope(native: &NativeTable, value: &str) {
+        let mut dataset = (*native.dataset.get().await.unwrap()).clone();
+        #[allow(deprecated)]
+        dataset
+            .replace_schema_metadata(vec![(
+                computed_columns::FUNCTION_BINDINGS_META_KEY.to_string(),
+                value.to_string(),
+            )])
+            .await
+            .unwrap();
+        native.dataset.update(dataset);
+    }
+
+    /// A one-column table for the envelope guards.
+    async fn envelope_table(name: &str) -> Table {
+        crate::connect("memory://")
+            .execute()
+            .await
+            .unwrap()
+            .create_table(name, arrow_array::record_batch!(("x", Int32, [1])).unwrap())
+            .execute()
+            .await
+            .unwrap()
+    }
+
+    /// The generic schema-metadata API never writes the binding envelope; an
+    /// invalid one may still be dropped, so a corrupted table is repairable.
+    #[tokio::test]
+    async fn schema_metadata_replacement_guards_the_binding_envelope() {
+        let key = computed_columns::FUNCTION_BINDINGS_META_KEY.to_string();
+        let table = envelope_table("bindings_meta").await;
+        let native = table.as_native().unwrap();
+
+        // Introduction through the generic API is refused.
+        let err = native
+            .replace_schema_metadata(vec![(key.clone(), "not-json".to_string())])
+            .await
+            .expect_err("introducing an envelope must be refused");
+        assert!(err.to_string().contains("declaration planning"), "{err}");
+
+        let valid = valid_envelope();
+        plant_envelope(native, &valid).await;
+        let err = native
+            .replace_schema_metadata(vec![("note".to_string(), "hi".to_string())])
+            .await
+            .expect_err("dropping a valid envelope must be refused");
+        assert!(err.to_string().contains("verbatim"), "{err}");
+        let err = native
+            .replace_schema_metadata(vec![(key.clone(), "rewritten".to_string())])
+            .await
+            .expect_err("rewriting a valid envelope must be refused");
+        assert!(err.to_string().contains("declaration planning"), "{err}");
+        native
+            .replace_schema_metadata(vec![
+                (key.clone(), valid.clone()),
+                ("note".to_string(), "hi".to_string()),
+            ])
+            .await
+            .unwrap();
+
+        // Dropping an invalid envelope is the repair path.
+        plant_envelope(native, "not-json").await;
+        native
+            .replace_schema_metadata(vec![("note".to_string(), "repaired".to_string())])
+            .await
+            .expect("dropping an invalid envelope is the repair path");
+    }
+
+    /// The guard judges the deduplicated map, exactly as lance applies it.
+    #[tokio::test]
+    async fn schema_metadata_replacement_judges_the_effective_map() {
+        let key = computed_columns::FUNCTION_BINDINGS_META_KEY.to_string();
+        let table = envelope_table("bindings_dupes").await;
+        let native = table.as_native().unwrap();
+        let valid = valid_envelope();
+        plant_envelope(native, &valid).await;
+
+        // First entry preserves, last duplicate rewrites: refused.
+        let err = native
+            .replace_schema_metadata(vec![
+                (key.clone(), valid.clone()),
+                (key.clone(), r#"{"version":1,"bindings":[{}]}"#.to_string()),
+            ])
+            .await
+            .expect_err("a duplicate rewriting entry must be refused");
+        assert!(err.to_string().contains("declaration planning"), "{err}");
+
+        // Duplicate identical preservation entries are harmless.
+        native
+            .replace_schema_metadata(vec![(key.clone(), valid.clone()), (key, valid)])
+            .await
+            .unwrap();
+    }
+
+    /// Row-only writes never publish their input schema, so a self-derived
+    /// batch carrying the table's own envelope is admitted. The join is not.
+    #[tokio::test]
+    async fn row_only_writes_admit_self_derived_schemas() {
+        let key = computed_columns::FUNCTION_BINDINGS_META_KEY;
+        let table = envelope_table("envelope_ingest").await;
+        let native = table.as_native().unwrap();
+        let valid = valid_envelope();
+        plant_envelope(native, &valid).await;
+
+        // A batch carrying the table's own envelope, as a query result would.
+        let self_derived = computed_columns::test_support::tag_schema(
+            arrow_array::record_batch!(("x", Int32, [2])).unwrap(),
+            &[(key, &valid)],
+        );
+
+        // add: admitted, row lands, table envelope untouched.
+        table.add(self_derived.clone()).execute().await.unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+
+        // merge_insert: likewise.
+        let mut merge_builder = table.merge_insert(&["x"]);
+        merge_builder
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all();
+        merge_builder
+            .execute(Box::new(RecordBatchIterator::new(
+                vec![Ok(self_derived.clone())],
+                self_derived.schema(),
+            )))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            table.schema().await.unwrap().metadata().get(key),
+            Some(&valid),
+            "row-only writes must not touch the table envelope"
+        );
+
+        // The column join imports schema metadata, so it still refuses.
+        let join = computed_columns::test_support::tag_schema(
+            arrow_array::record_batch!(("x", Int32, [1]), ("joined", Int32, [Some(9)])).unwrap(),
+            &[(key, &valid)],
+        );
+        let err = native
+            .clone()
+            .merge(
+                RecordBatchIterator::new(vec![Ok(join.clone())], join.schema()),
+                "x",
+                "x",
+            )
+            .await
+            .expect_err("column join with an envelope must be refused");
+        assert!(err.to_string().contains("declaration planning"), "{err}");
+    }
+
+    /// An Append-mode builder carrying WriteParams::Overwrite publishes its
+    /// input schema, so a smuggled declaration is refused.
+    #[tokio::test]
+    async fn write_params_overwrite_cannot_smuggle_declarations() {
+        let table = envelope_table("effective_overwrite").await;
+        let tainted = computed_columns::test_support::tag_field(
+            arrow_array::record_batch!(("x", Int32, [2]), ("y", Int32, [Some(999)])).unwrap(),
+            1,
+            &[
+                ("computed_column", "true"),
+                ("computed_column.kind", "sql"),
+                ("computed_column.expression", "x + 1"),
+                ("computed_column.inputs", r#"["x"]"#),
+            ],
+        );
+        let err = table
+            .add(tainted)
+            .mode(AddDataMode::Append)
+            .write_options(WriteOptions {
+                lance_write_params: Some(WriteParams {
+                    mode: WriteMode::Overwrite,
+                    ..Default::default()
+                }),
+            })
+            .execute()
+            .await
+            .expect_err("an effective overwrite carrying a declaration must be refused");
+        assert!(
+            err.to_string().contains("computed-column metadata"),
+            "{err}"
+        );
+    }
+
+    /// Creation publishes the input schema, so a caller-supplied envelope is
+    /// refused there too.
+    #[tokio::test]
+    async fn create_refuses_a_foreign_binding_envelope() {
+        let poisoned = computed_columns::test_support::tag_schema(
+            arrow_array::record_batch!(("x", Int32, [1])).unwrap(),
+            &[(
+                computed_columns::FUNCTION_BINDINGS_META_KEY,
+                r#"{"version":1,"bindings":[]}"#,
+            )],
+        );
+        let err = crate::connect("memory://")
+            .execute()
+            .await
+            .unwrap()
+            .create_table("foreign_envelope", poisoned)
+            .execute()
+            .await
+            .expect_err("creation with a caller-supplied envelope must be refused");
+        assert!(err.to_string().contains("declaration planning"), "{err}");
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table/computed_columns.rs
+++ b/rust/lancedb/src/table/computed_columns.rs
@@ -37,6 +37,9 @@ use crate::{Error, Result};
 /// Field metadata key marking a column as computed. The value is `"true"`.
 pub const COMPUTED_COLUMN_META_KEY: &str = "computed_column";
 
+/// Pre-`computed_column.*` marker: honored by the write guards, not parsed.
+pub const LEGACY_VIRTUAL_COLUMN_META_KEY: &str = "virtual_column";
+
 /// Field metadata key naming the kind of rule that defines the column.
 pub const KIND_META_KEY: &str = "computed_column.kind";
 
@@ -1042,17 +1045,100 @@ pub(crate) fn ensure_not_an_input(schema: &SchemaRef, paths: &[&str]) -> Result<
                     ),
                 });
             }
-            if inputs.iter().any(|input| root(input) == root(path)) {
-                return Err(Error::InvalidInput {
-                    message: format!(
-                        "column '{}' is read by computed column '{}'; drop that column first",
-                        path, declaration.name
-                    ),
-                });
+            ensure_not_read(&declaration.name, &inputs, path)?;
+        }
+    }
+    // Legacy declarations record their inputs in metadata; honor them the same.
+    for (column, inputs) in legacy_input_roots(schema.as_ref())? {
+        for path in paths {
+            if column != *path {
+                ensure_not_read(&column, &inputs, path)?;
             }
         }
     }
     Ok(())
+}
+
+/// Reject `path` when `column`'s declaration reads it.
+fn ensure_not_read(column: &str, inputs: &[String], path: &str) -> Result<()> {
+    if inputs.iter().any(|input| root(input) == root(path)) {
+        return Err(Error::InvalidInput {
+            message: format!(
+                "column '{path}' is read by computed column '{column}'; drop that column first"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Recorded inputs of every legacy-tagged column. An unreadable record is
+/// refused rather than ignored, matching the unevaluable-expression policy.
+fn legacy_input_roots(schema: &ArrowSchema) -> Result<Vec<(String, Vec<String>)>> {
+    let mut out = Vec::new();
+    for field in schema.fields() {
+        let metadata = field.metadata();
+        if !is_legacy_tagged(metadata) {
+            continue;
+        }
+        let mut inputs = Vec::new();
+        for key in ["virtual_column.inputs", "virtual_column.udf_inputs"] {
+            if let Some(raw) = metadata.get(key) {
+                let parsed: Vec<String> =
+                    serde_json::from_str(raw).map_err(|e| Error::InvalidInput {
+                        message: format!(
+                            "computed column '{}' has an unreadable '{key}' record ({e}); \
+                             drop it before changing the schema",
+                            field.name()
+                        ),
+                    })?;
+                inputs.extend(parsed);
+            }
+        }
+        if !inputs.is_empty() {
+            out.push((field.name().clone(), inputs));
+        }
+    }
+    Ok(out)
+}
+
+/// A schema published as the table's own -- creation and every effective
+/// overwrite -- carries no caller-supplied declarations. Row-only writes never
+/// publish their input schema, so metadata there is inert.
+pub(crate) fn ensure_publishable_schema(schema: &ArrowSchema) -> Result<()> {
+    ensure_no_foreign_declarations(schema.fields())?;
+    ensure_no_foreign_binding_envelope(schema.metadata(), "a published table schema")
+}
+
+/// Refuse incoming schema metadata carrying the Function-binding envelope:
+/// ingestion imports keys the table lacks, and a fabricated one wedges it.
+pub(crate) fn ensure_no_foreign_binding_envelope(
+    metadata: &HashMap<String, String>,
+    path: &str,
+) -> Result<()> {
+    if metadata.contains_key(FUNCTION_BINDINGS_META_KEY) {
+        return Err(Error::InvalidInput {
+            message: format!(
+                "'{FUNCTION_BINDINGS_META_KEY}' cannot be introduced through {path}: \
+                 Function bindings are written only by declaration planning"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Columns whose values may only be materialized by refresh, under either
+/// convention.
+pub fn write_protected_columns(schema: &ArrowSchema) -> Vec<String> {
+    schema
+        .fields()
+        .iter()
+        .filter_map(|field| {
+            let metadata = field.metadata();
+            let declared =
+                metadata.get(COMPUTED_COLUMN_META_KEY).map(String::as_str) == Some("true");
+            (declared || is_legacy_tagged(metadata)).then(|| field.name().clone())
+        })
+        .collect()
 }
 
 /// Reject a write that supplies values for a computed column directly:
@@ -1061,22 +1147,63 @@ pub(crate) fn ensure_not_written<'a>(
     schema: &ArrowSchema,
     written: impl IntoIterator<Item = &'a str>,
 ) -> Result<()> {
-    let declared: Vec<String> = computed_columns(schema)
-        .into_iter()
-        .map(|declaration| declaration.name)
-        .collect();
+    let protected = write_protected_columns(schema);
     for name in written {
-        if declared.iter().any(|declared| declared == root(name)) {
-            return Err(Error::InvalidInput {
-                message: format!(
-                    "column '{}' is computed; its values come from refresh and cannot be \
-                     written directly",
-                    root(name)
-                ),
-            });
+        if protected.iter().any(|column| column == root(name)) {
+            return Err(direct_write_error(root(name)));
         }
     }
     Ok(())
+}
+
+fn direct_write_error(name: &str) -> Error {
+    Error::InvalidInput {
+        message: format!(
+            "column '{name}' is computed; its values come from refresh and cannot be \
+             written directly"
+        ),
+    }
+}
+
+/// Rejects any batch carrying non-null values for a write-protected column.
+/// Names are not enough: appends pad them as all-null placeholders.
+pub(crate) struct WriteGuardedScannable {
+    inner: Box<dyn crate::data::scannable::Scannable>,
+    protected: Arc<Vec<String>>,
+}
+
+impl WriteGuardedScannable {
+    pub(crate) fn new(
+        inner: Box<dyn crate::data::scannable::Scannable>,
+        protected: Vec<String>,
+    ) -> Self {
+        Self {
+            inner,
+            protected: Arc::new(protected),
+        }
+    }
+}
+
+impl crate::data::scannable::Scannable for WriteGuardedScannable {
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn scan_as_stream(&mut self) -> crate::arrow::SendableRecordBatchStream {
+        use futures::StreamExt;
+        let protected = self.protected.clone();
+        let schema = self.inner.schema();
+        let stream = self.inner.scan_as_stream().map(move |batch| {
+            let batch = batch?;
+            ensure_batch_writes_no_computed_values(&protected, &batch)?;
+            Ok(batch)
+        });
+        Box::pin(crate::arrow::SimpleRecordBatchStream { schema, stream })
+    }
+
+    fn num_rows(&self) -> Option<usize> {
+        self.inner.num_rows()
+    }
 }
 
 /// Reject a batch holding values for a computed column. Null slots are the
@@ -1089,12 +1216,7 @@ pub(crate) fn ensure_batch_writes_no_computed_values(
         if let Some(column) = batch.column_by_name(name)
             && column.null_count() != column.len()
         {
-            return Err(Error::InvalidInput {
-                message: format!(
-                    "column '{name}' is computed; its values come from refresh and cannot \
-                     be written directly"
-                ),
-            });
+            return Err(direct_write_error(name));
         }
     }
     Ok(())
@@ -1129,6 +1251,28 @@ pub(crate) fn is_declaration_key(key: &str) -> bool {
     key == COMPUTED_COLUMN_META_KEY || key.starts_with("computed_column.")
 }
 
+/// Keys the metadata-mutation boundary must refuse: editing or removing one
+/// strips write protection. Wider than [`is_declaration_key`] by design.
+pub(crate) fn is_write_protection_key(key: &str) -> bool {
+    is_declaration_key(key) || is_legacy_key(key)
+}
+
+/// True for a legacy `virtual_column` metadata key.
+fn is_legacy_key(key: &str) -> bool {
+    key == LEGACY_VIRTUAL_COLUMN_META_KEY || key.starts_with("virtual_column.")
+}
+
+/// True for a field carrying the legacy convention.
+fn is_legacy_tagged(metadata: &HashMap<String, String>) -> bool {
+    metadata.iter().any(|(key, value)| {
+        if key == LEGACY_VIRTUAL_COLUMN_META_KEY {
+            value == "true"
+        } else {
+            is_legacy_key(key)
+        }
+    })
+}
+
 /// Reject retyping a computed column itself.
 ///
 /// A cast keeps the stored expression while changing the type it must yield
@@ -1136,14 +1280,14 @@ pub(crate) fn is_declaration_key(key: &str) -> bool {
 /// declaration silently stops being one. Dropping and redeclaring is the
 /// coherent way to change a computed column's type.
 pub(crate) fn ensure_not_retyped(schema: &ArrowSchema, paths: &[&str]) -> Result<()> {
-    for declaration in computed_columns(schema) {
+    // Legacy-tagged too: a cast rewrites the field without its metadata.
+    for protected in write_protected_columns(schema) {
         for path in paths {
-            if declaration.name == root(path) {
+            if protected == root(path) {
                 return Err(Error::InvalidInput {
                     message: format!(
-                        "column '{}' is computed; drop it and declare it again to change \
-                         its type",
-                        declaration.name
+                        "column '{protected}' is computed; drop it and declare it again \
+                         to change its type"
                     ),
                 });
             }
@@ -1338,8 +1482,72 @@ pub(super) async fn add_foreign_kind(table: &crate::Table, name: &str, kind: &st
     .unwrap();
 }
 
+/// Batch builders for tests that plant declaration metadata, which
+/// `record_batch!` cannot express.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::Arc;
+
+    use arrow_array::RecordBatch;
+    use arrow_schema::Schema as ArrowSchema;
+
+    use super::HashMap;
+
+    fn owned(metadata: &[(&str, &str)]) -> HashMap<String, String> {
+        metadata
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect()
+    }
+
+    /// `batch` with `field`'s metadata replaced.
+    pub fn tag_field(batch: RecordBatch, field: usize, metadata: &[(&str, &str)]) -> RecordBatch {
+        let mut fields = batch.schema().fields().to_vec();
+        fields[field] = Arc::new(
+            fields[field]
+                .as_ref()
+                .clone()
+                .with_metadata(owned(metadata)),
+        );
+        RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), batch.columns().to_vec()).unwrap()
+    }
+
+    /// `batch` with schema-level `metadata` attached.
+    pub fn tag_schema(batch: RecordBatch, metadata: &[(&str, &str)]) -> RecordBatch {
+        let schema = batch
+            .schema()
+            .as_ref()
+            .clone()
+            .with_metadata(owned(metadata));
+        RecordBatch::try_new(Arc::new(schema), batch.columns().to_vec()).unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    /// Legacy `virtual_column` columns are write-protected too.
+    #[test]
+    fn legacy_virtual_columns_are_write_protected() {
+        use std::collections::HashMap;
+        let plain = ArrowField::new("id", DataType::Int64, false);
+        let legacy_tagged = ArrowField::new("y", DataType::Int64, true).with_metadata(
+            HashMap::from([("virtual_column".to_string(), "true".to_string())]),
+        );
+        let legacy_prefixed = ArrowField::new("v", DataType::Utf8, true).with_metadata(
+            HashMap::from([("virtual_column.udf_name".to_string(), "f".to_string())]),
+        );
+        let schema = ArrowSchema::new(vec![plain, legacy_tagged, legacy_prefixed]);
+
+        let protected = super::write_protected_columns(&schema);
+        assert_eq!(protected, vec!["y".to_string(), "v".to_string()]);
+
+        super::ensure_not_written(&schema, ["id"]).unwrap();
+        let err = super::ensure_not_written(&schema, ["id", "y"]).unwrap_err();
+        assert!(err.to_string().contains("computed"), "{err}");
+        let err = super::ensure_not_written(&schema, ["v"]).unwrap_err();
+        assert!(err.to_string().contains("computed"), "{err}");
+    }
+
     #[test]
     fn output_arrow_type_grammar_matches_the_shared_golden() {
         let golden: serde_json::Value = serde_json::from_str(include_str!(

--- a/rust/lancedb/src/table/datafusion/insert.rs
+++ b/rust/lancedb/src/table/datafusion/insert.rs
@@ -194,12 +194,9 @@ impl ExecutionPlan for InsertExec {
 
         let output_bytes = MetricBuilder::new(&self.metrics).output_bytes(partition);
         let input_schema = input_stream.schema();
-        let declared: Vec<String> = crate::table::computed_columns::computed_columns(
+        let declared: Vec<String> = crate::table::computed_columns::write_protected_columns(
             &arrow_schema::Schema::from(self.dataset.schema()),
-        )
-        .into_iter()
-        .map(|declaration| declaration.name)
-        .collect();
+        );
         let input_stream: SendableRecordBatchStream =
             Box::pin(InstrumentedRecordBatchStreamAdapter::new(
                 input_schema,

--- a/rust/lancedb/src/table/merge/lsm.rs
+++ b/rust/lancedb/src/table/merge/lsm.rs
@@ -97,7 +97,8 @@ pub(crate) async fn set_lsm_write_spec(table: &NativeTable, spec: LsmWriteSpec) 
     table.checkout_latest().await?;
     let mut dataset = (*table.dataset.get().await?).clone();
     let schema = arrow_schema::Schema::from(dataset.schema());
-    if !crate::table::computed_columns::computed_columns(&schema).is_empty() {
+    // Legacy-tagged too: admitting one leaves no usable write path.
+    if !crate::table::computed_columns::write_protected_columns(&schema).is_empty() {
         return Err(Error::NotSupported {
             message: "an LSM write spec cannot be installed on a table with computed \
                       columns: rows in un-compacted tiers are invisible to refresh"

--- a/rust/lancedb/src/table/refresh.rs
+++ b/rust/lancedb/src/table/refresh.rs
@@ -908,6 +908,41 @@ mod tests {
         table.add(batch).execute().await.unwrap();
     }
 
+    /// A legacy-tagged table is refused at LSM install like a modern one.
+    #[tokio::test]
+    async fn lsm_install_refuses_legacy_write_protected_columns() {
+        use std::collections::HashMap;
+        let conn = crate::connect("memory://").execute().await.unwrap();
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("x", arrow_schema::DataType::Int32, false),
+            arrow_schema::Field::new("y", arrow_schema::DataType::Int32, true).with_metadata(
+                HashMap::from([("virtual_column".to_string(), "true".to_string())]),
+            ),
+        ]));
+        let batch = arrow_array::RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(Int32Array::from(vec![None as Option<i32>])),
+            ],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("legacy_lsm", batch)
+            .execute()
+            .await
+            .unwrap();
+        table.set_unenforced_primary_key(["x"]).await.unwrap();
+        let err = table
+            .set_lsm_write_spec(crate::table::LsmWriteSpec::unsharded())
+            .await
+            .expect_err("LSM install on a legacy-protected table must be refused");
+        assert!(
+            matches!(&err, Error::NotSupported { message } if message.contains("computed")),
+            "{err:?}"
+        );
+    }
+
     /// Both orders of declare+spec are refused at the source (see the
     /// schema_evolution tests); refresh's own check covers a dataset another
     /// writer left in that state.

--- a/rust/lancedb/src/table/schema_evolution.rs
+++ b/rust/lancedb/src/table/schema_evolution.rs
@@ -242,15 +242,13 @@ pub(crate) async fn execute_update_field_metadata(
     // silently erase it.
     let schema = ArrowSchema::from(dataset.schema());
     computed_columns::ensure_no_function_bindings_for_mutation(&schema, "schema evolution")?;
-    let declared: Vec<String> = computed_columns::computed_columns(&schema)
-        .into_iter()
-        .map(|declaration| declaration.name)
-        .collect();
+    let declared: Vec<String> = computed_columns::write_protected_columns(&schema);
     for update in updates {
+        // Set and delete alike: a removal arrives as a `None`-valued key.
         if update
             .metadata
             .keys()
-            .any(|key| computed_columns::is_declaration_key(key))
+            .any(|key| computed_columns::is_write_protection_key(key))
         {
             return Err(Error::InvalidInput {
                 message: format!(
@@ -293,7 +291,9 @@ pub(crate) async fn execute_update_field_metadata(
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{Int32Array, StringArray, record_batch};
+    use std::collections::HashMap;
+
+    use arrow_array::{Int32Array, RecordBatchIterator, StringArray, record_batch};
     use arrow_schema::DataType;
     use futures::TryStreamExt;
     use lance::dataset::ColumnAlteration;
@@ -301,7 +301,224 @@ mod tests {
     use super::FieldMetadataUpdate;
     use crate::connect;
     use crate::query::{ExecutableQuery, QueryBase, Select};
-    use crate::table::NewColumnTransform;
+    use crate::table::computed_columns::test_support::tag_field;
+    use crate::table::{NewColumnTransform, Table};
+
+    /// A table whose `y` column carries the legacy `virtual_column` marker.
+    async fn legacy_table(name: &str, extra: &[(&str, &str)]) -> Table {
+        let mut metadata = vec![("virtual_column", "true")];
+        metadata.extend_from_slice(extra);
+        let batch = tag_field(
+            record_batch!(("x", Int32, [1]), ("y", Int32, [None])).unwrap(),
+            1,
+            &metadata,
+        );
+        connect("memory://")
+            .execute()
+            .await
+            .unwrap()
+            .create_table(name, batch)
+            .execute()
+            .await
+            .unwrap()
+    }
+
+    /// The write guard still refuses a direct value for `y`.
+    async fn assert_direct_write_refused(table: &Table) {
+        let values = record_batch!(("x", Int32, [2]), ("y", Int32, [Some(999)])).unwrap();
+        let err = table
+            .add(values)
+            .execute()
+            .await
+            .expect_err("direct write to the legacy column must be refused");
+        assert!(err.to_string().contains("computed"), "{err}");
+    }
+
+    /// The lance field id of `name`.
+    async fn field_id(table: &Table, name: &str) -> u32 {
+        table
+            .as_native()
+            .unwrap()
+            .manifest()
+            .await
+            .unwrap()
+            .schema
+            .fields
+            .iter()
+            .find(|field| field.name == name)
+            .map(|field| field.id as u32)
+            .unwrap()
+    }
+
+    /// A legacy-tagged column's keys are immutable through the field-metadata
+    /// API, like a modern declaration's, and the write guard holds after each.
+    #[tokio::test]
+    async fn legacy_marker_survives_field_metadata_mutation() {
+        let table = legacy_table("legacy_meta", &[]).await;
+
+        // Removing the marker (a None-valued key) is refused.
+        let mut removal = FieldMetadataUpdate::new("y");
+        removal.metadata.insert("virtual_column".to_string(), None);
+        let err = table
+            .update_field_metadata(&[removal])
+            .await
+            .expect_err("removing the legacy marker must be refused");
+        assert!(err.to_string().contains("declaration"), "{err}");
+
+        // Editing a legacy declaration key is refused.
+        let edit = FieldMetadataUpdate::new("y").set("virtual_column.expression", "x * 3");
+        let err = table
+            .update_field_metadata(&[edit])
+            .await
+            .expect_err("editing a legacy declaration key must be refused");
+        assert!(err.to_string().contains("declaration"), "{err}");
+
+        // Replacing the field's whole metadata map is refused.
+        let mut replace = FieldMetadataUpdate::new("y").set("note", "hi");
+        replace.replace = true;
+        let err = table
+            .update_field_metadata(&[replace])
+            .await
+            .expect_err("replace on a write-protected field must be refused");
+        assert!(err.to_string().contains("erase"), "{err}");
+
+        assert_direct_write_refused(&table).await;
+    }
+
+    /// Casting a legacy-tagged column is refused: the cast would erase its
+    /// marker.
+    #[tokio::test]
+    async fn legacy_marker_survives_alter_columns_cast() {
+        let table = legacy_table("legacy_cast", &[]).await;
+
+        let err = table
+            .alter_columns(&[ColumnAlteration::new("y".into()).cast_to(DataType::Int64)])
+            .await
+            .expect_err("casting the legacy column must be refused");
+        assert!(err.to_string().contains("computed"), "{err}");
+
+        assert_direct_write_refused(&table).await;
+    }
+
+    /// The deprecated field-id replacement is bound by the same invariant:
+    /// stripping a protection marker through it is refused.
+    #[tokio::test]
+    async fn legacy_marker_survives_deprecated_replace_field_metadata() {
+        let table = legacy_table("legacy_replace", &[]).await;
+        let y_id = field_id(&table, "y").await;
+
+        #[allow(deprecated)]
+        let err = table
+            .as_native()
+            .unwrap()
+            .replace_field_metadata(vec![(y_id, HashMap::new())])
+            .await
+            .expect_err("replacing the legacy field's metadata must be refused");
+        assert!(err.to_string().contains("declaration"), "{err}");
+
+        assert_direct_write_refused(&table).await;
+    }
+
+    /// The column join is a write path: right-side values are refused too.
+    #[tokio::test]
+    async fn legacy_column_rejects_merge_join_values() {
+        let table = legacy_table("legacy_merge_join", &[]).await;
+        let right = record_batch!(("x", Int32, [1]), ("y", Int32, [Some(999)])).unwrap();
+        let err = table
+            .as_native()
+            .unwrap()
+            .clone()
+            .merge(
+                RecordBatchIterator::new(vec![Ok(right.clone())], right.schema()),
+                "x",
+                "x",
+            )
+            .await
+            .expect_err("merging values into the legacy column must be refused");
+        assert!(err.to_string().contains("computed"), "{err}");
+    }
+
+    /// A fabricated marker through the deprecated field-id replacement would
+    /// wedge the table, so it is refused.
+    #[tokio::test]
+    async fn field_metadata_replacement_rejects_fabricated_markers() {
+        let conn = connect("memory://").execute().await.unwrap();
+        let batch = record_batch!(("id", Int32, [1, 2]), ("v", Int32, [10, 20])).unwrap();
+        let table = conn
+            .create_table("fabricate_marker", batch)
+            .execute()
+            .await
+            .unwrap();
+        let v_id = field_id(&table, "v").await;
+
+        for key in [
+            "virtual_column",
+            "computed_column",
+            "virtual_column.expression",
+        ] {
+            #[allow(deprecated)]
+            let err = table
+                .as_native()
+                .unwrap()
+                .replace_field_metadata(vec![(
+                    v_id,
+                    HashMap::from([(key.to_string(), "true".to_string())]),
+                )])
+                .await
+                .expect_err("fabricating a declaration marker must be refused");
+            assert!(err.to_string().contains("declaration"), "{key}: {err}");
+        }
+    }
+
+    /// A column join cannot introduce declaration-tagged fields either.
+    #[tokio::test]
+    async fn merge_join_rejects_fabricated_markers() {
+        let conn = connect("memory://").execute().await.unwrap();
+        let table = conn
+            .create_table(
+                "fabricate_merge",
+                record_batch!(("x", Int32, [1, 2])).unwrap(),
+            )
+            .execute()
+            .await
+            .unwrap();
+        let right = tag_field(
+            record_batch!(("x", Int32, [1]), ("planted", Int32, [Some(7)])).unwrap(),
+            1,
+            &[("virtual_column", "true")],
+        );
+        let err = table
+            .as_native()
+            .unwrap()
+            .clone()
+            .merge(
+                RecordBatchIterator::new(vec![Ok(right.clone())], right.schema()),
+                "x",
+                "x",
+            )
+            .await
+            .expect_err("merging a declaration-tagged column must be refused");
+        assert!(err.to_string().contains("declaration"), "{err}");
+    }
+
+    /// A column a legacy declaration records as an input is protected from
+    /// rename, retype, and drop, matching the modern input policy.
+    #[tokio::test]
+    async fn legacy_recorded_inputs_are_protected() {
+        let table = legacy_table("legacy_inputs", &[("virtual_column.inputs", r#"["x"]"#)]).await;
+
+        let err = table
+            .alter_columns(&[ColumnAlteration::new("x".into()).rename("x2".into())])
+            .await
+            .expect_err("renaming a recorded legacy input must be refused");
+        assert!(err.to_string().contains("is read by"), "{err}");
+
+        let err = table
+            .drop_columns(&["x"])
+            .await
+            .expect_err("dropping a recorded legacy input must be refused");
+        assert!(err.to_string().contains("is read by"), "{err}");
+    }
 
     // Add Columns Tests
 


### PR DESCRIPTION
Computed columns declared under the older `virtual_column` convention were readable but not protected. Refresh materializes them and never revisits a filled row, so a hand-written value became silently permanent. The write guards now key off a write-protected set covering both conventions, and the append guard judges values rather than names, since a padded batch legitimately carries the column as an all-null placeholder.

That protection has to survive every path that could strip it: metadata edits, removals and replacements, casts, the deprecated field-id replacement, LSM admission and the column join all refuse to touch a protected field. They also refuse to fabricate a marker onto an ordinary one, which would leave the table write-refused and immutable.

Schema-level Function bindings get the same treatment from the other side. They must ride through the generic metadata API verbatim, judged on the deduplicated map lance actually applies, and only an invalid envelope may be dropped -- so a table that somehow carries one is repairable rather than trapped.
