### PR TITLE
ci: add spell checking

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,20 @@
+name: Typo checker
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Check spelling of the entire repository
+        uses: crate-ci/typos@6802cc60d4e7f78b9d5454f6cf3935c042d5e1e3 # v1.26.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
     rev: v0.9.9
     hooks:
       - id: ruff
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.26.0
+    hooks:
+      - id: typos
   # - repo: https://github.com/RobertCraigie/pyright-python
   #   rev: v1.1.395
   #   hooks:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,19 @@
+[default]
+extend-ignore-re = ["(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"]
+
+[default.extend-words]
+# Azure Kubernetes Service, mentioned in rust/lancedb/src/remote/oauth.rs.
+AKS = "AKS"
+# RabitQ is the name of a vector quantization algorithm, not a typo of "Rabbit".
+Rabit = "Rabit"
+# `VarBuilder::from_mmaped_safetensors` is the real (if oddly-spelled) name of
+# the candle-core API we call in rust/lancedb/src/embeddings/sentence_transformers.rs.
+mmaped = "mmaped"
+# `WriteableBuffer` is the real name of a type from Python's `_typeshed` stubs,
+# used in python/python/lancedb/_blob.py.
+Writeable = "Writeable"
+
+[files]
+extend-exclude = [
+    "*_THIRD_PARTY_LICENSES.*",
+]

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -155,7 +155,7 @@ paths:
                 vector:
                   type: FixedSizeList
                   description: |
-                    The targetted vector to search for. Required.
+                    The targeted vector to search for. Required.
                 vector_column:
                   type: string
                   description: |

--- a/docs/src/js/classes/MergeInsertBuilder.md
+++ b/docs/src/js/classes/MergeInsertBuilder.md
@@ -141,7 +141,7 @@ Currently this causes multiple copies of the row to be created
 but that behavior is subject to change.
 
 An optional condition may be specified.  If it is, then only
-matched rows that satisfy the condtion will be updated.  Any
+matched rows that satisfy the condition will be updated.  Any
 rows that do not satisfy the condition will be left as they
 are.  Failing to satisfy the condition does not cause a
 "matched row" to become a "not matched" row.

--- a/docs/src/js/classes/Table.md
+++ b/docs/src/js/classes/Table.md
@@ -1266,7 +1266,7 @@ value is 0")
 Note: if your condition is something like "some_id_column == 7" and
 you are updating many rows (with different ids) then you will get
 better performance with a single [`merge_insert`] call instead of
-repeatedly calilng this method.
+repeatedly calling this method.
 
 ##### Parameters
 

--- a/docs/src/js/interfaces/HnswPqOptions.md
+++ b/docs/src/js/interfaces/HnswPqOptions.md
@@ -118,7 +118,7 @@ Number of sub-vectors of PQ.
 This value controls how much the vector is compressed during the quantization step.
 The more sub vectors there are the less the vector is compressed.  The default is
 the dimension of the vector divided by 16.  If the dimension is not evenly divisible
-by 16 we use the dimension divded by 8.
+by 16 we use the dimension divided by 8.
 
 The above two cases are highly preferred.  Having 8 or 16 values per subvector allows
 us to use efficient SIMD instructions.

--- a/docs/src/js/interfaces/IndexOptions.md
+++ b/docs/src/js/interfaces/IndexOptions.md
@@ -16,7 +16,7 @@ optional config: Index;
 
 Advanced index configuration
 
-This option allows you to specify a specfic index to create and also
+This option allows you to specify a specific index to create and also
 allows you to pass in configuration for training the index.
 
 See the static methods on Index for details on the various index types.

--- a/docs/src/js/interfaces/IvfPqOptions.md
+++ b/docs/src/js/interfaces/IvfPqOptions.md
@@ -112,7 +112,7 @@ Number of sub-vectors of PQ.
 This value controls how much the vector is compressed during the quantization step.
 The more sub vectors there are the less the vector is compressed.  The default is
 the dimension of the vector divided by 16.  If the dimension is not evenly divisible
-by 16 we use the dimension divded by 8.
+by 16 we use the dimension divided by 8.
 
 The above two cases are highly preferred.  Having 8 or 16 values per subvector allows
 us to use efficient SIMD instructions.

--- a/nodejs/__test__/table.test.ts
+++ b/nodejs/__test__/table.test.ts
@@ -3252,7 +3252,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
       const db = await connect(tmpDir.name);
       const data = [
         { text: "fa", vector: [0.1, 0.2, 0.3] },
-        { text: "fo", vector: [0.4, 0.5, 0.6] },
+        { text: "fo", vector: [0.4, 0.5, 0.6] }, // spellchecker:disable-line
         { text: "fob", vector: [0.4, 0.5, 0.6] },
         { text: "focus", vector: [0.4, 0.5, 0.6] },
         { text: "foo", vector: [0.4, 0.5, 0.6] },
@@ -3277,7 +3277,7 @@ describe.each([arrow15, arrow16, arrow17, arrow18])(
       const resultSet = new Set(fuzzyResults.map((r) => r.text));
       expect(resultSet.has("foo")).toBe(true);
       expect(resultSet.has("fob")).toBe(true);
-      expect(resultSet.has("fo")).toBe(true);
+      expect(resultSet.has("fo")).toBe(true); // spellchecker:disable-line
       expect(resultSet.has("food")).toBe(true);
 
       const prefixResults = await table

--- a/nodejs/lancedb/arrow.ts
+++ b/nodejs/lancedb/arrow.ts
@@ -600,7 +600,7 @@ function makeVector(
   }
   if (values.length === 0) {
     throw Error(
-      "makeVector requires at least one value or the type must be specfied",
+      "makeVector requires at least one value or the type must be specified",
     );
   }
   const sampleValue = values.find((val) => val !== null && val !== undefined);
@@ -858,7 +858,7 @@ async function applyEmbeddings<T>(
  * customized by the `embeddingDataType` property of the embedding function.
  *
  * If a schema is provided in `makeTableOptions` then it should include the
- * embedding columns.  If no schema is provded then embedding columns will
+ * embedding columns.  If no schema is provided then embedding columns will
  * be placed at the end of the table, after all of the input columns.
  */
 export async function convertToTable(

--- a/nodejs/lancedb/indices.ts
+++ b/nodejs/lancedb/indices.ts
@@ -26,7 +26,7 @@ export interface IvfPqOptions {
    * This value controls how much the vector is compressed during the quantization step.
    * The more sub vectors there are the less the vector is compressed.  The default is
    * the dimension of the vector divided by 16.  If the dimension is not evenly divisible
-   * by 16 we use the dimension divded by 8.
+   * by 16 we use the dimension divided by 8.
    *
    * The above two cases are highly preferred.  Having 8 or 16 values per subvector allows
    * us to use efficient SIMD instructions.
@@ -228,7 +228,7 @@ export interface HnswPqOptions {
    * This value controls how much the vector is compressed during the quantization step.
    * The more sub vectors there are the less the vector is compressed.  The default is
    * the dimension of the vector divided by 16.  If the dimension is not evenly divisible
-   * by 16 we use the dimension divded by 8.
+   * by 16 we use the dimension divided by 8.
    *
    * The above two cases are highly preferred.  Having 8 or 16 values per subvector allows
    * us to use efficient SIMD instructions.
@@ -825,7 +825,7 @@ export interface IndexOptions {
   /**
    * Advanced index configuration
    *
-   * This option allows you to specify a specfic index to create and also
+   * This option allows you to specify a specific index to create and also
    * allows you to pass in configuration for training the index.
    *
    * See the static methods on Index for details on the various index types.

--- a/nodejs/lancedb/merge.ts
+++ b/nodejs/lancedb/merge.ts
@@ -27,7 +27,7 @@ export class MergeInsertBuilder {
    * but that behavior is subject to change.
    *
    * An optional condition may be specified.  If it is, then only
-   * matched rows that satisfy the condtion will be updated.  Any
+   * matched rows that satisfy the condition will be updated.  Any
    * rows that do not satisfy the condition will be left as they
    * are.  Failing to satisfy the condition does not cause a
    * "matched row" to become a "not matched" row.

--- a/nodejs/lancedb/sanitize.ts
+++ b/nodejs/lancedb/sanitize.ts
@@ -3,7 +3,7 @@
 
 // The utilities in this file help sanitize data from the user's arrow
 // library into the types expected by vectordb's arrow library.  Node
-// generally allows for mulitple versions of the same library (and sometimes
+// generally allows for multiple versions of the same library (and sometimes
 // even multiple copies of the same version) to be installed at the same
 // time.  However, arrow-js uses instanceof which expected that the input
 // comes from the exact same library instance.  This is not always the case

--- a/nodejs/lancedb/table.ts
+++ b/nodejs/lancedb/table.ts
@@ -313,7 +313,7 @@ export abstract class Table {
    * Note: if your condition is something like "some_id_column == 7" and
    * you are updating many rows (with different ids) then you will get
    * better performance with a single [`merge_insert`] call instead of
-   * repeatedly calilng this method.
+   * repeatedly calling this method.
    * @param {Map<string, string> | Record<string, string>} updates - the
    * columns to update
    * @returns {Promise<UpdateResult>} A promise that resolves to an object

--- a/python/python/lancedb/embeddings/instructor.py
+++ b/python/python/lancedb/embeddings/instructor.py
@@ -60,7 +60,7 @@ class InstructorEmbeddingFunction(TextEmbeddingFunction):
 
     import lancedb
     from lancedb.pydantic import LanceModel, Vector
-    from lancedb.embeddings import get_registry, InstuctorEmbeddingFunction
+    from lancedb.embeddings import get_registry, InstructorEmbeddingFunction
 
     instructor = get_registry().get("instructor").create(
         source_instruction="represent the document for retrieval",

--- a/python/python/lancedb/table.py
+++ b/python/python/lancedb/table.py
@@ -5638,7 +5638,7 @@ class AsyncTable:
         if fill_value is None:
             fill_value = 0.0
 
-        # _santitize_data is an old code path, but we will use it until the
+        # _sanitize_data is an old code path, but we will use it until the
         # new code path is ready.
         if mode == "overwrite":
             # For overwrite, apply the same preprocessing as create_table

--- a/python/python/tests/test_embeddings.py
+++ b/python/python/tests/test_embeddings.py
@@ -327,8 +327,8 @@ def test_embedding_function_with_pandas(tmp_path):
         ) -> List[np.array]:
             return [np.random.randn(self.ndims()).tolist() for _ in range(len(texts))]
 
-    registery = get_registry()
-    func = registery.get("mock-embedding").create()
+    registry = get_registry()
+    func = registry.get("mock-embedding").create()
 
     class TestSchema(LanceModel):
         text: str = func.SourceField()
@@ -394,9 +394,9 @@ def test_multiple_embeddings_for_pandas(tmp_path):
         ) -> List[np.array]:
             return [np.random.randn(self.ndims()).tolist() for _ in range(len(texts))]
 
-    registery = get_registry()
-    func1 = registery.get("mock-embedding").create()
-    func2 = registery.get("mock-embedding2").create()
+    registry = get_registry()
+    func1 = registry.get("mock-embedding").create()
+    func2 = registry.get("mock-embedding2").create()
 
     class TestSchema(LanceModel):
         text: str = func1.SourceField()

--- a/python/python/tests/test_fts.py
+++ b/python/python/tests/test_fts.py
@@ -1011,8 +1011,13 @@ def test_fts_ngram(mem_db: DBConnection):
     assert set(r["text"] for r in results) == {"lance database", "lance is cool"}
 
     results = (
-        table.search("nce", query_type="fts").limit(10).to_list()
-    )  # spellchecker:disable-line
+        table.search(
+            "nce",  # spellchecker:disable-line
+            query_type="fts",
+        )
+        .limit(10)
+        .to_list()
+    )
     assert len(results) == 2
     assert set(r["text"] for r in results) == {"lance database", "lance is cool"}
 
@@ -1034,8 +1039,13 @@ def test_fts_ngram(mem_db: DBConnection):
     assert set(r["text"] for r in results) == {"lance database", "lance is cool"}
 
     results = (
-        table.search("nce", query_type="fts").limit(10).to_list()
-    )  # spellchecker:disable-line
+        table.search(
+            "nce",  # spellchecker:disable-line
+            query_type="fts",
+        )
+        .limit(10)
+        .to_list()
+    )
     assert len(results) == 0
 
     results = table.search("la", query_type="fts").limit(10).to_list()

--- a/python/python/tests/test_rerankers.py
+++ b/python/python/tests/test_rerankers.py
@@ -81,7 +81,7 @@ def get_test_table(tmp_path):
         "but his son was mortal",
         "there hasn't been a good battlefield game since 2142",
         "I wish they would make another one",
-        "campains are not as good as they used to be",
+        "campaigns are not as good as they used to be",
         "Multiplayer and open world games have destroyed the single player experience",
         "Maybe the future is console games",
         "I don't know",

--- a/python/python/tests/test_table.py
+++ b/python/python/tests/test_table.py
@@ -3354,7 +3354,7 @@ def test_empty_query(mem_db: DBConnection):
     # None is the same as default
     df = table.search().select(["id"]).limit(None).to_arrow()
     assert df.num_rows == 100
-    # invalid limist is the same as None, wihch is the same as default
+    # invalid limist is the same as None, which is the same as default
     df = table.search().select(["id"]).limit(-1).to_arrow()
     assert df.num_rows == 100
     # valid limit should work

--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -334,7 +334,7 @@ pub struct PyQueryRequest {
     pub column: Option<String>,
     pub query_vector: Option<PyQueryVectors>,
     pub minimum_nprobes: Option<usize>,
-    // None means user did not set it and default shoud be used (currenty 20)
+    // None means user did not set it and default should be used (currently 20)
     // Some(0) means user set it to None and there is no limit
     pub maximum_nprobes: Option<usize>,
     pub lower_bound: Option<f32>,

--- a/rust/lancedb/src/arrow.rs
+++ b/rust/lancedb/src/arrow.rs
@@ -163,7 +163,7 @@ pub struct PolarsDataFrameRecordBatchReader {
 impl PolarsDataFrameRecordBatchReader {
     /// Creates a new `PolarsDataFrameRecordBatchReader` from a given Polars DataFrame.
     /// If the input dataframe does not have aligned chunks, this function undergoes
-    /// the costly operation of reallocating each series as a single contigous chunk.
+    /// the costly operation of reallocating each series as a single contiguous chunk.
     pub fn new(mut df: DataFrame) -> Result<Self> {
         df.align_chunks();
         let arrow_schema =

--- a/rust/lancedb/src/connection.rs
+++ b/rust/lancedb/src/connection.rs
@@ -827,7 +827,7 @@ impl Connection {
 pub struct ConnectRequest {
     /// Database URI
     ///
-    /// ### Accpeted URI formats
+    /// ### Accepted URI formats
     ///
     /// - `/path/to/database` - local database on file system.
     /// - `s3://bucket/path/to/database` or `gs://bucket/path/to/database` - database on cloud object store

--- a/rust/lancedb/src/database/listing.rs
+++ b/rust/lancedb/src/database/listing.rs
@@ -512,7 +512,7 @@ impl ListingDatabase {
                 // iter thru the query params and extract the commit store param
                 let mut engine = None;
                 let mut mirrored_store = None;
-                let mut filtered_querys = vec![];
+                let mut filtered_queries = vec![];
 
                 // WARNING: specifying engine is NOT a publicly supported feature in lancedb yet
                 // THE API WILL CHANGE
@@ -528,13 +528,13 @@ impl ListingDatabase {
                         mirrored_store = Some(value.to_string());
                     } else {
                         // to owned so we can modify the url
-                        filtered_querys.push((key.to_string(), value.to_string()));
+                        filtered_queries.push((key.to_string(), value.to_string()));
                     }
                 }
 
                 // Filter out the commit store query param -- it's a lancedb param
                 url.query_pairs_mut().clear();
-                url.query_pairs_mut().extend_pairs(filtered_querys);
+                url.query_pairs_mut().extend_pairs(filtered_queries);
                 // Take a copy of the query string so we can propagate it to lance.
                 // `query_pairs_mut()` leaves the URL with `Some("")` even when no
                 // pairs survive (or none existed in the first place), so an empty
@@ -896,11 +896,11 @@ impl Database for ListingDatabase {
     }
 
     async fn read_consistency(&self) -> Result<ReadConsistency> {
-        if let Some(read_consistency_inverval) = self.read_consistency_interval {
-            if read_consistency_inverval.is_zero() {
+        if let Some(interval) = self.read_consistency_interval {
+            if interval.is_zero() {
                 Ok(ReadConsistency::Strong)
             } else {
-                Ok(ReadConsistency::Eventual(read_consistency_inverval))
+                Ok(ReadConsistency::Eventual(interval))
             }
         } else {
             Ok(ReadConsistency::Manual)
@@ -3043,15 +3043,15 @@ mod tests {
     /// across platforms — see the `file://` test below).
     fn capture_query_like_connect(input_uri: &str) -> Option<String> {
         let mut url = url::Url::parse(input_uri).unwrap();
-        let mut filtered_querys = Vec::new();
+        let mut filtered_queries = Vec::new();
         for (key, value) in url.query_pairs() {
             if key == ENGINE || key == MIRRORED_STORE {
                 continue;
             }
-            filtered_querys.push((key.to_string(), value.to_string()));
+            filtered_queries.push((key.to_string(), value.to_string()));
         }
         url.query_pairs_mut().clear();
-        url.query_pairs_mut().extend_pairs(filtered_querys);
+        url.query_pairs_mut().extend_pairs(filtered_queries);
         url.query().filter(|q| !q.is_empty()).map(|s| s.to_string())
     }
 

--- a/rust/lancedb/src/database/namespace.rs
+++ b/rust/lancedb/src/database/namespace.rs
@@ -251,11 +251,11 @@ impl Database for LanceNamespaceDatabase {
     }
 
     async fn read_consistency(&self) -> Result<ReadConsistency> {
-        if let Some(read_consistency_inverval) = self.read_consistency_interval {
-            if read_consistency_inverval.is_zero() {
+        if let Some(interval) = self.read_consistency_interval {
+            if interval.is_zero() {
                 Ok(ReadConsistency::Strong)
             } else {
-                Ok(ReadConsistency::Eventual(read_consistency_inverval))
+                Ok(ReadConsistency::Eventual(interval))
             }
         } else {
             Ok(ReadConsistency::Manual)

--- a/rust/lancedb/src/index/vector.rs
+++ b/rust/lancedb/src/index/vector.rs
@@ -125,7 +125,7 @@ macro_rules! impl_pq_params_setter {
         /// This value controls how much the vector is compressed during the quantization step.
         /// The more sub vectors there are the less the vector is compressed.  The default is
         /// the dimension of the vector divided by 16.  If the dimension is not evenly divisible
-        /// by 16 we use the dimension divded by 8.
+        /// by 16 we use the dimension divided by 8.
         ///
         /// The above two cases are highly preferred.  Having 8 or 16 values per subvector allows
         /// us to use efficient SIMD instructions.

--- a/rust/lancedb/src/query.rs
+++ b/rust/lancedb/src/query.rs
@@ -1299,7 +1299,7 @@ impl VectorQuery {
     /// This can be useful when there is a narrow filter to allow these queries to
     /// spend more time searching and avoid potential false negatives.
     ///
-    /// Set to None to search all partitions, if needed, to satsify the limit
+    /// Set to None to search all partitions, if needed, to satisfy the limit
     pub fn maximum_nprobes(mut self, maximum_nprobes: Option<usize>) -> Result<Self> {
         if let Some(maximum_nprobes) = maximum_nprobes {
             if maximum_nprobes == 0 {

--- a/rust/lancedb/src/table.rs
+++ b/rust/lancedb/src/table.rs
@@ -240,7 +240,7 @@ enum BadVectorHandling {
     /// An error is returned
     #[default]
     Error,
-    /// The offending row is droppped
+    /// The offending row is dropped
     Drop,
     /// The invalid/missing items are replaced by fill_value
     Fill(f32),
@@ -1326,7 +1326,7 @@ impl Table {
     /// Note: if your condition is something like "some_id_column == 7" and
     /// you are updating many rows (with different ids) then you will get
     /// better performance with a single [`merge_insert`] call instead of
-    /// repeatedly calilng this method.
+    /// repeatedly calling this method.
     pub fn update(&self) -> UpdateBuilder {
         UpdateBuilder::new(self.inner.clone())
     }

--- a/rust/lancedb/src/table/dataset.rs
+++ b/rust/lancedb/src/table/dataset.rs
@@ -52,7 +52,7 @@ enum ConsistencyMode {
     /// refresh_window = min(3s, TTL/4)
     ///
     /// | t < TTL - refresh_window | t < TTL                           | t >= TTL            |
-    /// |  Return value            | Background refresh & return value |  syncronous refresh |
+    /// |  Return value            | Background refresh & return value |  synchronous refresh |
     Eventual(BackgroundCache<Arc<Dataset>, Error>),
 }
 

--- a/rust/lancedb/src/table/merge.rs
+++ b/rust/lancedb/src/table/merge.rs
@@ -103,7 +103,7 @@ impl MergeInsertBuilder {
     /// but that behavior is subject to change.
     ///
     /// An optional condition may be specified.  If it is, then only
-    /// matched rows that satisfy the condtion will be updated.  Any
+    /// matched rows that satisfy the condition will be updated.  Any
     /// rows that do not satisfy the condition will be left as they
     /// are.  Failing to satisfy the condition does not cause a
     /// "matched row" to become a "not matched" row.

--- a/rust/lancedb/src/table/merge/lsm.rs
+++ b/rust/lancedb/src/table/merge/lsm.rs
@@ -904,7 +904,7 @@ fn unsharded_shard_id() -> Uuid {
 
 /// Build a [`ShardWriterConfig`] from the persisted `writer_config_defaults`.
 ///
-/// Unknown or unparseable keys are ignored; absent keys keep the
+/// Unknown or unparsable keys are ignored; absent keys keep the
 /// [`ShardWriterConfig`] default. The shard id is set by `mem_wal_writer`.
 fn shard_writer_config_from_defaults(defaults: &HashMap<String, String>) -> ShardWriterConfig {
     let mut config = ShardWriterConfig::default().with_shard_spec_id(SHARDING_SPEC_ID);


### PR DESCRIPTION
Adds [typos](https://github.com/crate-ci/typos) as a CI check and pre-commit hook, the same way Lance does it, so misspellings like the ones fixed in #4146 get caught automatically going forward.

This also fixes the misspellings `typos` found across the repo (Rust, Python, TypeScript source, comments, and generated docs), and adds a small `.typos.toml` with `extend-words` entries for terms that are correct but look like typos: `AKS` (Azure Kubernetes Service), `RabitQ` (a real quantization algorithm name), `mmaped` (the actual name of a `candle-core` API we call), and `Writeable` (from Python's `_typeshed.WriteableBuffer`). Third-party license files are excluded.

Fixes #4147
