### PR TITLE
docs(embeddings): correct the documented max_retries default

### DIFF
--- a/python/python/lancedb/embeddings/utils.py
+++ b/python/python/lancedb/embeddings/utils.py
@@ -249,7 +249,7 @@ def retry_with_exponential_backoff(
         initial_delay (float): Initial delay in seconds (default is 1).
         exponential_base (float): The base for exponential backoff (default is 2).
         jitter (bool): Whether to add jitter to the delay (default is True).
-        max_retries (int): Maximum number of retries (default is 10).
+        max_retries (int): Maximum number of retries (default is 7).
 
     Returns:
         function: The decorated function.


### PR DESCRIPTION
`lancedb/embeddings/utils.py` documents `max_retries` with "(default is 10)" — the signature default is `7`. Docs-only; conventional title per the contribution guide.