### PR TITLE
ci(python): add opt-in native Intel macOS wheel validation

### DIFF
--- a/.github/workflows/macos-intel-wheel.yml
+++ b/.github/workflows/macos-intel-wheel.yml
@@ -1,0 +1,56 @@
+name: Optional Intel macOS wheel
+
+# Intel publishing was retired in #2836. This is an opt-in source-build
+# path, not a restoration of the default PyPI release/support matrix.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/macos-intel-wheel.yml
+      - ci/smoke_native_wheel.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wheel:
+    runs-on: macos-15-intel
+    timeout-minutes: 120
+    env:
+      MACOSX_DEPLOYMENT_TARGET: '10.15'
+      CARGO_BUILD_JOBS: '3'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          architecture: x64
+      - name: Require an Intel runner
+        run: test "$(uname -m)" = x86_64
+      - uses: ./.github/workflows/build_mac_wheel
+        with:
+          python-minor-version: 12
+          args: --locked --release --strip --target x86_64-apple-darwin --features fp16kernels
+      - name: Install the wheel outside the source tree
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -m venv wheel-env
+          wheel-env/bin/python -m pip install "$GITHUB_WORKSPACE"/target/wheels/lancedb-*.whl
+          wheel-env/bin/python -m pip check
+          wheel-env/bin/python "$GITHUB_WORKSPACE/ci/smoke_native_wheel.py" --architecture x86_64
+      - name: Record build provenance
+        run: |
+          git rev-parse HEAD > target/wheels/UPSTREAM_COMMIT.txt
+          cp Cargo.lock target/wheels/Cargo.lock
+          rustc --version > target/wheels/RUST_VERSION.txt
+          shasum -a 256 target/wheels/*.whl > target/wheels/SHA256SUMS
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-macos-x86_64
+          path: target/wheels/*
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/macos-intel-wheel.yml
+++ b/.github/workflows/macos-intel-wheel.yml
@@ -19,7 +19,9 @@ concurrency:
 jobs:
   wheel:
     runs-on: macos-15-intel
-    timeout-minutes: 120
+    # Native release compilation exceeded 120 minutes in the validated run.
+    # Keep release flags intact and leave time for installed-wheel tests.
+    timeout-minutes: 240
     env:
       MACOSX_DEPLOYMENT_TARGET: '10.15'
       CARGO_BUILD_JOBS: '3'

--- a/ci/smoke_native_wheel.py
+++ b/ci/smoke_native_wheel.py
@@ -1,0 +1,65 @@
+"""Exercise an installed macOS wheel, never a source-tree editable install."""
+
+import argparse
+import importlib.metadata
+import platform
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import tomllib
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--architecture", choices=["x86_64", "arm64"], required=True)
+    args = parser.parse_args()
+    if sys.platform != "darwin" or platform.machine() != args.architecture:
+        raise RuntimeError(
+            "wheel smoke test must run on the requested macOS architecture"
+        )
+
+    import lancedb
+    import lancedb._lancedb as native
+    import pyarrow as pa
+    from packaging.version import Version
+
+    repo = Path(__file__).resolve().parents[1]
+    expected = tomllib.loads((repo / "python" / "Cargo.toml").read_text())["package"][
+        "version"
+    ]
+    assert Version(importlib.metadata.version("lancedb")) == Version(expected)
+    assert not Path(native.__file__).resolve().is_relative_to(repo)
+    architectures = subprocess.check_output(
+        ["lipo", "-archs", native.__file__], text=True
+    ).strip()
+    assert architectures == args.architecture, architectures
+
+    with tempfile.TemporaryDirectory() as root:
+        db = lancedb.connect(root)
+        schema = pa.schema([("id", pa.string()), ("vector", pa.list_(pa.float32(), 3))])
+        table = db.create_table("memories", schema=schema)
+        table.add([{"id": "first", "vector": [1.0, 0.0, 0.0]}])
+        table.add_columns({"scopeKey": "cast('' as string)"})
+        table.add([{"id": "second", "vector": [0.0, 1.0, 0.0], "scopeKey": "private"}])
+        assert table.count_rows() == 2
+        assert table.search([1.0, 0.0, 0.0]).limit(1).to_list()[0]["id"] == "first"
+        assert (
+            table.search([0.0, 1.0, 0.0])
+            .where("scopeKey = 'private'")
+            .limit(1)
+            .to_list()[0]["id"]
+            == "second"
+        )
+        table.update(where="id = 'first'", values={"scopeKey": "updated"})
+        reopened = lancedb.connect(root).open_table("memories")
+        assert reopened.count_rows("scopeKey = 'updated'") == 1
+        assert reopened.schema.field("vector").type.list_size == 3
+        reopened.delete("id = 'second'")
+        assert reopened.count_rows() == 1
+    print(f"PASS: installed LanceDB {expected} on native {args.architecture}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -82,3 +82,18 @@ To see all commands, run:
 ```shell
 make help
 ```
+
+### Optional Intel macOS wheel
+
+Intel macOS wheels are not part of the default PyPI release matrix. Maintainers
+or downstream forks can run the **Optional Intel macOS wheel** workflow manually
+on a selected branch. It builds a release wheel on `macos-15-intel`, installs it
+in an isolated environment outside the checkout, checks the Mach-O architecture,
+and exercises table creation, schema extension, filtered vector search, update,
+reopen, and deletion. A successful run uploads the wheel, source commit, Rust
+version, Cargo lockfile, and SHA-256 checksum as a short-lived Actions artifact.
+
+This does not publish to PyPI or reinstate general Intel platform support. The
+deployment target is a wheel compatibility tag, not a claim that every older
+macOS version or Intel CPU has been tested; runtime verification uses the runner's
+actual OS and CPU. Consumers must still validate their own dependency stack.


### PR DESCRIPTION
## Summary

Add an opt-in native Intel macOS wheel workflow using the explicit `macos-15-intel` runner. This respects the low-volume/platform-cost rationale in #2836: it does **not** restore Intel to the default release matrix or publish anything to PyPI.

Downstream users still run local embedded LanceDB on Intel Macs. This provides a source-build path with an installed-wheel smoke test.

## Changes

- Manual dispatch, plus PR validation only when this workflow or its smoke script changes.
- Existing macOS composite build action, repository release profile, locked dependencies, native x86_64 target and default feature set including fp16 kernels.
- Fresh venv outside the source tree; installed-version and Mach-O architecture checks.
- Actual create/insert, additive column migration, filtered vector search, update, reopen and delete smoke tests.
- Short-lived wheel artifact with source commit, Cargo.lock, Rust version and SHA-256 checksum; documentation states the compatibility/acceptance boundaries.

## Validation

- Native Intel build **and installed-wheel smoke passed** for this PR's source at `fa824b927d2fa40072cba1472e625ce9df746434`: [run 34060681299](https://github.com/Cyb3rb1ade/openclaw-plur1bus-memory/actions/runs/34060681299).
- Artifact: `lancedb-0.39.0b3-cp310-abi3-macosx_10_15_x86_64.whl`; downloaded artifact independently SHA-256 checked: `c68028e55927e5cba9703c4c1dbbb176b16d589afc7de6b8633e3cc433f8ebba`.
- Fresh installed environment passed `pip check`, native x86_64 Mach-O validation, insert/additive schema/filtered ANN/update/reopen/delete checks. No source-tree import was used.
- The only follow-up source change raises the workflow budget from 120 to 240 minutes to match the successful validation run; build flags and smoke code are unchanged. No LTO/release-profile relaxation.
- Ruff lint and formatting passed for the smoke script; whitespace check passes.
- Separate downstream pinned LanceDB 0.34.0 verification also passed in [run 34048642479](https://github.com/Cyb3rb1ade/openclaw-plur1bus-memory/actions/runs/34048642479); this is distinct from the 0.39.0b3 evidence above.

A 10.15 deployment tag is **not** a claim that Catalina or all older Intel CPUs were tested. Downstream ML dependencies need their own validation. No production data, credentials, publish permissions or release changes are involved.
