### PR TITLE
fix(python): decode file URIs in OpenCLIP

### DIFF
--- a/python/python/lancedb/embeddings/open_clip.py
+++ b/python/python/lancedb/embeddings/open_clip.py
@@ -7,6 +7,7 @@ import io
 import os
 import urllib.parse as urlparse
 from typing import TYPE_CHECKING, List, Union
+from urllib.request import url2pathname
 
 import numpy as np
 import pyarrow as pa
@@ -154,7 +155,7 @@ class OpenClipEmbeddings(EmbeddingFunction):
             parsed = urlparse.urlparse(image)
             # TODO handle drive letter on windows.
             if parsed.scheme == "file":
-                return PIL_Image.open(parsed.path)
+                return PIL_Image.open(url2pathname(parsed.path))
             elif parsed.scheme == "":
                 return PIL_Image.open(image if os.name == "nt" else parsed.path)
             elif parsed.scheme.startswith("http"):

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -633,6 +633,18 @@ def test_url_retrieve_downloads_image():
     assert img.size[0] > 0 and img.size[1] > 0
 
 
+def test_open_clip_opens_percent_encoded_file_uri(tmp_path):
+    """OpenCLIP should decode local file URIs before opening them."""
+    Image = pytest.importorskip("PIL.Image")
+    from lancedb.embeddings.open_clip import OpenClipEmbeddings
+
+    image_path = tmp_path / "test image.png"
+    Image.new("RGB", (4, 4), color="red").save(image_path, format="PNG")
+
+    with OpenClipEmbeddings._to_pil(None, image_path.as_uri()) as image:
+        assert image.size == (4, 4)
+
+
 def test_jina_generate_image_input_dict_local_path(tmp_path):
     """
     JinaEmbeddings._generate_image_input_dict must accept a local image path


### PR DESCRIPTION
## What

Decode the path component of `file://` image URIs before passing it to Pillow.

## Why

`Path.as_uri()` percent-encodes characters such as spaces. Passing `parsed.path` directly to Pillow therefore tries to open a literal `%20` path and fails.

## Testing

- Added a regression test that opens an image whose local filename contains a space.
- Verified the focused URI conversion behavior against the changed method.
- Ruff check, formatting check, and `compileall` on both changed files.