### PR TITLE
fix(query): lock the pre/post-filter mode at the first where() call

### DIFF
--- a/python/python/lancedb/query.py
+++ b/python/python/lancedb/query.py
@@ -1287,8 +1287,14 @@ class LanceQueryBuilder(ABC):
         Calling this multiple times combines the filters with a logical AND
         rather than replacing the previous filter.
         """
+        first_filter = self._where is None
         self._where = _combine_where(self._where, where)
-        self._postfilter = not prefilter
+        if first_filter:
+            # The pre/post-filter mode applies to the whole combined
+            # predicate, so it is fixed by the FIRST where() call. Later
+            # calls previously overwrote it, silently changing the recall
+            # semantics of filters the user asked to pre-filter.
+            self._postfilter = not prefilter
         return self
 
     def with_row_id(self, with_row_id: bool) -> Self:


### PR DESCRIPTION
## Summary

`LanceQueryBuilder.where()` overwrote `self._postfilter = not prefilter` on **every** call. Chaining `.where(a, prefilter=True).where(b, prefilter=False)` silently applied the **combined** predicate after the vector search: rows matching `a` outside the approximate top-k vanished from results with no error — order-dependent recall semantics that contradicted the first call's explicit `prefilter=True`.

The mode is now fixed by the first `where()` call; later calls combine predicates but cannot change earlier filters' mode. (Pure semantic fix for the mixed-mode case; single-call behavior is unchanged.)

## Test plan

Existing query tests pass; the change only affects builders that chain `where()` with mixed `prefilter` values, which previously produced order-dependent recall.