### PR TITLE
fix(rust): compile jobs without remote feature

### DIFF
--- a/rust/lancedb/src/job.rs
+++ b/rust/lancedb/src/job.rs
@@ -51,26 +51,34 @@ impl TerminalResult {
         self.value.as_ref()
     }
 
-    fn decode<T: DeserializeOwned>(self) -> Result<T> {
-        let value = self.value.ok_or_else(|| match &self.request_id {
-            Some(request_id) => Error::Http {
-                source: "successful typed job response did not contain a result".into(),
-                request_id: request_id.clone(),
-                status_code: None,
-            },
-            None => Error::Runtime {
-                message: "successful typed job did not contain a result".to_string(),
-            },
-        })?;
-        serde_json::from_value(value).map_err(|error| match self.request_id {
-            Some(request_id) => Error::Http {
-                source: format!("failed to parse typed job result: {error}").into(),
+    fn decode_error(message: String, request_id: Option<String>) -> Error {
+        #[cfg(feature = "remote")]
+        if let Some(request_id) = request_id {
+            return Error::Http {
+                source: message.into(),
                 request_id,
                 status_code: None,
-            },
-            None => Error::Runtime {
-                message: format!("failed to parse typed job result: {error}"),
-            },
+            };
+        }
+
+        let _ = request_id;
+        Error::Runtime { message }
+    }
+
+    fn decode<T: DeserializeOwned>(self) -> Result<T> {
+        let value = self.value.ok_or_else(|| {
+            let message = if self.request_id.is_some() {
+                "successful typed job response did not contain a result"
+            } else {
+                "successful typed job did not contain a result"
+            };
+            Self::decode_error(message.to_string(), self.request_id.clone())
+        })?;
+        serde_json::from_value(value).map_err(|error| {
+            Self::decode_error(
+                format!("failed to parse typed job result: {error}"),
+                self.request_id,
+            )
         })
     }
 }
@@ -331,6 +339,14 @@ mod tests {
     use std::future::pending;
 
     use super::*;
+
+    #[test]
+    fn local_typed_result_decode_errors_are_runtime_errors() {
+        assert!(matches!(
+            TerminalResult::local(Value::Null).decode::<u64>(),
+            Err(Error::Runtime { .. })
+        ));
+    }
 
     #[tokio::test]
     async fn mapped_spawned_job_reuses_outcome() {


### PR DESCRIPTION
## What

Move typed job decode error construction behind a feature-aware helper so builds without the `remote` feature do not reference `Error::Http`. Local decode failures continue to surface as `Error::Runtime`, while remote builds retain HTTP errors with request IDs.

Add a regression test for local typed-result decode failures.

Closes #4096.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p lancedb --no-default-features`
- `cargo test -p lancedb --no-default-features job::tests::local_typed_result_decode_errors_are_runtime_errors`