### PR TITLE
docs(python): fix docstring param names, wrong default, and typos

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -155,7 +155,7 @@ paths:
                 vector:
                   type: FixedSizeList
                   description: |
-                    The targetted vector to search for. Required.
+                    The targeted vector to search for. Required.
                 vector_column:
                   type: string
                   description: |

--- a/python/python/lancedb/remote/table.py
+++ b/python/python/lancedb/remote/table.py
@@ -720,7 +720,7 @@ class RemoteTable(Table):
         Parameters
         ----------
         query: list/np.ndarray/str/PIL.Image.Image, default None
-            The targetted vector to search for.
+            The targeted vector to search for.
 
             - *default None*.
             Acceptable types are: list, np.ndarray, PIL.Image.Image

--- a/python/python/lancedb/rerankers/base.py
+++ b/python/python/lancedb/rerankers/base.py
@@ -25,7 +25,7 @@ class Reranker(ABC):
         Parameters
         ----------
         return_score : str, default "relevance"
-            opntions are "relevance" or "all"
+            options are "relevance" or "all"
             The type of score to return. If "relevance", will return only the relevance
             score. If "all", will return all scores from the vector and FTS search along
             with the relevance score.

--- a/python/python/lancedb/rerankers/linear_combination.py
+++ b/python/python/lancedb/rerankers/linear_combination.py
@@ -23,7 +23,7 @@ class LinearCombinationReranker(Reranker):
         TODO: We should just hardcode this--
         its pretty confusing as we invert scores to calculate final score
     return_score : str, default "relevance"
-        opntions are "relevance" or "all"
+        options are "relevance" or "all"
         The type of score to return. If "relevance", will return only the relevance
         score. If "all", will return all scores from the vector and FTS search along
         with the relevance score.

--- a/python/python/lancedb/rerankers/rrf.py
+++ b/python/python/lancedb/rerankers/rrf.py
@@ -24,7 +24,7 @@ class RRFReranker(Reranker):
         not critical. See paper:
         https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
     return_score : str, default "relevance"
-        opntions are "relevance" or "all"
+        options are "relevance" or "all"
         The type of score to return. If "relevance", will return only the relevance
         score. If "all", will return all scores from the vector and FTS search along
         with the relevance score.

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -1619,7 +1619,7 @@ class Table(ABC):
         Parameters
         ----------
         query: list/np.ndarray/str/PIL.Image.Image, default None
-            The targetted vector to search for.
+            The targeted vector to search for.
 
             - *default None*.
             Acceptable types are: list, np.ndarray, PIL.Image.Image
@@ -3841,7 +3841,7 @@ class LanceTable(Table):
         Parameters
         ----------
         query: list/np.ndarray/str/PIL.Image.Image, default None
-            The targetted vector to search for.
+            The targeted vector to search for.
 
             - *default None*.
             Acceptable types are: list, np.ndarray, PIL.Image.Image
@@ -5814,7 +5814,7 @@ class AsyncTable:
         Parameters
         ----------
         query: list/np.ndarray/str/PIL.Image.Image, default None
-            The targetted vector to search for.
+            The targeted vector to search for.
 
             - *default None*.
             Acceptable types are: list, np.ndarray, PIL.Image.Image


### PR DESCRIPTION
Docstring accuracy fixes in the Python package, all verified against signatures:

Docstring/signature mismatches:
- `BedRockText._generate_embedding(text)` documented `texts: str` — copy-paste from the public plural `generate_embeddings(texts)`
- `JinaAI._generate_embeddings(input)` documented `texts`; the body reads `input`
- `retry_with_exponential_backoff` documented `max_retries (default is 10)` while the signature — and the runtime error message — use 7

Typos:
- `targetted` → `targeted` (the `query:` param description of `search()`, ×5 across table.py / remote/table.py / docs/openapi.yml)
- `opntions` → `options` (reranker `return_score` descriptions, ×3; the mrr reranker spells it correctly)
- `inteded` → `intended` (rerankers/base.py)