### PR TITLE
feat(python): Support prebuilt permutation table in StreamingDataset

### DIFF
--- a/python/python/lancedb/streaming.py
+++ b/python/python/lancedb/streaming.py
@@ -386,6 +386,7 @@ class StreamingDataset(IterableDataset):
         self,
         table,
         *,
+        plan: Optional[Any] = None,
         num_splits: Optional[int] = None,
         shuffle: bool = True,
         shuffle_seed: Optional[int] = 0,
@@ -574,17 +575,38 @@ class StreamingDataset(IterableDataset):
         # this instance has never iterated have no entry.
         self._resume_positions: dict[int, int] = {}
 
-        # Build the permutation table once, deterministically.
-        builder = permutation_builder(table)
-        if filter is not None:
-            builder = builder.filter(filter)
-        if shuffle:
-            perm_seed = shuffle_seed + epoch * _EPOCH_PRIME
-            self._perm_table = builder.split_random(
-                fixed=num_splits, seed=perm_seed, clump_size=shuffle_clump_size
-            ).execute()
+        # If a plan is provided, use it directly.
+        if plan is not None:
+            self._perm_table = plan
+            # Validate plan metadata if available
+            if getattr(self._perm_table, "schema", None) is not None:
+                metadata = self._perm_table.schema.metadata
+                if metadata is not None:
+                    raw_names = metadata.get(b"split_names")
+                    if raw_names is not None:
+                        import json
+                        try:
+                            split_names = json.loads(raw_names.decode("utf-8"))
+                            plan_splits = len(split_names)
+                            if plan_splits != num_splits:
+                                raise ValueError(
+                                    f"Requested num_splits ({num_splits}) does not match "
+                                    f"plan table metadata split count ({plan_splits})"
+                                )
+                        except json.JSONDecodeError:
+                            pass
         else:
-            self._perm_table = builder.split_sequential(fixed=num_splits).execute()
+            # Build the permutation table once, deterministically.
+            builder = permutation_builder(table)
+            if filter is not None:
+                builder = builder.filter(filter)
+            if shuffle:
+                perm_seed = shuffle_seed + epoch * _EPOCH_PRIME
+                self._perm_table = builder.split_random(
+                    fixed=num_splits, seed=perm_seed, clump_size=shuffle_clump_size
+                ).execute()
+            else:
+                self._perm_table = builder.split_sequential(fixed=num_splits).execute()
 
         if self._blocks_per_epoch == "auto":
             self._blocks_per_epoch = self._estimate_blocks_per_epoch()
@@ -1298,12 +1320,9 @@ class StreamingDataset(IterableDataset):
             state["_table"] = None
         else:
             state["_table"] = _table_to_pickle_state(self._table)
-        # _perm_table: always in-memory; serialise as Arrow data (mirrors
-        # how Permutation.__getstate__ handles its permutation_table).
-        state["_perm_table"] = (
-            self._perm_table.name,
-            self._perm_table.to_arrow(),
-        )
+        # _perm_table: serialize using table protocol so persisted plans
+        # are re-opened instead of being copied as Arrow data into memory.
+        state["_perm_table_state"] = _table_to_pickle_state(self._perm_table)
         for key in (
             "_raw_batches_ref",
             "_cooked_ref",
@@ -1321,17 +1340,26 @@ class StreamingDataset(IterableDataset):
 
         table_name = state.pop("_table_name")
         table_state = state.pop("_table")
-        perm_name, perm_data = state.pop("_perm_table")
+        perm_state = state.pop("_perm_table_state", None)
+        if perm_state is None:
+            perm_name, perm_data = state.pop("_perm_table")
+        
         self.__dict__.update(state)
         self._consumer_iterator_lock = threading.Lock()
+        
         if self._connection_factory is not None:
             self._table = self._connection_factory(table_name)
         else:
             self._table = _table_from_pickle_state(table_state)
+            
+        if perm_state is not None:
+            if table_state["kind"] == "memory" and perm_state["kind"] == "memory":
+                perm_state["data"] = _drop_base_version(perm_state["data"])
+            self._perm_table = _table_from_pickle_state(perm_state)
+        else:
             if table_state["kind"] == "memory":
-                # Rebuilt from Arrow, so the recorded pin cannot resolve on it.
                 perm_data = _drop_base_version(perm_data)
-        self._perm_table = _connect("memory://").create_table(perm_name, perm_data)
+            self._perm_table = _connect("memory://").create_table(perm_name, perm_data)
 
     def state_dict(self) -> dict:
         """Snapshot the dataset's consumption state.

--- a/python/python/tests/test_elastic_dataloader.py
+++ b/python/python/tests/test_elastic_dataloader.py
@@ -3195,3 +3195,112 @@ def test_streaming_dataset_over_remote_table():
     assert len(server.scans) == 1, "the permutation is built with one row-id scan"
     assert server.takes, "rows must be fetched with row-id takes"
     assert_server_safe_row_id_requests(server)
+
+
+# ---------------------------------------------------------------------------
+# Prebuilt Plan tests
+# ---------------------------------------------------------------------------
+
+def test_streaming_dataset_with_prebuilt_plan(lance_table, tmp_path):
+    """Providing a prebuilt plan prevents table scan and works as expected."""
+    from lancedb.permutation import permutation_builder
+    
+    # Pre-build a plan locally
+    plan = permutation_builder(lance_table).split_random(fixed=NUM_SPLITS, seed=SHUFFLE_SEED).execute()
+    
+    # Pass it as a plan
+    ds = StreamingDataset(
+        lance_table,
+        plan=plan,
+        num_splits=NUM_SPLITS,
+        shuffle_seed=SHUFFLE_SEED,
+        rank=0,
+        world_size=1,
+    )
+    
+    ids = [row["id"] for row in ds]
+    assert sorted(ids) == list(range(NUM_ROWS)), "Expected to see all rows from the prebuilt plan"
+
+
+def test_streaming_dataset_prebuilt_plan_validation(lance_table):
+    """Providing an incompatible plan raises ValueError."""
+    from lancedb.permutation import permutation_builder
+    
+    # In-memory plan has the correct split_names metadata
+    plan = permutation_builder(lance_table).split_random(fixed=NUM_SPLITS, split_names=[str(i) for i in range(NUM_SPLITS)]).execute()
+    
+    # Request different number of splits
+    with pytest.raises(ValueError, match="does not match plan table metadata split count"):
+        ds = StreamingDataset(
+            lance_table,
+            plan=plan,
+            num_splits=NUM_SPLITS * 2,
+            rank=0,
+            world_size=1,
+        )
+
+
+def test_streaming_dataset_plan_serialization(lance_table, tmp_path):
+    """A persisted plan table is serialized via its own pickle state and not Arrow."""
+    from lancedb.permutation import permutation_builder
+    import pyarrow as pa
+    
+    # Save a plan out to disk
+    db = lancedb.connect(tmp_path / "plan_db")
+    in_memory_plan = permutation_builder(lance_table).split_sequential(fixed=NUM_SPLITS).execute()
+    
+    # Must preserve the metadata so the validation works properly
+    persisted_plan = db.create_table("persisted_plan", in_memory_plan.to_arrow())
+    
+    ds = StreamingDataset(
+        lance_table,
+        plan=persisted_plan,
+        num_splits=NUM_SPLITS,
+        rank=0,
+        world_size=1,
+    )
+    
+    state = ds.__getstate__()
+    assert "_perm_table_state" in state
+    perm_state = state["_perm_table_state"]
+    assert perm_state["kind"] == "local"
+    assert perm_state["name"] == "persisted_plan"
+    
+    # Mock a worker process unpickling
+    import pickle
+    dumped = pickle.dumps(ds)
+    ds_worker = pickle.loads(dumped)
+    
+    ids = [row["id"] for row in ds_worker]
+    assert sorted(ids) == list(range(NUM_ROWS))
+
+
+def test_streaming_dataset_remote_table_with_local_plan(tmp_path):
+    """Can use a local plan with a remote base table."""
+    from lancedb.permutation import permutation_builder
+    
+    server = MockPermutationServer()
+
+    with mock_remote_table(server) as base_table:
+        # Build local plan
+        db = lancedb.connect(tmp_path / "plan_db")
+        in_memory_plan = permutation_builder(base_table).split_sequential(fixed=2).execute()
+        local_plan = db.create_table("local_plan", in_memory_plan.to_arrow())
+        
+        # We start counting scans now.
+        scans_before = len(server.scans)
+        
+        ds = StreamingDataset(
+            base_table,
+            plan=local_plan,
+            num_splits=2,
+            rank=0,
+            world_size=1,
+        )
+        
+        # It shouldn't scan the base table to plan!
+        assert len(server.scans) == scans_before, "Passing a plan must skip base-table planning scan"
+        
+        ids = [row["id"] for row in ds]
+        
+    assert sorted(ids) == list(range(server.num_rows))


### PR DESCRIPTION
Previously, StreamingDataset.__init__ always built a new in-memory permutation table by initiating a row-ID scan, sort, and shuffle over the base dataset for every rank worker (or when initializing/resuming datasets). In large distributed multi-GPU training jobs (torchrun), every worker repeated this full planning step independently. When working with large datasets or remote tables, this redundant scan caused significant memory overhead, repeated network round-trips, and initialization latency (Fixes #4016).

Key Changes
This PR introduces support for passing a pre-computed or persisted plan directly to StreamingDataset.

plan Parameter Support:

Added an optional plan: Union[Table, str] parameter to StreamingDataset.__init__.
When provided, StreamingDataset skips calling permutation_builder on the base table entirely, avoiding any base-table row-ID scan during initialization.
Metadata & Split Validation:

When a pre-built plan Table is provided, StreamingDataset checks its Arrow schema metadata (b"split_names").
Validates that the requested num_splits matches the split count encoded in the plan table metadata, raising a descriptive ValueError if there is a mismatch.
Table Protocol Serialization (__getstate__ / __setstate__):

Updated StreamingDataset.__getstate__ to serialize _perm_table via _table_to_pickle_state instead of forcing a conversion to in-memory Arrow data (to_arrow()).
Enables workers to reconnect to persisted plan tables (e.g. disk/remote) without copying the entire permutation back into RAM upon process spawn or checkpoint loading.
Preserved backwards compatibility with unpickling legacy state payloads.
Verification & Testing
Added 4 new test cases to lancedb/python/python/tests/test_elastic_dataloader.py:

test_streaming_dataset_with_prebuilt_plan: Verifies StreamingDataset executes properly with a pre-computed plan without re-indexing.
test_streaming_dataset_prebuilt_plan_validation: Asserts ValueError is raised when num_splits does not match the plan's split count.
test_streaming_dataset_plan_serialization: Ensures persisted plan tables serialize via _perm_table_state (table protocol) and deserialize correctly across worker process boundaries.
test_streaming_dataset_remote_table_with_local_plan: Verifies using a MockPermutationServer that passing a prebuilt plan guarantees 0 additional scans on the base table.