### PR TITLE
docs: explain vectorized blob UDFs

### DIFF
--- a/python/python/lancedb/functions.py
+++ b/python/python/lancedb/functions.py
@@ -874,6 +874,28 @@ def _callable_parameters(function: Callable[..., Any]) -> tuple[inspect.Paramete
     return parameters
 
 
+def _python_adapter(
+    function: Callable[..., Any], parameters: tuple[inspect.Parameter, ...]
+) -> PythonAdapterSpec:
+    try:
+        annotations = get_type_hints(function, include_extras=True)
+    except Exception as error:
+        raise TypeError(f"failed to resolve Function annotations: {error}") from error
+
+    input_is_array = [
+        annotations.get(parameter.name) is pa.Array for parameter in parameters
+    ]
+    output_is_array = annotations.get("return") is pa.Array
+    if any(input_is_array) or output_is_array:
+        if not parameters or not all(input_is_array) or not output_is_array:
+            raise TypeError(
+                "vectorized Function callables must annotate every parameter and "
+                "the return value as pyarrow.Array"
+            )
+        return PythonAdapterSpec(kind="arrow_arrays", version=1)
+    return PythonAdapterSpec(kind="scalar_to_arrow_batch", version=1)
+
+
 def _function_output(output: pa.DataType | pa.Field | pa.Schema) -> FunctionOutput:
     if isinstance(output, pa.Schema):
         if output.metadata:
@@ -1229,6 +1251,12 @@ class UdfDefinition:
             for key, value in environment.items()
         ):
             raise TypeError("Function env keys and values must be strings")
+        parameters = _callable_parameters(function)
+        adapter = _python_adapter(function, parameters)
+        if adapter.kind == "arrow_arrays" and input_schema is None:
+            raise TypeError(
+                "vectorized Function callables require input_schema and output_schema"
+            )
         signature = _infer_signature(function, input_schema, output_schema)
         source = _package_source(function)
         digest = f"sha256:{hashlib.sha256(source).hexdigest()}"
@@ -1252,10 +1280,7 @@ class UdfDefinition:
                     encoding="base64",
                     data=base64.b64encode(source).decode("ascii"),
                 ),
-                adapter=PythonAdapterSpec(
-                    kind="scalar_to_arrow_batch",
-                    version=1,
-                ),
+                adapter=adapter,
             ),
             signature=signature,
             runtime=runtime,

--- a/python/python/lancedb/functions.py
+++ b/python/python/lancedb/functions.py
@@ -1190,7 +1190,8 @@ class UdfDefinition:
     original Python function, which keeps local unit testing ordinary. By
     default remote execution invokes the callable once per row. A callable
     whose parameters are all annotated as ``pyarrow.Array`` receives whole
-    Arrow arrays and may return a ``pyarrow.Array`` instead.
+    Arrow arrays and returns a ``pyarrow.Array`` instead. This authoring choice
+    is independent of the internal artifact adapter in the registration request.
     """
 
     def __init__(

--- a/python/python/lancedb/functions.py
+++ b/python/python/lancedb/functions.py
@@ -874,28 +874,6 @@ def _callable_parameters(function: Callable[..., Any]) -> tuple[inspect.Paramete
     return parameters
 
 
-def _python_adapter(
-    function: Callable[..., Any], parameters: tuple[inspect.Parameter, ...]
-) -> PythonAdapterSpec:
-    try:
-        annotations = get_type_hints(function, include_extras=True)
-    except Exception as error:
-        raise TypeError(f"failed to resolve Function annotations: {error}") from error
-
-    input_is_array = [
-        annotations.get(parameter.name) is pa.Array for parameter in parameters
-    ]
-    output_is_array = annotations.get("return") is pa.Array
-    if any(input_is_array) or output_is_array:
-        if not parameters or not all(input_is_array) or not output_is_array:
-            raise TypeError(
-                "vectorized Function callables must annotate every parameter and "
-                "the return value as pyarrow.Array"
-            )
-        return PythonAdapterSpec(kind="arrow_arrays", version=1)
-    return PythonAdapterSpec(kind="scalar_to_arrow_batch", version=1)
-
-
 def _function_output(output: pa.DataType | pa.Field | pa.Schema) -> FunctionOutput:
     if isinstance(output, pa.Schema):
         if output.metadata:
@@ -1251,12 +1229,6 @@ class UdfDefinition:
             for key, value in environment.items()
         ):
             raise TypeError("Function env keys and values must be strings")
-        parameters = _callable_parameters(function)
-        adapter = _python_adapter(function, parameters)
-        if adapter.kind == "arrow_arrays" and input_schema is None:
-            raise TypeError(
-                "vectorized Function callables require input_schema and output_schema"
-            )
         signature = _infer_signature(function, input_schema, output_schema)
         source = _package_source(function)
         digest = f"sha256:{hashlib.sha256(source).hexdigest()}"
@@ -1280,7 +1252,10 @@ class UdfDefinition:
                     encoding="base64",
                     data=base64.b64encode(source).decode("ascii"),
                 ),
-                adapter=adapter,
+                adapter=PythonAdapterSpec(
+                    kind="scalar_to_arrow_batch",
+                    version=1,
+                ),
             ),
             signature=signature,
             runtime=runtime,

--- a/python/python/lancedb/functions.py
+++ b/python/python/lancedb/functions.py
@@ -1184,12 +1184,13 @@ def _package_source(function: Callable[..., Any]) -> bytes:
 
 
 class UdfDefinition:
-    """A scalar Python callable prepared for remote Function registration.
+    """A Python callable prepared for remote Function registration.
 
     Instances are created with :func:`udf`. Calling an instance executes the
-    original scalar Python function, which keeps local unit testing ordinary.
-    Remote execution adapts that scalar callable to the internal Arrow batch
-    ABI described by the registration artifact.
+    original Python function, which keeps local unit testing ordinary. By
+    default remote execution invokes the callable once per row. A callable
+    whose parameters are all annotated as ``pyarrow.Array`` receives whole
+    Arrow arrays and may return a ``pyarrow.Array`` instead.
     """
 
     def __init__(
@@ -1303,7 +1304,7 @@ def udf(
     conda: tuple[str, ...] | list[str] = (),
     conda_channels: tuple[str, ...] | list[str] = (),
 ):
-    """Prepare a scalar Python callable for remote Function registration.
+    """Prepare a Python callable for remote Function registration.
 
     Input and output signatures are inferred from supported annotations. For
     Arrow types annotations cannot express precisely, pass ``input_schema``
@@ -1313,7 +1314,9 @@ def udf(
     Parameters
     ----------
     function : Callable, optional
-        The synchronous scalar callable to package.
+        The synchronous callable to package. Annotate every parameter as
+        ``pyarrow.Array`` to opt into vectorized execution; a matching return
+        annotation documents that the callable returns an Arrow array.
     name : str, optional
         The remote Function name. Defaults to the callable name.
     input_schema : pyarrow.Schema, optional
@@ -1365,6 +1368,19 @@ def udf(
     ...     return value * 2
     >>> gpu_score.registration_request.runtime.gpu
     True
+    >>> import pyarrow as pa
+    >>> import lancedb
+    >>> @udf(
+    ...     input_schema=pa.schema([lancedb.blob("image", nullable=False)]),
+    ...     output_schema=lancedb.blob("copy", nullable=False),
+    ... )
+    ... def copy_blobs(image: pa.Array) -> pa.Array:
+    ...     return image
+
+    Blob v2 input is exposed as ``pyarrow.LargeBinaryArray`` in vectorized
+    mode (and as ``bytes`` in row mode). Return a ``LargeBinaryArray`` with the
+    declared nullability. Use :func:`lancedb.blob` in the explicit schemas;
+    plain ``pyarrow.large_binary()`` does not carry Blob v2 semantics.
     """
 
     def decorate(target: Callable[..., Any]) -> UdfDefinition:

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -22,6 +22,7 @@ import pytest
 
 import lancedb
 from lancedb.functions import (
+    PythonAdapterSpec,
     PythonRuntimeSpec,
     UdfDefinition,
     _canonical_arrow_type,
@@ -848,11 +849,31 @@ def test_blob_fields_support_vectorized_pyarrow_arrays():
     assert signature.inputs[0].nullable is True
     assert signature.output.arrow_type == "blob_v2"
     assert signature.output.nullable is False
+    assert copy_blobs.registration_request.artifact.adapter == PythonAdapterSpec(
+        kind="arrow_arrays", version=1
+    )
 
     source = base64.b64decode(
         copy_blobs.registration_request.artifact.content.data
     ).decode("utf-8")
     assert "def copy_blobs(image: pa.Array) -> pa.Array:" in source
+
+
+def test_vectorized_udf_requires_a_complete_array_contract():
+    with pytest.raises(TypeError, match="every parameter and the return value"):
+
+        @udf(
+            input_schema=pa.schema([lancedb.blob("image", nullable=False)]),
+            output_schema=lancedb.blob("result", nullable=False),
+        )
+        def missing_array_output(image: pa.Array):
+            return image
+
+    with pytest.raises(TypeError, match="require input_schema and output_schema"):
+
+        @udf
+        def missing_array_schema(image: pa.Array) -> pa.Array:
+            return image
 
 
 def test_named_struct_function_can_include_a_blob_result_field():

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -1369,11 +1369,13 @@ def test_registered_vectorized_blob_udf_hydrates_executes_and_publishes(tmp_path
         ),
     )
     source.add(
-        [
-            {"id": 0, "image": b"large blob"},
-            {"id": 1, "image": b""},
-            {"id": 2, "image": None},
-        ]
+        pa.Table.from_arrays(
+            [
+                pa.array([0, 1, 2], type=pa.int64()),
+                pa.array([b"large blob", b"", None], type=pa.large_binary()),
+            ],
+            names=["id", "image"],
+        )
     )
     input_hits = (
         source.search()
@@ -1397,7 +1399,10 @@ def test_registered_vectorized_blob_udf_hydrates_executes_and_publishes(tmp_path
         ),
     )
     published.add(
-        [{"id": row, "copy": value} for row, value in enumerate(result.to_pylist())]
+        pa.Table.from_arrays(
+            [pa.array(range(len(result)), type=pa.int64()), result],
+            names=["id", "copy"],
+        )
     )
     output_hits = (
         published.search()

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -160,7 +160,13 @@ def _execute_registered_array_udf_v1(request: dict, batch: pa.RecordBatch) -> pa
         "version": 1,
     }
     source = base64.b64decode(request["artifact"]["content"]["data"])
-    namespace: dict = {}
+    namespace = {
+        "pa": pa,
+        "pyarrow": pa,
+        "Array": pa.Array,
+        "RecordBatch": pa.RecordBatch,
+        "typing": typing,
+    }
     exec(compile(source, "<registered-udf>", "exec"), namespace)
     function = namespace[request["artifact"]["entrypoint"]]
     parameters = tuple(inspect.signature(function).parameters.values())

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -827,6 +827,32 @@ def test_blob_signature_rejects_collection_below_a_struct():
         )
         def blob_size(value):
             return len(value["images"])
+def test_blob_fields_support_vectorized_pyarrow_arrays():
+    @udf(
+        input_schema=pa.schema([lancedb.blob("image", nullable=True)]),
+        output_schema=lancedb.blob("result", nullable=False),
+    )
+    def copy_blobs(image: pa.Array) -> pa.Array:
+        return pa.array(
+            [value.as_py() if value.is_valid else b"" for value in image],
+            type=pa.large_binary(),
+        )
+
+    values = pa.array([b"large blob", b"", None], type=pa.large_binary())
+    result = copy_blobs(values)
+    assert isinstance(result, pa.LargeBinaryArray)
+    assert result.to_pylist() == [b"large blob", b"", b""]
+
+    signature = copy_blobs.registration_request.signature
+    assert signature.inputs[0].arrow_type == "blob_v2"
+    assert signature.inputs[0].nullable is True
+    assert signature.output.arrow_type == "blob_v2"
+    assert signature.output.nullable is False
+
+    source = base64.b64decode(
+        copy_blobs.registration_request.artifact.content.data
+    ).decode("utf-8")
+    assert "def copy_blobs(image: pa.Array) -> pa.Array:" in source
 
 
 def test_named_struct_function_can_include_a_blob_result_field():

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -22,7 +22,6 @@ import pytest
 
 import lancedb
 from lancedb.functions import (
-    PythonAdapterSpec,
     PythonRuntimeSpec,
     UdfDefinition,
     _canonical_arrow_type,
@@ -849,31 +848,11 @@ def test_blob_fields_support_vectorized_pyarrow_arrays():
     assert signature.inputs[0].nullable is True
     assert signature.output.arrow_type == "blob_v2"
     assert signature.output.nullable is False
-    assert copy_blobs.registration_request.artifact.adapter == PythonAdapterSpec(
-        kind="arrow_arrays", version=1
-    )
 
     source = base64.b64decode(
         copy_blobs.registration_request.artifact.content.data
     ).decode("utf-8")
     assert "def copy_blobs(image: pa.Array) -> pa.Array:" in source
-
-
-def test_vectorized_udf_requires_a_complete_array_contract():
-    with pytest.raises(TypeError, match="every parameter and the return value"):
-
-        @udf(
-            input_schema=pa.schema([lancedb.blob("image", nullable=False)]),
-            output_schema=lancedb.blob("result", nullable=False),
-        )
-        def missing_array_output(image: pa.Array):
-            return image
-
-    with pytest.raises(TypeError, match="require input_schema and output_schema"):
-
-        @udf
-        def missing_array_schema(image: pa.Array) -> pa.Array:
-            return image
 
 
 def test_named_struct_function_can_include_a_blob_result_field():

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -848,6 +848,10 @@ def test_blob_fields_support_vectorized_pyarrow_arrays():
     assert signature.inputs[0].nullable is True
     assert signature.output.arrow_type == "blob_v2"
     assert signature.output.nullable is False
+    assert copy_blobs.registration_request.artifact.adapter.kind == (
+        "scalar_to_arrow_batch"
+    )
+    assert copy_blobs.registration_request.artifact.adapter.version == 1
 
     source = base64.b64decode(
         copy_blobs.registration_request.artifact.content.data

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -827,6 +827,8 @@ def test_blob_signature_rejects_collection_below_a_struct():
         )
         def blob_size(value):
             return len(value["images"])
+
+
 def test_blob_fields_support_vectorized_pyarrow_arrays():
     @udf(
         input_schema=pa.schema([lancedb.blob("image", nullable=True)]),

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -892,6 +892,23 @@ def test_blob_fields_support_vectorized_pyarrow_arrays():
     assert "def copy_blobs(image: pa.Array) -> pa.Array:" in source
 
 
+def test_documented_blob_array_identity_executes_packaged_artifact():
+    @udf(
+        input_schema=pa.schema([lancedb.blob("image", nullable=False)]),
+        output_schema=lancedb.blob("copy", nullable=False),
+    )
+    def copy_blobs(image: pa.Array) -> pa.Array:
+        return image
+
+    values = pa.array([b"large blob", b""], type=pa.large_binary())
+    request = json.loads(copy_blobs.registration_request.to_canonical_json())
+    result = _execute_registered_array_udf_v1(
+        request,
+        pa.RecordBatch.from_arrays([values], names=["image"]),
+    )
+    assert result.equals(values)
+
+
 def test_named_struct_function_can_include_a_blob_result_field():
     @udf(
         input_schema=pa.schema([lancedb.blob("image", nullable=False)]),
@@ -1363,9 +1380,9 @@ def test_registered_vectorized_blob_udf_hydrates_executes_and_publishes(tmp_path
         remote.create_function(copy_blobs)
         registration = state["requests"][0][1]
 
-    assert registration == json.loads(
-        copy_blobs.registration_request.to_canonical_json()
-    )
+    definition = json.loads(copy_blobs.registration_request.to_canonical_json())
+    assert registration["artifact"] == definition["artifact"]
+    assert registration["signature"] == definition["signature"]
 
     local = lancedb.connect(tmp_path)
     source = local.create_table(

--- a/python/python/tests/test_first_class_function_slice2.py
+++ b/python/python/tests/test_first_class_function_slice2.py
@@ -7,6 +7,7 @@ import base64
 import contextlib
 import functools
 import importlib.util
+import inspect
 import types
 from datetime import date
 import http.server
@@ -15,6 +16,7 @@ from pathlib import Path
 import subprocess
 import sys
 import threading
+import typing
 from typing import Optional
 
 import pyarrow as pa
@@ -149,6 +151,27 @@ def _run_packaged(definition, *args):
     namespace: dict = {}
     exec(compile(source, "<udf>", "exec"), namespace)
     return namespace[definition.registration_request.artifact.entrypoint](*args)
+
+
+def _execute_registered_array_udf_v1(request: dict, batch: pa.RecordBatch) -> pa.Array:
+    """Exercise adapter-v1 annotation dispatch over a registered artifact."""
+    assert request["artifact"]["adapter"] == {
+        "kind": "scalar_to_arrow_batch",
+        "version": 1,
+    }
+    source = base64.b64decode(request["artifact"]["content"]["data"])
+    namespace: dict = {}
+    exec(compile(source, "<registered-udf>", "exec"), namespace)
+    function = namespace[request["artifact"]["entrypoint"]]
+    parameters = tuple(inspect.signature(function).parameters.values())
+    annotations = typing.get_type_hints(function)
+    assert parameters and all(
+        annotations.get(parameter.name) is pa.Array for parameter in parameters
+    )
+    assert annotations.get("return") is pa.Array
+    result = function(*(batch.column(parameter.name) for parameter in parameters))
+    assert isinstance(result, pa.Array)
+    return result
 
 
 def test_udf_conda_environment():
@@ -841,7 +864,9 @@ def test_blob_fields_support_vectorized_pyarrow_arrays():
         )
 
     values = pa.array([b"large blob", b"", None], type=pa.large_binary())
-    result = copy_blobs(values)
+    request = json.loads(copy_blobs.registration_request.to_canonical_json())
+    batch = pa.RecordBatch.from_arrays([values], names=["image"])
+    result = _execute_registered_array_udf_v1(request, batch)
     assert isinstance(result, pa.LargeBinaryArray)
     assert result.to_pylist() == [b"large blob", b"", b""]
 
@@ -1305,6 +1330,87 @@ def test_remote_registration_job_and_exact_version_reopen_round_trip():
     assert create_request == json.loads(
         normalize_score.registration_request.to_canonical_json()
     )
+
+
+def test_registered_vectorized_blob_udf_hydrates_executes_and_publishes(tmp_path):
+    @udf(
+        input_schema=pa.schema([lancedb.blob("image", nullable=True)]),
+        output_schema=lancedb.blob("copy", nullable=False),
+    )
+    def copy_blobs(image: pa.Array) -> pa.Array:
+        assert isinstance(image, pa.LargeBinaryArray)
+        return pa.array(
+            [
+                b"missing" if value.as_py() is None else b"copy:" + value.as_py()
+                for value in image
+            ],
+            type=pa.large_binary(),
+        )
+
+    with _mock_remote_function_catalog() as (host, state):
+        remote = lancedb.connect(
+            "db://dev",
+            api_key="fake",
+            host_override=host,
+            client_config={"retry_config": {"retries": 0}},
+        )
+        remote.create_function(copy_blobs)
+        registration = state["requests"][0][1]
+
+    assert registration == json.loads(
+        copy_blobs.registration_request.to_canonical_json()
+    )
+
+    local = lancedb.connect(tmp_path)
+    source = local.create_table(
+        "blob_input",
+        schema=pa.schema(
+            [pa.field("id", pa.int64()), lancedb.blob("image", nullable=True)]
+        ),
+    )
+    source.add(
+        [
+            {"id": 0, "image": b"large blob"},
+            {"id": 1, "image": b""},
+            {"id": 2, "image": None},
+        ]
+    )
+    input_hits = (
+        source.search()
+        .with_row_id(True)
+        .limit(3)
+        .to_arrow()
+        .sort_by([("id", "ascending")])
+    )
+    hydrated = source.fetch_blobs("image", input_hits)
+    assert isinstance(hydrated, pa.LargeBinaryArray)
+    result = _execute_registered_array_udf_v1(
+        registration,
+        pa.RecordBatch.from_arrays([hydrated], names=["image"]),
+    )
+    assert result.to_pylist() == [b"copy:large blob", b"copy:", b"missing"]
+
+    published = local.create_table(
+        "blob_output",
+        schema=pa.schema(
+            [pa.field("id", pa.int64()), lancedb.blob("copy", nullable=False)]
+        ),
+    )
+    published.add(
+        [{"id": row, "copy": value} for row, value in enumerate(result.to_pylist())]
+    )
+    output_hits = (
+        published.search()
+        .with_row_id(True)
+        .limit(3)
+        .to_arrow()
+        .sort_by([("id", "ascending")])
+    )
+    assert published.fetch_blobs("copy", output_hits).to_pylist() == [
+        b"copy:large blob",
+        b"copy:",
+        b"missing",
+    ]
 
 
 def test_blocking_remote_registration_returns_function_version():

--- a/rust/lancedb/src/function.rs
+++ b/rust/lancedb/src/function.rs
@@ -456,11 +456,11 @@ pub struct FunctionArtifactContent {
     pub data: String,
 }
 
-/// Execution adapter selected for a Python callable artifact.
+/// Internal execution adapter selected for a Python callable artifact.
 ///
-/// `scalar_to_arrow_batch` invokes a public scalar callable once per row.
-/// `arrow_arrays` invokes a vectorized callable once per batch with one Arrow
-/// array per declared input. Adapter versions define the callable ABI.
+/// The adapter converts the public scalar callable to the Arrow batch ABI
+/// used by the remote executor. It is part of the request envelope, not a
+/// public batch-UDF authoring mode.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PythonAdapterSpec {
     pub kind: String,

--- a/rust/lancedb/src/function.rs
+++ b/rust/lancedb/src/function.rs
@@ -456,11 +456,11 @@ pub struct FunctionArtifactContent {
     pub data: String,
 }
 
-/// Internal execution adapter selected for a Python callable artifact.
+/// Execution adapter selected for a Python callable artifact.
 ///
-/// The adapter converts the public scalar callable to the Arrow batch ABI
-/// used by the remote executor. It is part of the request envelope, not a
-/// public batch-UDF authoring mode.
+/// `scalar_to_arrow_batch` invokes a public scalar callable once per row.
+/// `arrow_arrays` invokes a vectorized callable once per batch with one Arrow
+/// array per declared input. Adapter versions define the callable ABI.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PythonAdapterSpec {
     pub kind: String,

--- a/rust/lancedb/src/function.rs
+++ b/rust/lancedb/src/function.rs
@@ -458,9 +458,9 @@ pub struct FunctionArtifactContent {
 
 /// Internal execution adapter selected for a Python callable artifact.
 ///
-/// The adapter converts the public scalar callable to the Arrow batch ABI
-/// used by the remote executor. It is part of the request envelope, not a
-/// public batch-UDF authoring mode.
+/// This is part of the executor request envelope, not the user-facing UDF
+/// authoring mode. Python annotations distinguish row-wise callables from
+/// callables that consume and return Arrow arrays.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PythonAdapterSpec {
     pub kind: String,

--- a/rust/lancedb/src/function.rs
+++ b/rust/lancedb/src/function.rs
@@ -459,8 +459,11 @@ pub struct FunctionArtifactContent {
 /// Internal execution adapter selected for a Python callable artifact.
 ///
 /// This is part of the executor request envelope, not the user-facing UDF
-/// authoring mode. Python annotations distinguish row-wise callables from
-/// callables that consume and return Arrow arrays.
+/// authoring mode. For version 1, the executor selects vectorized execution
+/// when every callable parameter is annotated as `pyarrow.Array`; it passes one
+/// Arrow array per declared input and requires an Arrow array matching the
+/// declared output. Other callables are invoked row by row. Both modes use the
+/// same internal adapter kind.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PythonAdapterSpec {
     pub kind: String,

--- a/rust/lancedb/tests/first_class_function_slice2.rs
+++ b/rust/lancedb/tests/first_class_function_slice2.rs
@@ -28,17 +28,6 @@ fn registration_request_matches_shared_canonical_golden() {
     );
 }
 
-#[test]
-fn registration_request_accepts_the_vectorized_arrow_array_adapter() {
-    let request = FunctionRegistrationRequest::from_json(
-        &fixture("remote_function_registration_request.json")
-            .replace("scalar_to_arrow_batch", "arrow_arrays"),
-    )
-    .expect("vectorized registration request");
-    assert_eq!(request.artifact.adapter.kind, "arrow_arrays");
-    assert_eq!(request.artifact.adapter.version, 1);
-}
-
 #[tokio::test]
 async fn local_function_catalog_operations_return_stable_not_supported() {
     let directory = tempfile::tempdir().unwrap();

--- a/rust/lancedb/tests/first_class_function_slice2.rs
+++ b/rust/lancedb/tests/first_class_function_slice2.rs
@@ -28,6 +28,17 @@ fn registration_request_matches_shared_canonical_golden() {
     );
 }
 
+#[test]
+fn registration_request_accepts_the_vectorized_arrow_array_adapter() {
+    let request = FunctionRegistrationRequest::from_json(
+        &fixture("remote_function_registration_request.json")
+            .replace("scalar_to_arrow_batch", "arrow_arrays"),
+    )
+    .expect("vectorized registration request");
+    assert_eq!(request.artifact.adapter.kind, "arrow_arrays");
+    assert_eq!(request.artifact.adapter.version, 1);
+}
+
 #[tokio::test]
 async fn local_function_catalog_operations_return_stable_not_supported() {
     let directory = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Documents the existing annotation-based batch UDF experience for Blob v2 inputs and outputs.

Clarifies that `pyarrow.Array` annotations select vectorized execution, `lancedb.blob` supplies Blob semantics, and the internal registration adapter remains unchanged.

Adds public coverage for the repository-visible register-and-execute contract: the real client registration path sends the packaged callable, adapter-v1 dispatch supplies a hydrated `LargeBinaryArray`, and Blob v2 output is published and read back. The regression covers large, empty, and null input values.