### PR TITLE
fix: gate job.rs's Error::Http arms behind the remote feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,13 @@ jobs:
         run: cargo clippy --profile ci --workspace --tests --all-features -- -D warnings
       - name: Run clippy (without remote feature)
         run: cargo clippy --profile ci --workspace --tests -- -D warnings
+      - name: Check lancedb without remote feature (package-scoped)
+        # Workspace-wide feature unification means the step above still
+        # builds `lancedb` with `remote` enabled, because `python/Cargo.toml`
+        # and `nodejs/Cargo.toml` both default to it. Scope this check to
+        # just the `lancedb` package so `remote`-gated code paths (e.g.
+        # `rust/lancedb/src/job.rs`) are actually exercised without it.
+        run: cargo check --profile ci -p lancedb --tests --no-default-features
 
   deny:
     # Supply-chain checks: advisories, licenses, banned crates, and source

--- a/rust/lancedb/src/job.rs
+++ b/rust/lancedb/src/job.rs
@@ -52,21 +52,36 @@ impl TerminalResult {
     }
 
     fn decode<T: DeserializeOwned>(self) -> Result<T> {
+        // `request_id` is only ever `Some` via `TerminalResult::remote`, which
+        // is only constructed behind the `remote` feature (see
+        // `crate::remote::job`). `Error::Http` is likewise `remote`-gated, so
+        // the `Some` arms below must be too — without `remote` the case is
+        // unreachable, but the match still needs a value of type `Error`.
         let value = self.value.ok_or_else(|| match &self.request_id {
+            #[cfg(feature = "remote")]
             Some(request_id) => Error::Http {
                 source: "successful typed job response did not contain a result".into(),
                 request_id: request_id.clone(),
                 status_code: None,
+            },
+            #[cfg(not(feature = "remote"))]
+            Some(_) => Error::Runtime {
+                message: "successful typed job did not contain a result".to_string(),
             },
             None => Error::Runtime {
                 message: "successful typed job did not contain a result".to_string(),
             },
         })?;
         serde_json::from_value(value).map_err(|error| match self.request_id {
+            #[cfg(feature = "remote")]
             Some(request_id) => Error::Http {
                 source: format!("failed to parse typed job result: {error}").into(),
                 request_id,
                 status_code: None,
+            },
+            #[cfg(not(feature = "remote"))]
+            Some(_) => Error::Runtime {
+                message: format!("failed to parse typed job result: {error}"),
             },
             None => Error::Runtime {
                 message: format!("failed to parse typed job result: {error}"),


### PR DESCRIPTION
## What is the bug?

Fixes #4096.

Building `lancedb` with `default-features = false` and without the `remote` feature fails
to compile:

```
error[E0599]: no variant named `Http` found for enum `error::Error`
  --> rust/lancedb/src/job.rs:56:40
error[E0599]: no variant named `Http` found for enum `error::Error`
  --> rust/lancedb/src/job.rs:66:40
```

`TerminalResult::decode` (added by the recent job-handle work, e.g. #3742, #3755, #3939,
#4013) matches on `Error::Http { .. }` unconditionally in two places. `Error::Http` (and
`Error::Retry`) are `#[cfg(feature = "remote")]`-gated in `error.rs`, but `lib.rs`'s
`pub mod job;` is not itself feature-gated, so `job.rs` is compiled for every feature
combination — including any downstream consumer that doesn't enable `remote` (our own
case pins `default-features = false, features = ["metrics-otel"]`).

## How does this PR fix the problem?

`request_id: Option<String>` on `TerminalResult` is only ever `Some` via
`TerminalResult::remote(..)`, which is itself only constructed from `remote`-gated code
(`crate::remote::job`). So the two `Some(request_id) => Error::Http { .. }` arms are gated
behind `#[cfg(feature = "remote")]`, with a `#[cfg(not(feature = "remote"))]` fallback arm
producing `Error::Runtime` for the (unreachable without `remote`) case — matching the
existing `None => Error::Runtime { .. }` arm's message.

## Why did CI not catch this?

Worth flagging separately: the "Run clippy (without remote feature)" step in
`.github/workflows/rust.yml` runs `cargo clippy --workspace --tests` (no `--all-features`),
but `python/Cargo.toml` and `nodejs/Cargo.toml` both declare
`default = ["remote", ...]` on their `lancedb` dependency. Workspace-wide feature
unification means that default re-enables `remote` on the shared `lancedb` build unit even
in this step, so it never actually builds `lancedb` without `remote`. Scoping that step to
`-p lancedb` does catch this class of bug (confirmed locally), but it also currently trips
on ~10 pre-existing, unrelated `dead_code` warnings elsewhere in the crate (`job.rs`'s own
`TerminalResult::remote`/`value`, `query.rs`, `table/computed_columns.rs`,
`table/lsm_stats.rs`, `utils/mod.rs`) once it gets far enough to run clippy's lints — so
I've left that CI change out of this PR to keep it scoped to the actual bug. Happy to open
a follow-up for that if it's useful.

## Validation

All run against this branch, from `rust/`:

```
$ cargo check -p lancedb --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.69s
# (only the pre-existing, unrelated dead_code warnings noted above; no errors)

$ cargo test -p lancedb --lib job::
running 2 tests
test job::tests::mapped_spawned_job_preserves_cancellation ... ok
test job::tests::mapped_spawned_job_reuses_outcome ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 737 filtered out

$ cargo check -p lancedb --tests --features remote
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 08s
# clean, confirming the remote-gated arms still compile and are exercised correctly

$ cargo fmt --all -- --check
# clean
```

No existing tests needed changes; `job.rs`'s own unit tests don't exercise the `remote`
path (nothing in that file constructs `TerminalResult::remote`), so this is purely a
compile-time fix.
