### PR TITLE
fix(python): add missing f-string prefix on permutation split error

### DIFF
--- a/python/python/lancedb/permutation.py
+++ b/python/python/lancedb/permutation.py
@@ -597,7 +597,7 @@ class Permutation:
         if split is not None:
             if permutation_table is None:
                 raise ValueError(
-                    "Cannot create a permutation on split `{split}`"
+                    f"Cannot create a permutation on split `{split}`"
                     " because no permutation table is provided"
                 )
             if isinstance(split, str):

--- a/python/tests/test_permutation.py
+++ b/python/tests/test_permutation.py
@@ -1,0 +1,13 @@
+
+
+def test_from_tables_split_without_permutation_table(mem_db):
+    """A split requested without a permutation table raises a descriptive error."""
+    tbl = mem_db.create_table(
+        "split_no_perm_table", pa.table({"x": range(10), "y": range(10)})
+    )
+    with pytest.raises(ValueError) as exc_info:
+        Permutation.from_tables(tbl, None, split="train")
+
+    assert str(exc_info.value) == (
+        "Cannot create a permutation on split `train` because no permutation table is provided"
+    )


### PR DESCRIPTION
The `ValueError` raised by `Permutation.from_tables(..., permutation_table=None, split=...)` rendered the literal `{split}` instead of the split name — the string was missing the `f` prefix. The three sibling messages in the same function interpolate correctly. One-character fix.