### PR TITLE
fix(embeddings): re-raise OpenAI BadRequestError instead of returning None vectors

### DIFF
--- a/python/python/lancedb/embeddings/openai.py
+++ b/python/python/lancedb/embeddings/openai.py
@@ -114,8 +114,13 @@ class OpenAIEmbeddings(TextEmbeddingFunction):
             logging.error("Authentication failed: Invalid API key provided")
             raise
         except openai.BadRequestError:
+            # A BadRequestError is permanent (input too long, invalid model,
+            # content filter) — swallowing it here and returning None vectors
+            # would silently drop rows (on_bad_vectors='drop') or persist
+            # zero vectors ('fill') while add() reports success. Re-raise so
+            # the caller sees the real API error.
             logging.exception("Bad request: %s", texts)
-            return [None] * len(texts)
+            raise
         except Exception:
             logging.exception("OpenAI embeddings error")
             raise


### PR DESCRIPTION
## Summary

`OpenAIEmbeddings` caught `openai.BadRequestError`, logged it, and returned `[None] * len(texts)` — pretending success. Downstream, `table.add()` then applied `on_bad_vectors`:

- `'drop'` (a documented recommendation in the error message): **every row silently deleted**, `add()` succeeds
- `'fill'`: all-zero vectors persisted, permanently poisoning vector search for those rows

Meanwhile the user never sees the real API error (input too long, invalid model, content filter). The exception now propagates so the caller can fix the input.

## Test plan

Docs-code path fix; the error path is exercised by any invalid embed input. No existing tests covered the swallow.